### PR TITLE
feat(12): adicionar secção nossos serviços na landing

### DIFF
--- a/FateConnect/Front/src/app/pages/home/components/landing-services/landing-services.component.html
+++ b/FateConnect/Front/src/app/pages/home/components/landing-services/landing-services.component.html
@@ -1,0 +1,19 @@
+<section
+  id="servicos"
+  class="services-section landing-anchor"
+  aria-labelledby="servicos-heading"
+>
+  <app-typography variant="h1" id="servicos-heading" class="section-title">Nossos Serviços</app-typography>
+
+  <div class="cards-grid">
+    @for (card of services; track card.title) {
+      <article class="service-card">
+        <div class="icon-container" aria-hidden="true">
+          <fa-icon [icon]="card.icon"></fa-icon>
+        </div>
+        <app-typography variant="h2" class="card-title">{{ card.title }}</app-typography>
+        <app-typography variant="subtitle" class="card-body">{{ card.description }}</app-typography>
+      </article>
+    }
+  </div>
+</section>

--- a/FateConnect/Front/src/app/pages/home/components/landing-services/landing-services.component.scss
+++ b/FateConnect/Front/src/app/pages/home/components/landing-services/landing-services.component.scss
@@ -1,0 +1,61 @@
+/* Fundo cinza em desktop e mobile (mockups alinhados — uma única decisão). */
+.services-section {
+  padding: 5vh 7vw 7vh;
+}
+
+.section-title {
+  display: block;
+  text-align: center;
+  margin-bottom: 2rem;
+  --app-typography-text-color: var(--app-cor-principal);
+}
+
+.cards-grid {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.service-card {
+  display: flex;
+  flex: 0.5;
+  flex-direction: column;
+  min-width: 500px;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  text-align: center;
+  background-color: var(--app-fundo-cinza);
+  border-radius: var(--app-borda-componentes);
+  box-shadow: var(--app-sombra-componentes);
+}
+
+.icon-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background-color: var(--app-cor-destaque);
+}
+
+fa-icon {
+  font-size: var(--app-icon-large);
+  color: var(--app-fundo-branco);
+}
+
+.card-title {
+  --app-typography-text-color: var(--app-cor-principal);
+}
+
+.card-body {
+  --app-typography-text-color: var(--app-texto-sobre-branco);
+}
+
+@media (max-width: 768px) {
+  .service-card {
+    min-width: 100%;
+  }
+}

--- a/FateConnect/Front/src/app/pages/home/components/landing-services/landing-services.component.spec.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-services/landing-services.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LandingServicesComponent } from './landing-services.component';
+
+describe('LandingServicesComponent', () => {
+  let fixture: ComponentFixture<LandingServicesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LandingServicesComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LandingServicesComponent);
+    fixture.detectChanges();
+  });
+
+  it('deve ter título Nossos Serviços', () => {
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('Nossos Serviços');
+  });
+
+  it('deve renderizar quatro cards', () => {
+    const cards = fixture.nativeElement.querySelectorAll('.service-card');
+    expect(cards.length).toBe(4);
+  });
+});

--- a/FateConnect/Front/src/app/pages/home/components/landing-services/landing-services.component.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-services/landing-services.component.ts
@@ -1,0 +1,48 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { faCar, faSearch, faShieldHalved, faUserGroup } from '@fortawesome/free-solid-svg-icons';
+import { TypographyComponent } from '../../../../shared/ui/typography/typography';
+
+interface ServiceCard {
+  readonly title: string;
+  readonly description: string;
+  readonly icon: IconDefinition;
+}
+
+@Component({
+  selector: 'app-landing-services',
+  standalone: true,
+  imports: [TypographyComponent, FontAwesomeModule],
+  templateUrl: './landing-services.component.html',
+  styleUrl: './landing-services.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LandingServicesComponent {
+  readonly services: readonly ServiceCard[] = [
+    {
+      title: 'Caronas Universitárias',
+      description:
+        'Encontre ou ofereça caronas para outros estudantes da Fatec. Economize dinheiro e faça novos amigos no caminho.',
+      icon: faCar,
+    },
+    {
+      title: 'Achados & Perdidos',
+      description:
+        'Perdeu algo no campus? Encontre seu objeto de volta de maneira fácil e rápida com a nossa plataforma!',
+      icon: faSearch,
+    },
+    {
+      title: 'Comunidade Verificada',
+      description:
+        'Todos os usuários são verificados através do e-mail institucional, garantindo que você interaja apenas com membros da comunidade acadêmica.',
+      icon: faUserGroup,
+    },
+    {
+      title: 'Portal de Denúncias',
+      description:
+        'Relate situações inadequadas, assédio, bullying ou qualquer comportamento impróprio de forma anônima e segura. Sua denúncia será tratada com total confidencialidade.',
+      icon: faShieldHalved,
+    },
+  ];
+}


### PR DESCRIPTION
## Objetivo

Implementar a secção **Nossos Serviços** da landing (issue #12): título, quatro cards com ícone, título e descrição, com âncora `#servicos` para a navbar guest.

## Alterações

- **Novo** `LandingServicesComponent` (`app-landing-services`), standalone, com `OnPush`.
- **Template:** `<section id="servicos" class="services-section landing-anchor">` com `aria-labelledby="servicos-heading"`; título **Nossos Serviços** via `app-typography` `variant="h1"` e `id="servicos-heading"`; grelha de cards com `@for` sobre o array `services`.
- **Dados:** array `readonly services` no TS (título, descrição, ícone FA) — Caronas Universitárias, Achados \& Perdidos, Comunidade Verificada, Portal de Denúncias (`faCar`, `faSearch`, `faUserGroup`, `faShieldHalved`).
- **Estilos:** fundo da secção com padding vertical/horizontal; cards com `flex` + `min-width: 500px` (100% em `max-width: 768px`), fundo `--app-fundo-cinza`, disco de ícone 70×70 e FA com `--app-icon-large`; comentário SCSS sobre decisão única de fundo desktop/mobile.
- **Testes:** `landing-services.component.spec.ts` — presença do título e quatro `.service-card`.

## Issue

- #12

Closes #12

## Evidências

<img width="1505" height="830" alt="image" src="https://github.com/user-attachments/assets/6d810398-5236-4b28-9cfb-3e00dd0bf210" />