### PR TITLE
feat(10): adicionar componente landing-description e constante de contacto

### DIFF
--- a/FateConnect/Front/src/app/core/layout/layout-shell.shared.scss
+++ b/FateConnect/Front/src/app/core/layout/layout-shell.shared.scss
@@ -49,6 +49,5 @@
   .conteudo {
     display: flex;
     flex: 1;
-    padding: 3vw 7vw;
   }
 }

--- a/FateConnect/Front/src/app/pages/caronas/caronas.component.scss
+++ b/FateConnect/Front/src/app/pages/caronas/caronas.component.scss
@@ -4,6 +4,7 @@
   flex: 1;
   width: 100%;
   gap: 1rem;
+  padding: 3vw 7vw;
 }
 
 .caronas-header {

--- a/FateConnect/Front/src/app/pages/home/components/landing-description/landing-description.component.html
+++ b/FateConnect/Front/src/app/pages/home/components/landing-description/landing-description.component.html
@@ -1,0 +1,23 @@
+<div class="landing-description">
+  <div class="description-title-container">
+    <app-typography variant="h1" class="description-title">
+      Conectando a Comunidade Acadêmica
+    </app-typography>
+  </div>
+
+  <app-typography variant="subtitle" class="description-lead">
+    Facilite sua vida na Fatec Sorocaba: encontre caronas, recupere pertences, registre denúncias e interaja com outros
+    estudantes com total praticidade e segurança.
+  </app-typography>
+
+  <ul class="highlights" aria-label="Destaques do FateConnect">
+    @for (item of highlights; track item.label) {
+    <li class="highlight-item">
+      <span class="icon-disc" aria-hidden="true">
+        <fa-icon [icon]="item.icon" [fixedWidth]="true"></fa-icon>
+      </span>
+      <app-typography variant="subtitle-bold" class="highlight-label">{{ item.label }}</app-typography>
+    </li>
+    }
+  </ul>
+</div>

--- a/FateConnect/Front/src/app/pages/home/components/landing-description/landing-description.component.scss
+++ b/FateConnect/Front/src/app/pages/home/components/landing-description/landing-description.component.scss
@@ -1,0 +1,63 @@
+.landing-description {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  max-width: 600px;
+}
+
+.description-title-container {
+  display: flex;
+  max-width: 500px;
+  justify-content: center;
+}
+
+.description-title {
+  --app-typography-text-color: var(--app-cor-principal);
+  text-align: center;
+}
+
+.description-lead {
+  --app-typography-text-color: var(--app-texto-sobre-branco);
+  text-align: center;
+}
+
+.highlights {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}
+
+.highlight-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  max-width: 120px;
+}
+
+.icon-disc {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  fa-icon {
+    font-size: var(--app-icon-small);
+    color: var(--app-cor-destaque);
+  }
+}
+
+.highlight-label {
+  --app-typography-text-color: var(--app-cor-principal);
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .landing-description {
+    align-items: center;
+  }
+
+  .highlights {
+    display: none;
+  }
+}

--- a/FateConnect/Front/src/app/pages/home/components/landing-description/landing-description.component.spec.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-description/landing-description.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LandingDescriptionComponent } from './landing-description.component';
+
+describe('LandingDescriptionComponent', () => {
+  let fixture: ComponentFixture<LandingDescriptionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LandingDescriptionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LandingDescriptionComponent);
+    fixture.detectChanges();
+  });
+
+  it('deve exibir o título da hero', () => {
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('Conectando a Comunidade Acadêmica');
+  });
+
+  it('deve renderizar quatro destaques', () => {
+    const items = fixture.nativeElement.querySelectorAll('.highlight-item');
+    expect(items.length).toBe(4);
+  });
+});

