### PR TITLE
feat(14): adicionar componente typography e usar no menu e footer

### DIFF
--- a/FateConnect/Front/src/app/pages/menu/menu.component.html
+++ b/FateConnect/Front/src/app/pages/menu/menu.component.html
@@ -1,5 +1,5 @@
-<h1>Bem-vindo ao FateConnect</h1>
-<p>Escolha um dos serviços abaixo para começar.</p>
+<app-typography variant="display">Bem-vindo ao FateConnect</app-typography>
+<app-typography variant="lead">Escolha um dos serviços abaixo para começar.</app-typography>
 
 <div class="cards-container">
   <button routerLink="/achados-perdidos">
@@ -7,7 +7,7 @@
       <fa-icon [icon]="faSearch"></fa-icon>
     </div>
 
-    <h2>Achados & Perdidos</h2>
+    <app-typography variant="title">Achados & Perdidos</app-typography>
   </button>
 
   <button routerLink="/caronas">
@@ -15,6 +15,6 @@
       <fa-icon [icon]="faCar"></fa-icon>
     </div>
 
-    <h2>Caronas</h2>
+    <app-typography variant="title">Caronas</app-typography>
   </button>
 </div>

--- a/FateConnect/Front/src/app/pages/menu/menu.component.scss
+++ b/FateConnect/Front/src/app/pages/menu/menu.component.scss
@@ -10,19 +10,6 @@
   padding: 7vw;
 }
 
-h1 {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--app-cor-principal);
-}
-
-p {
-  font-size: 1rem;
-  font-weight: 500;
-  color: var(--app-texto-sobre-branco);
-  margin-bottom: 1rem;
-}
-
 .cards-container {
   display: flex;
   flex-direction: row;
@@ -68,8 +55,3 @@ fa-icon {
   color: var(--app-fundo-branco);
 }
 
-h2 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--app-cor-principal);
-}

--- a/FateConnect/Front/src/app/pages/menu/menu.component.ts
+++ b/FateConnect/Front/src/app/pages/menu/menu.component.ts
@@ -1,12 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faSearch } from '@fortawesome/free-solid-svg-icons';
-import { faCar } from '@fortawesome/free-solid-svg-icons';
+import { faCar, faSearch } from '@fortawesome/free-solid-svg-icons';
+import { TypographyComponent } from '../../shared/ui/typography/typography';
 
 @Component({
   selector: 'app-menu',
-  imports: [FontAwesomeModule, RouterModule],
+  imports: [FontAwesomeModule, RouterModule, TypographyComponent],
   templateUrl: './menu.component.html',
   styleUrl: './menu.component.scss',
 })

--- a/FateConnect/Front/src/app/shared/ui/footer/footer.component.html
+++ b/FateConnect/Front/src/app/shared/ui/footer/footer.component.html
@@ -1,15 +1,24 @@
 <div class="footer">
   <div class="contacts-container">
-    <p class="footer-title">Entre em contato</p>
-    <span><fa-icon [icon]="faEnvelope" size="sm"></fa-icon> f003.alunos@fatec.sp.gov.br</span>
-    <span><fa-icon [icon]="faPhone" size="sm"></fa-icon> (15) 3238-5266</span>
-    <span><fa-icon [icon]="faLocationDot" size="sm"></fa-icon> Av. Eng. Carlos Reinaldo Mendes, 2015</span>
+    <app-typography variant="title">Entre em contato</app-typography>
+    <div class="contact-item">
+      <fa-icon [icon]="faEnvelope" size="sm"></fa-icon>
+      <app-typography variant="footer-body">f003.alunos@fatec.sp.gov.br</app-typography>
+    </div>
+    <div class="contact-item">
+      <fa-icon [icon]="faPhone" size="sm"></fa-icon>
+      <app-typography variant="footer-body">(15) 3238-5266</app-typography>
+    </div>
+    <div class="contact-item">
+      <fa-icon [icon]="faLocationDot" size="sm"></fa-icon>
+      <app-typography variant="footer-body">Av. Eng. Carlos Reinaldo Mendes, 2015</app-typography>
+    </div>
   </div>
 
   <div class="divider-container"></div>
 
   <div class="copyright-container">
