### PR TITLE
feat(13): adicionar secção como funciona na landing

### DIFF
--- a/FateConnect/Front/src/app/pages/home/components/landing-how-it-works/landing-how-it-works.component.html
+++ b/FateConnect/Front/src/app/pages/home/components/landing-how-it-works/landing-how-it-works.component.html
@@ -1,0 +1,21 @@
+<section
+  id="como-funciona"
+  class="how-section landing-anchor"
+  aria-labelledby="como-funciona-heading"
+>
+  <app-typography variant="h1" id="como-funciona-heading" class="section-title">
+    Como Funciona
+  </app-typography>
+
+  <div class="steps-grid">
+    @for (step of steps; track step.number) {
+      <article class="passo step-card">
+        <span class="step-badge" aria-hidden="true">{{ step.number }}</span>
+        <div class="step-body">
+          <app-typography variant="h2" class="step-title">{{ step.title }}</app-typography>
+          <app-typography variant="subtitle" class="step-desc">{{ step.description }}</app-typography>
+        </div>
+      </article>
+    }
+  </div>
+</section>

--- a/FateConnect/Front/src/app/pages/home/components/landing-how-it-works/landing-how-it-works.component.scss
+++ b/FateConnect/Front/src/app/pages/home/components/landing-how-it-works/landing-how-it-works.component.scss
@@ -1,0 +1,73 @@
+.how-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3rem 7vw;
+}
+
+.section-title {
+  display: flex;
+  text-align: center;
+  margin-bottom: 2rem;
+  --app-typography-text-color: var(--app-cor-principal);
+}
+
+.steps-grid {
+  display: flex;
+  gap: 2rem;
+}
+
+.step-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1.5rem 1.75rem;
+  background: var(--app-fundo-branco);
+  border-radius: var(--app-borda-componentes);
+  box-shadow: var(--app-sombra-componentes);
+  text-align: center;
+}
+
+.step-badge {
+  position: absolute;
+  top: -1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background-color: var(--app-cor-destaque);
+  color: var(--app-fundo-branco);
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+.step-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.step-title {
+  --app-typography-text-color: var(--app-cor-principal);
+}
+
+.step-desc {
+  --app-typography-text-color: var(--app-texto-sobre-branco);
+}
+
+@media (max-width: 768px) {
+  .steps-grid {
+    flex-direction: column;
+  }
+
+  .step-badge {
+    left: 2rem;
+  }
+}

--- a/FateConnect/Front/src/app/pages/home/components/landing-how-it-works/landing-how-it-works.component.spec.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-how-it-works/landing-how-it-works.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LandingHowItWorksComponent } from './landing-how-it-works.component';
+
+describe('LandingHowItWorksComponent', () => {
+  let fixture: ComponentFixture<LandingHowItWorksComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LandingHowItWorksComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LandingHowItWorksComponent);
+    fixture.detectChanges();
+  });
+
+  it('deve exibir dois passos', () => {
+    const passos = fixture.nativeElement.querySelectorAll('.passo');
+    expect(passos.length).toBe(2);
+  });
+
+  it('deve mencionar Cadastre-se e Explore', () => {
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('Cadastre-se');
+    expect(text).toContain('Explore');
+  });
+});

--- a/FateConnect/Front/src/app/pages/home/components/landing-how-it-works/landing-how-it-works.component.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-how-it-works/landing-how-it-works.component.ts
@@ -1,0 +1,33 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TypographyComponent } from '../../../../shared/ui/typography/typography';
+
+interface Step {
+  readonly number: 1 | 2;
+  readonly title: string;
+  readonly description: string;
+}
+
+@Component({
+  selector: 'app-landing-how-it-works',
+  standalone: true,
+  imports: [TypographyComponent],
+  templateUrl: './landing-how-it-works.component.html',
+  styleUrl: './landing-how-it-works.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LandingHowItWorksComponent {
+  readonly steps: readonly Step[] = [
+    {
+      number: 1,
+      title: 'Cadastre-se',
+      description:
+        'Crie sua conta com o e-mail institucional da Fatec Sorocaba para fazer parte da comunidade verificada do FateConnect.',
+    },
+    {
+      number: 2,
+      title: 'Explore',
+      description:
+        'Busque caronas, publique em achados e perdidos e use os demais serviços pensados para o dia a dia no campus.',
+    },
+  ];
+}


### PR DESCRIPTION
## Objetivo

Implementar a secção **Como Funciona** da landing (issue #13): título, dois passos numerados com texto de apoio e âncora `#como-funciona` para a navbar guest.

## Alterações

- **Novo** `LandingHowItWorksComponent` (`app-landing-how-it-works`), standalone, com `OnPush`.
- **Template:** `<section id="como-funciona" class="how-section landing-anchor">` com `aria-labelledby="como-funciona-heading"`; título **Como Funciona** com `app-typography` `variant="h1"` e `id="como-funciona-heading"`; `@for` sobre `steps` renderizando `<article class="passo step-card">` com badge numérico (`.step-badge`, `aria-hidden="true"`), título (`h2`) e descrição (`subtitle`).
- **Dados:** array `readonly steps` no TS — passo 1 **Cadastre-se** (e-mail institucional Fatec Sorocaba), passo 2 **Explore** (caronas, achados e perdidos, outros serviços).
- **Estilos:** secção centrada com padding; grelha de passos em `flex` com `gap`; cards brancos com `border-radius` e sombra via tokens; badge circular vermelho (`--app-cor-destaque`) sobre o topo do card; em `max-width: 768px`, passos em coluna e ajuste de posição do badge (`left: 2rem`).
- **Testes:** `landing-how-it-works.component.spec.ts` — dois elementos `.passo` e texto contendo **Cadastre-se** e **Explore**.

## Issue

- #13

Closes #13

## Evidências

<img width="1505" height="830" alt="image" src="https://github.com/user-attachments/assets/d941cd79-3846-4589-b7f4-0e4c82a1742f" />