--- a/FateConnect/Front/src/app/pages/home/components/landing-description/landing-description.component.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-description/landing-description.component.ts
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { faCar, faSearch, faShieldHalved, faUserGroup } from '@fortawesome/free-solid-svg-icons';
+import { TypographyComponent } from '../../../../shared/ui/typography/typography';
+
+interface DescriptionHighlight {
+  readonly label: string;
+  readonly icon: IconDefinition;
+}
+
+@Component({
+  selector: 'app-landing-description',
+  standalone: true,
+  imports: [TypographyComponent, FontAwesomeModule],
+  templateUrl: './landing-description.component.html',
+  styleUrl: './landing-description.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LandingDescriptionComponent {
+  readonly highlights: readonly DescriptionHighlight[] = [
+    { label: 'Caronas Seguras', icon: faCar },
+    { label: 'Achados & Perdidos', icon: faSearch },
+    { label: 'Portal de Denúncias', icon: faShieldHalved },
+    { label: 'Comunidade Verificada', icon: faUserGroup },
+  ];
+}

--- a/FateConnect/Front/src/app/shared/constants/app-contact.ts
+++ b/FateConnect/Front/src/app/shared/constants/app-contact.ts
@@ -1,0 +1,6 @@
+/** Dados de contacto institucionais (footer, landing #contato). */
+export const APP_CONTACT = {
+  email: 'f003.alunos@fatec.sp.gov.br',
+  phone: '(15) 3238-5266',
+  address: 'Av. Eng. Carlos Reinaldo Mendes, 2015',
+};

--- a/FateConnect/Front/src/app/shared/ui/footer/footer.component.html
+++ b/FateConnect/Front/src/app/shared/ui/footer/footer.component.html
@@ -3,15 +3,15 @@
     <app-typography variant="h2">Entre em contato</app-typography>
     <div class="contact-item">
       <fa-icon [icon]="faEnvelope" size="sm"></fa-icon>
-      <app-typography variant="caption">f003.alunos@fatec.sp.gov.br</app-typography>
+      <app-typography variant="caption">{{ contact.email }}</app-typography>
     </div>
     <div class="contact-item">
       <fa-icon [icon]="faPhone" size="sm"></fa-icon>
-      <app-typography variant="caption">(15) 3238-5266</app-typography>
+      <app-typography variant="caption">{{ contact.phone }}</app-typography>
     </div>
     <div class="contact-item">
       <fa-icon [icon]="faLocationDot" size="sm"></fa-icon>
-      <app-typography variant="caption">Av. Eng. Carlos Reinaldo Mendes, 2015</app-typography>
+      <app-typography variant="caption">{{ contact.address }}</app-typography>
     </div>
   </div>
 

--- a/FateConnect/Front/src/app/shared/ui/footer/footer.component.ts
+++ b/FateConnect/Front/src/app/shared/ui/footer/footer.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faEnvelope, faPhone, faLocationDot } from '@fortawesome/free-solid-svg-icons';
+import { faEnvelope, faLocationDot, faPhone } from '@fortawesome/free-solid-svg-icons';
+import { APP_CONTACT } from '../../constants/app-contact';
 import { TypographyComponent } from '../typography/typography';
 
 @Component({
@@ -10,7 +11,8 @@ import { TypographyComponent } from '../typography/typography';
   styleUrl: './footer.component.scss',
 })
 export class FooterComponent {
-  faEnvelope = faEnvelope;
-  faPhone = faPhone;
-  faLocationDot = faLocationDot;
+  readonly contact = APP_CONTACT;
+  readonly faEnvelope = faEnvelope;
+  readonly faPhone = faPhone;
+  readonly faLocationDot = faLocationDot;
 }

--- a/FateConnect/Front/src/app/shared/ui/typography/typography.scss
+++ b/FateConnect/Front/src/app/shared/ui/typography/typography.scss
@@ -4,7 +4,7 @@
   --app-typography-text-color: var(--app-cor-principal);
 
   --app-typography-h1-size: 2rem;
-  --app-typography-h1-size-narrow: 1.875rem;
+  --app-typography-h1-size-narrow: 1.5rem;
   --app-typography-h1-weight: 700;
   --app-typography-h1-lh: 1.2;
 
@@ -21,6 +21,8 @@
   --app-typography-caption-size: 0.875rem;
   --app-typography-caption-weight: 400;
   --app-typography-caption-lh: 1.4;
+
+  --app-typography-caption-bold-weight: 700;
 
   --app-typography-logo-size: 1.3rem;
   --app-typography-logo-weight: 600;
@@ -60,6 +62,12 @@
 .typography--caption {
   font-size: var(--app-typography-caption-size);
   font-weight: var(--app-typography-caption-weight);
+  line-height: var(--app-typography-caption-lh);
+}
+
+.typography--caption-bold {
+  font-size: var(--app-typography-caption-size);
+  font-weight: var(--app-typography-caption-bold-weight);
   line-height: var(--app-typography-caption-lh);
 }
 

--- a/FateConnect/Front/src/app/shared/ui/typography/typography.ts
+++ b/FateConnect/Front/src/app/shared/ui/typography/typography.ts
@@ -6,6 +6,7 @@ export type TypographyVariant =
   | 'subtitle'
   | 'subtitle-bold'
   | 'caption'
+  | 'caption-bold'
   | 'logo';
 
 @Component({

--- a/FateConnect/Front/src/styles.scss
+++ b/FateConnect/Front/src/styles.scss
@@ -38,6 +38,10 @@ $tema-claro: mat.m2-define-light-theme((
 
 @include mat.all-component-themes($tema-claro);
 
+html {
+  scroll-behavior: smooth;
+}
+
 html,
 body,
 * {


### PR DESCRIPTION
## Objetivo

Entregar o bloco informativo da landing (GitHub #10) como componente standalone reutilizável, centralizar os dados de contacto institucional e aplicar pequenos ajustes de layout e tipografia no Front.

## Alterações

- **Novo** `LandingDescriptionComponent` (`app-landing-description`): título, texto de apoio e lista de quatro destaques com ícones Font Awesome; estilos responsivos (destaques ocultos abaixo de 768px); testes unitários em `landing-description.component.spec.ts`.
- **Novo** `APP_CONTACT` em `shared/constants/app-contact.ts` e **footer** passa a exibir e-mail, telefone e endereço a partir dessa constante.
- **Tipografia:** variante `caption-bold` (`typography.ts` / `typography.scss`) e ajuste de `--app-typography-h1-size-narrow` para `1.5rem` em mobile.
- **Global:** `html { scroll-behavior: smooth; }` em `styles.scss`.
- **Layout:** removido o padding horizontal/vertical genérico de `.conteudo` em `layout-shell.shared.scss`; o mesmo espaçamento (`padding: 3vw 7vw`) foi aplicado em `caronas.component.scss` para manter o alinhamento na área de caronas.

## Issue

- #10

Closes #10

## Evidências

<img width="942" height="516" alt="image" src="https://github.com/user-attachments/assets/75f5a23f-3cb6-4d81-974a-067971a25bd9" />