-    <p>© 2026 FateConnect. Todos os direitos reservados.</p>
-    <p>Desenvolvido para facilitar a vida do Fatecano.</p>
+    <app-typography variant="footer-body">© 2026 FateConnect. Todos os direitos reservados.</app-typography>
+    <app-typography variant="footer-body">Desenvolvido para facilitar a vida do Fatecano.</app-typography>
   </div>
 </div>

--- a/FateConnect/Front/src/app/shared/ui/footer/footer.component.scss
+++ b/FateConnect/Front/src/app/shared/ui/footer/footer.component.scss
@@ -10,24 +10,19 @@
   width: 100vw;
 }
 
-p,
-span {
-  font-size: 14px;
-  font-weight: 400;
-  color: var(--app-texto-fundo-forte);
-}
-
-.footer-title {
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
 .contacts-container {
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 1rem;
   width: 100%;
+}
+
+.contact-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .divider-container {
@@ -63,8 +58,4 @@ span {
     height: 1px;
   }
 
-  p,
-  span {
-    text-align: center;
-  }
 }

--- a/FateConnect/Front/src/app/shared/ui/footer/footer.component.ts
+++ b/FateConnect/Front/src/app/shared/ui/footer/footer.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faEnvelope, faPhone, faLocationDot } from '@fortawesome/free-solid-svg-icons';
+import { TypographyComponent } from '../typography/typography';
 
 @Component({
   selector: 'app-footer',
-  imports: [FontAwesomeModule],
+  imports: [FontAwesomeModule, TypographyComponent],
   templateUrl: './footer.component.html',
   styleUrl: './footer.component.scss',
 })

--- a/FateConnect/Front/src/app/shared/ui/typography/typography.html
+++ b/FateConnect/Front/src/app/shared/ui/typography/typography.html
@@ -1,0 +1,1 @@
+<ng-content />

