### PR TITLE
feat(11): adicionar card de login da landing (somente ui)

### DIFF
--- a/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.html
+++ b/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.html
@@ -1,0 +1,37 @@
+<article class="login-card" aria-labelledby="landing-login-title">
+  <app-typography variant="h2" id="landing-login-title">Acesse sua conta</app-typography>
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="full-width">
+      <mat-label>E-mail</mat-label>
+      <input matInput id="landing-login-email" type="email" formControlName="email" autocomplete="email" />
+      @if (form.controls.email.hasError('required') && form.controls.email.touched) {
+      <mat-error>Informe o e-mail</mat-error>
+      } @else if (form.controls.email.hasError('email') && form.controls.email.touched) {
+      <mat-error>E-mail inválido</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="full-width">
+      <mat-label>Senha</mat-label>
+      <input matInput [type]="hidePassword() ? 'password' : 'text'" formControlName="password"
+        autocomplete="current-password" />
+      <button matIconSuffix mat-icon-button type="button" [attr.aria-pressed]="!hidePassword()"
+        aria-label="Mostrar ou ocultar senha" (click)="togglePasswordVisibility()">
+        <fa-icon [icon]="hidePassword() ? faEye : faEyeSlash"></fa-icon>
+      </button>
+      @if (form.controls.password.hasError('required') && form.controls.password.touched) {
+      <mat-error>Informe a senha</mat-error>
+      }
+    </mat-form-field>
+
+    <button mat-raised-button color="warn" type="submit" class="submit-btn">Entrar</button>
+  </form>
+
+  <p class="signup-row">
+    <app-typography variant="caption">Não tem conta?</app-typography>
+    <a href="#" class="signup-link" (click)="$event.preventDefault()">
+      <app-typography variant="caption-bold" class="signup-link">Cadastre-se</app-typography>
+    </a>
+  </p>
+</article>

--- a/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.scss
+++ b/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.scss
@@ -1,0 +1,74 @@
+:host {
+  display: flex;
+}
+
+.login-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem;
+  width: 360px;
+  background: var(--app-fundo-branco);
+  border-radius: var(--app-borda-componentes);
+  box-shadow: var(--app-sombra-componentes);
+}
+
+app-typography#landing-login-title {
+  --app-typography-text-color: var(--app-cor-principal);
+  text-align: center;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.full-width {
+  width: 100%;
+
+  fa-icon {
+    color: var(--app-texto-sobre-branco);
+  }
+}
+
+.submit-btn {
+  margin-top: 0.5rem;
+  width: 100%;
+  height: 40px;
+  border-radius: var(--app-borda-componentes);
+}
+
+.signup-row {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem;
+  justify-content: center;
+  text-align: center;
+
+  app-typography {
+    --app-typography-text-color: var(--app-texto-sobre-branco);
+  }
+
+  app-typography.signup-link {
+    --app-typography-text-color: var(--app-cor-destaque);
+  }
+}
+
+.signup-link {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-color: var(--app-cor-destaque);
+  }
+}
+
+@media (max-width: 968px) {
+  :host {
+    justify-self: center;
+    max-width: 24rem;
+  }
+}

--- a/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.spec.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { LandingLoginCardComponent } from './landing-login-card.component';
+
+describe('LandingLoginCardComponent', () => {
+  let fixture: ComponentFixture<LandingLoginCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LandingLoginCardComponent, RouterTestingModule],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LandingLoginCardComponent);
+    fixture.detectChanges();
+  });
+
+  it('não deve marcar campos até o submit', () => {
+    expect(fixture.componentInstance.form.touched).toBeFalse();
+  });
+
+  it('deve marcar campos inválidos ao submeter vazio', () => {
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.form.touched).toBeTrue();
+  });
+
+  it('deve alternar tipo do campo senha ao clicar no botão', () => {
+    const host = fixture.nativeElement as HTMLElement;
+    const passwordInput = host.querySelector<HTMLInputElement>(
+      'input[formcontrolname="password"]'
+    )!;
+    const toggle = host.querySelector<HTMLButtonElement>('button[aria-label="Mostrar ou ocultar senha"]')!;
+
+    expect(passwordInput.type).toBe('password');
+    toggle.click();
+    fixture.detectChanges();
+    expect(passwordInput.type).toBe('text');
+    toggle.click();
+    fixture.detectChanges();
+    expect(passwordInput.type).toBe('password');
+  });
+});

--- a/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.ts
@@ -1,0 +1,88 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { NavigationEnd, Router } from '@angular/router';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { filter } from 'rxjs/operators';
+import { TypographyComponent } from '../../../../shared/ui/typography/typography';
+
+@Component({
+  selector: 'app-landing-login-card',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    FontAwesomeModule,
+    TypographyComponent,
+  ],
+  templateUrl: './landing-login-card.component.html',
+  styleUrl: './landing-login-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LandingLoginCardComponent implements AfterViewInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly router = inject(Router);
+  private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly form = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required],
+  });
+
+  readonly hidePassword = signal(true);
+  readonly faEye = faEye;
+  readonly faEyeSlash = faEyeSlash;
+
+  ngAfterViewInit(): void {
+    const focusEmail = (): void => {
+      const input = this.host.nativeElement.querySelector('#landing-login-email') as
+        | HTMLInputElement
+        | null;
+      input?.focus();
+    };
+
+    this.router.events
+      .pipe(
+        filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => {
+        if (this.router.parseUrl(this.router.url).fragment === 'login') {
+          setTimeout(focusEmail);
+        }
+      });
+
+    if (this.router.parseUrl(this.router.url).fragment === 'login') {
+      setTimeout(focusEmail);
+    }
+  }
+
+  togglePasswordVisibility(): void {
+    this.hidePassword.update((v) => !v);
+  }
+
+  onSubmit(): void {
+    if (this.form.valid) {
+      /* UI only (#11): autenticação real virá com a API. */
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+}


### PR DESCRIPTION
## Objetivo

Implementar o formulário de login da landing conforme a issue #11: card "Acesse sua conta" com validação no cliente, sem chamada HTTP de autenticação nesta entrega.

## Alterações

- **Novo** `LandingLoginCardComponent` (`app-landing-login-card`): `FormBuilder` + `ReactiveFormsModule`, campos e-mail e senha com `Validators.required` e `Validators.email`, mensagens `mat-error`, botão **Entrar** (`mat-raised-button` `color="warn"`), link **Cadastre-se** com `href="#"` e `preventDefault`.
- **UX / a11y:** botão sufixo no campo senha para mostrar/ocultar (`faEye` / `faEyeSlash`), `aria-pressed` e `aria-label` em PT-BR; `id="landing-login-email"` para foco programático.
- **Navegação:** em `ngAfterViewInit`, foco no e-mail quando o URL tem fragmento `login`, ouvindo `Router.events` (`NavigationEnd`) com `takeUntilDestroyed`; `onSubmit` apenas valida e marca touched se inválido (comentário de UI-only para API futura).
- **Estilos:** card com `border-radius` e `box-shadow` via tokens (`--app-borda-componentes`, `--app-sombra-componentes`), largura fixa desktop e ajuste em `max-width: 968px`.
- **Testes:** `landing-login-card.component.spec.ts` com `RouterTestingModule`, `provideNoopAnimations`, asserções de touched, submit vazio e alternância do tipo do input de senha.

## Issue

- #11

Closes #11

## Evidências

<img width="1505" height="516" alt="image" src="https://github.com/user-attachments/assets/ce2b06a0-9ce9-4d08-83c0-5d135cd45fda" />