--- a/FateConnect/Front/src/app/shared/ui/typography/typography.scss
+++ b/FateConnect/Front/src/app/shared/ui/typography/typography.scss
@@ -1,0 +1,119 @@
+/* Tokens só usados por app-typography; escalas base em :root (styles.scss). */
+:host {
+  display: contents;
+
+  --app-typography-display-size: 2rem;
+  --app-typography-display-size-narrow: 1.875rem;
+  --app-typography-display-weight: 700;
+  --app-typography-display-lh: 1.2;
+
+  --app-typography-lead-size: 1rem;
+  --app-typography-lead-weight: 500;
+  --app-typography-lead-lh: 1.5;
+
+  --app-typography-title-size: 1.5rem;
+  --app-typography-title-weight: 600;
+  --app-typography-title-lh: 1.3;
+
+  --app-typography-subtitle-size: var(--app-tamanho-subtitulo-fonte);
+  --app-typography-subtitle-weight: 600;
+  --app-typography-subtitle-lh: 1.3;
+
+  --app-typography-body-size: var(--app-tamanho-texto-fonte);
+  --app-typography-body-weight: 400;
+  --app-typography-body-lh: 1.4;
+
+  --app-typography-caption-size: var(--app-tamanho-tag-fonte);
+  --app-typography-caption-weight: 400;
+  --app-typography-caption-lh: 1.35;
+  --app-typography-tag-weight: 600;
+
+  --app-typography-brand-size: 1.3rem;
+  --app-typography-brand-weight: 600;
+  --app-typography-brand-lh: 1.2;
+
+  --app-typography-footer-body-size: 0.875rem;
+  --app-typography-footer-body-weight: 400;
+  --app-typography-footer-body-lh: 1.4;
+}
+
+.typography {
+  margin: 0;
+  font-family: inherit;
+}
+
+.typography--display {
+  font-size: var(--app-typography-display-size);
+  font-weight: var(--app-typography-display-weight);
+  line-height: var(--app-typography-display-lh);
+  color: var(--app-cor-principal);
+}
+
+.typography--lead {
+  font-size: var(--app-typography-lead-size);
+  font-weight: var(--app-typography-lead-weight);
+  line-height: var(--app-typography-lead-lh);
+  color: var(--app-texto-sobre-branco);
+  margin-bottom: 1rem;
+}
+
+.typography--title {
+  font-size: var(--app-typography-title-size);
+  font-weight: var(--app-typography-title-weight);
+  line-height: var(--app-typography-title-lh);
+  color: var(--app-cor-principal);
+}
+
+.typography--subtitle {
+  font-size: var(--app-typography-subtitle-size);
+  font-weight: var(--app-typography-subtitle-weight);
+  line-height: var(--app-typography-subtitle-lh);
+  color: var(--app-cor-principal);
+}
+
+.typography--body {
+  font-size: var(--app-typography-body-size);
+  font-weight: var(--app-typography-body-weight);
+  line-height: var(--app-typography-body-lh);
+  color: var(--app-texto-sobre-branco);
+}
+
+.typography--caption {
+  font-size: var(--app-typography-caption-size);
+  font-weight: var(--app-typography-caption-weight);
+  line-height: var(--app-typography-caption-lh);
+  color: var(--app-texto-sobre-branco);
+}
+
+.typography--tag {
+  font-size: var(--app-typography-caption-size);
+  font-weight: var(--app-typography-tag-weight);
+  line-height: var(--app-typography-caption-lh);
+  color: var(--app-cor-principal);
+}
+
+.typography--brand {
+  font-size: var(--app-typography-brand-size);
+  font-weight: var(--app-typography-brand-weight);
+  line-height: var(--app-typography-brand-lh);
+  color: var(--app-texto-fundo-forte);
+}
+
+.typography--footer-body {
+  font-size: var(--app-typography-footer-body-size);
+  font-weight: var(--app-typography-footer-body-weight);
+  line-height: var(--app-typography-footer-body-lh);
+  color: var(--app-texto-fundo-forte);
+}
+
+@media (max-width: 768px) {
+  .typography--display {
+    font-size: var(--app-typography-display-size-narrow);
+  }
+
+  :host-context(.copyright-container) .typography--footer-body,
+  :host-context(.contacts-container) .typography--footer-body,
+  :host-context(.contacts-container) .typography--title {
+    text-align: center;
+  }
+}

--- a/FateConnect/Front/src/app/shared/ui/typography/typography.ts
+++ b/FateConnect/Front/src/app/shared/ui/typography/typography.ts
@@ -1,0 +1,107 @@
+import { DOCUMENT } from '@angular/common';
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  inject,
+  input,
+  untracked,
+} from '@angular/core';
+
+export type TypographyVariant =
+  | 'display'
+  | 'lead'
+  | 'title'
+  | 'subtitle'
+  | 'body'
+  | 'caption'
+  | 'tag'
+  | 'brand'
+  | 'footer-body';
+
+export type TypographyElement = 'h1' | 'h2' | 'h3' | 'p' | 'span' | 'div';
+
+function defaultElementForVariant(variant: TypographyVariant): TypographyElement {
+  switch (variant) {
+    case 'display':
+      return 'h1';
+    case 'lead':
+    case 'body':
+    case 'footer-body':
+      return 'p';
+    case 'title':
+      return 'h2';
+    case 'subtitle':
+      return 'h3';
+    case 'caption':
+    case 'tag':
+    case 'brand':
+      return 'span';
+    default:
+      return 'p';
+  }
+}
+
+@Component({
+  selector: 'app-typography',
+  imports: [],
+  templateUrl: './typography.html',
+  styleUrl: './typography.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TypographyComponent {
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly document = inject(DOCUMENT);
+  readonly variant = input.required<TypographyVariant>();
+
+  readonly tag = computed(() => defaultElementForVariant(this.variant()));
+
+  readonly variantClass = computed(() => `typography typography--${this.variant()}`);
+
+  private wrapper: HTMLElement | null = null;
+  private domReady = false;
+
+  constructor() {
+    afterNextRender(() => {
+      this.syncHost();
+      this.domReady = true;
+    });
+
+    effect(() => {
+      this.variant();
+      if (this.domReady) {
+        untracked(() => this.syncHost());
+      }
+    });
+  }
+
+  private syncHost(): void {
+    const host = this.host.nativeElement;
+    const tagName = this.tag();
+    const className = this.variantClass();
+
+    if (!this.wrapper) {
+      this.wrapper = this.document.createElement(tagName);
+      while (host.firstChild) {
+        this.wrapper.appendChild(host.firstChild);
+      }
+      host.appendChild(this.wrapper);
+      this.wrapper.className = className;
+      return;
+    }
+
+    if (this.wrapper.nodeName.toLowerCase() !== tagName) {
+      const next = this.document.createElement(tagName);
+      while (this.wrapper.firstChild) {
+        next.appendChild(this.wrapper.firstChild);
+      }
+      host.replaceChild(next, this.wrapper);
+      this.wrapper = next;
+    }
+
+    this.wrapper.className = className;
+  }
+}


### PR DESCRIPTION
## Objetivo

Centralizar estilos de texto em um componente reutilizável com variants, alinhado à escala já usada no app, e aplicá-lo na página de menu e no footer para reduzir duplicação de SCSS e manter consistência visual.

## Alterações

- Novo componente standalone `app-typography` em `shared/ui/typography/` (`typography.ts`, `typography.html`, `typography.scss`): variants (`display`, `lead`, `title`, `subtitle`, `body`, `caption`, `tag`, `brand`, `footer-body`), tokens CSS no `:host` do componente, responsivo em `max-width: 768px` para o variant `display` e alinhamento centralizado no mobile para título e corpo do footer via `:host-context`.
- Renderização semântica via elemento interno criado após o render (`afterNextRender` + `effect`), com conteúdo projetado por `<ng-content />`.
- **Menu:** substituição de `h1`, `p` e `h2` por `app-typography` com variants adequados; remoção das regras tipográficas redundantes em `menu.component.scss`; import de `TypographyComponent` e pequeno ajuste nos imports dos ícones FA.
- **Footer:** substituição de `p`, `span` e `.footer-title` por `app-typography`; layout de contatos com `.contact-item` (flex + gap) para ícone + texto; remoção de estilos tipográficos duplicados em `footer.component.scss` e das regras de `text-align` no mobile (passando a responsabilidade ao typography).

## Issue

- #14

Closes #14

## Evidências

<img width="1505" height="831" alt="image" src="https://github.com/user-attachments/assets/8e4884d6-d416-4063-85f1-d3824356f4c4" />
<img width="1505" height="831" alt="image" src="https://github.com/user-attachments/assets/afd800fd-e0fb-42de-ac10-539ab85cd0dc" />
<img width="1505" height="831" alt="image" src="https://github.com/user-attachments/assets/72bc23f7-5721-4f7a-bf1e-2a75fcebc258" />

### Mobile

<img width="1505" height="831" alt="image" src="https://github.com/user-attachments/assets/85377fd4-004d-4d3b-a1d8-71180c8ced87" />
<img width="1505" height="831" alt="image" src="https://github.com/user-attachments/assets/f7961885-6651-4a95-bf8c-c24530a6b9e2" />
<img width="1505" height="831" alt="image" src="https://github.com/user-attachments/assets/e1136e0f-5d44-41f2-bbea-c3c17453c7ea" />
<img width="1505" height="831" alt="image" src="https://github.com/user-attachments/assets/8ba6d6d2-b52f-4c60-8b15-bef0bbaf6e4e" />
