### PR TITLE
feat(5): landing com âncoras, componentes e header fixo no shell

### DIFF
--- a/FateConnect/Front/src/app/core/landing-anchor.service.ts
+++ b/FateConnect/Front/src/app/core/landing-anchor.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, inject } from '@angular/core';
+import { Router } from '@angular/router';
+
+/**
+ * Navegação para `/inicio` com fragmento + scroll até o elemento.
+ * O Router costuma ignorar navegações “iguais” só com hash diferente; o scroll nativo
+ * também falha se o scroll principal não for a janela — daí o `scrollIntoView` após o `navigate`.
+ */
+@Injectable({ providedIn: 'root' })
+export class LandingAnchorService {
+  private readonly router = inject(Router);
+
+  go(fragment: string): void {
+    const scrollToTarget = (): void => {
+      document.getElementById(fragment)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    void this.router.navigate(['/inicio'], { fragment }).finally(() => {
+      setTimeout(scrollToTarget, 0);
+      setTimeout(scrollToTarget, 100);
+    });
+  }
+}

--- a/FateConnect/Front/src/app/core/layout/layout-guest.component.html
+++ b/FateConnect/Front/src/app/core/layout/layout-guest.component.html
@@ -7,14 +7,10 @@
     </div>
 
     <mat-nav-list>
-      <a mat-list-item routerLink="/inicio" fragment="servicos" (click)="drawer.close()">Serviços</a>
-      <a mat-list-item routerLink="/inicio" fragment="como-funciona" (click)="drawer.close()">
-        Como Funciona
-      </a>
-      <a mat-list-item routerLink="/inicio" fragment="contato" (click)="drawer.close()">
-        Entre em Contato
-      </a>
-      <a mat-list-item routerLink="/inicio" fragment="login" (click)="drawer.close()">Entrar</a>
+      <a mat-list-item (click)="navigateFragment(drawer, 'servicos')">Serviços</a>
+      <a mat-list-item (click)="navigateFragment(drawer, 'como-funciona')">Como Funciona</a>
+      <a mat-list-item (click)="navigateFragment(drawer, 'contato')">Entre em Contato</a>
+      <a mat-list-item (click)="navigateFragment(drawer, 'login')">Entrar</a>
     </mat-nav-list>
   </mat-sidenav>
 

--- a/FateConnect/Front/src/app/core/layout/layout-guest.component.spec.ts
+++ b/FateConnect/Front/src/app/core/layout/layout-guest.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter, RouterLink } from '@angular/router';
 
+import { LandingAnchorService } from '../landing-anchor.service';
 import { LayoutGuestComponent } from './layout-guest.component';
 
 @Component({ standalone: true, template: '' })
@@ -10,6 +11,7 @@ class InicioStubComponent {}
 
 describe('LayoutGuestComponent', () => {
   let fixture: ComponentFixture<LayoutGuestComponent>;
+  let landingAnchor: LandingAnchorService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -17,24 +19,32 @@ describe('LayoutGuestComponent', () => {
       providers: [provideRouter([{ path: 'inicio', component: InicioStubComponent }])],
     }).compileComponents();
 
+    landingAnchor = TestBed.inject(LandingAnchorService);
     fixture = TestBed.createComponent(LayoutGuestComponent);
     fixture.detectChanges();
     await fixture.whenStable();
   });
 
-  it('deve listar no sidenav os quatro itens com fragment e logo para /inicio', () => {
+  it('deve listar no sidenav quatro itens que chamam landingAnchor.go com o fragmento certo', () => {
+    spyOn(landingAnchor, 'go');
     const sidenav = fixture.debugElement.query(By.css('mat-sidenav'));
     expect(sidenav).not.toBeNull();
     if (!sidenav) return;
 
-    const links = sidenav.queryAll(By.directive(RouterLink));
-    const routerLinks = links.map((el) => el.injector.get(RouterLink));
+    const items = sidenav.queryAll(By.css('a[mat-list-item]'));
+    expect(items.length).toBe(4);
 
-    const fragments = routerLinks
-      .map((rl) => rl.fragment)
-      .filter((f): f is string => f != null)
-      .sort((a, b) => a.localeCompare(b));
-    expect(fragments).toEqual(['como-funciona', 'contato', 'login', 'servicos']);
+    const expected = ['servicos', 'como-funciona', 'contato', 'login'];
+    for (let i = 0; i < expected.length; i++) {
+      (items[i].nativeElement as HTMLElement).click();
+      expect(landingAnchor.go).toHaveBeenCalledWith(expected[i]);
+    }
+  });
+
+  it('logo no sidenav aponta para /inicio sem fragment', () => {
+    const sidenav = fixture.debugElement.query(By.css('mat-sidenav'));
+    expect(sidenav).not.toBeNull();
+    if (!sidenav) return;
 
     const logo = sidenav.query(By.css('a.logo-app'));
     expect(logo).not.toBeNull();

--- a/FateConnect/Front/src/app/core/layout/layout-guest.component.ts
+++ b/FateConnect/Front/src/app/core/layout/layout-guest.component.ts
@@ -1,10 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatListModule } from '@angular/material/list';
-import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 import { RouterModule, RouterOutlet } from '@angular/router';
 import { FooterComponent } from '../../shared/ui/footer/footer.component';
 import { HeaderComponent } from '../../shared/ui/header/header.component';
 import { TypographyComponent } from '../../shared/ui/typography/typography';
+import { LandingAnchorService } from '../landing-anchor.service';
 
 @Component({
   selector: 'app-layout-guest',
@@ -21,4 +22,11 @@ import { TypographyComponent } from '../../shared/ui/typography/typography';
   templateUrl: './layout-guest.component.html',
   styleUrl: './layout-guest.component.scss',
 })
-export class LayoutGuestComponent {}
+export class LayoutGuestComponent {
+  private readonly landingAnchor = inject(LandingAnchorService);
+
+  navigateFragment(drawer: MatSidenav, fragment: string): void {
+    drawer.close();
+    this.landingAnchor.go(fragment);
+  }
+}

--- a/FateConnect/Front/src/app/core/layout/layout-shell.shared.scss
+++ b/FateConnect/Front/src/app/core/layout/layout-shell.shared.scss
@@ -42,6 +42,7 @@
 
   .layout {
     min-height: 100vh;
+    padding-top: 64px;
     display: flex;
     flex-direction: column;
   }

--- a/FateConnect/Front/src/app/pages/home/home.component.html
+++ b/FateConnect/Front/src/app/pages/home/home.component.html
@@ -1,12 +1,14 @@
-<section id="servicos" class="landing-anchor" aria-label="Serviços">
-  <app-typography variant="subtitle">Serviços (placeholder)</app-typography>
-</section>
-<section id="como-funciona" class="landing-anchor" aria-label="Como funciona">
-  <app-typography variant="subtitle">Como funciona (placeholder)</app-typography>
-</section>
-<section id="contato" class="landing-anchor" aria-label="Contato">
-  <app-typography variant="subtitle">Contato (placeholder)</app-typography>
-</section>
-<section id="login" class="landing-anchor" aria-label="Acesse sua conta">
-  <app-typography variant="subtitle">Login (placeholder)</app-typography>
-</section>
+<div class="home-page">
+  <section class="description-container" aria-label="Apresentação e acesso">
+    <app-landing-description />
+    <div id="login" class="login-anchor">
+      <app-landing-login-card />
+    </div>
+  </section>
+
+  <section class="services-container" aria-label="Nossos Serviços">
+    <app-landing-services />
+  </section>
+
+  <app-landing-how-it-works />
+</div>

--- a/FateConnect/Front/src/app/pages/home/home.component.scss
+++ b/FateConnect/Front/src/app/pages/home/home.component.scss
@@ -4,7 +4,36 @@
   width: 100%;
 }
 
-.landing-anchor {
-  min-height: 40vh;
-  padding: 1rem;
+.home-page {
+  display: flex;
+  flex-direction: column;
+}
+
+.description-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding: 7vh 7vw;
+  gap: 32px;
+}
+
+.login-anchor {
+  display: flex;
+}
+
+.services-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--app-fundo-branco);
+}
+
+@media (max-width: 968px) {
+  .description-container {
+    flex-direction: column;
+  }
+
+  .login-anchor {
+    justify-content: center;
+  }
 }

--- a/FateConnect/Front/src/app/pages/home/home.component.ts
+++ b/FateConnect/Front/src/app/pages/home/home.component.ts
@@ -1,10 +1,18 @@
 import { Component } from '@angular/core';
-import { TypographyComponent } from '../../shared/ui/typography/typography';
+import { LandingDescriptionComponent } from './components/landing-description/landing-description.component';
+import { LandingHowItWorksComponent } from './components/landing-how-it-works/landing-how-it-works.component';
+import { LandingLoginCardComponent } from './components/landing-login-card/landing-login-card.component';
+import { LandingServicesComponent } from './components/landing-services/landing-services.component';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [TypographyComponent],
+  imports: [
+    LandingDescriptionComponent,
+    LandingLoginCardComponent,
+    LandingServicesComponent,
+    LandingHowItWorksComponent,
+  ],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss',
 })

--- a/FateConnect/Front/src/app/shared/ui/footer/footer.component.html
+++ b/FateConnect/Front/src/app/shared/ui/footer/footer.component.html
@@ -1,5 +1,5 @@
 <div class="footer">
-  <div class="contacts-container">
+  <div id="contato" class="contacts-container">
     <app-typography variant="h2">Entre em contato</app-typography>
     <div class="contact-item">
       <fa-icon [icon]="faEnvelope" size="sm"></fa-icon>

--- a/FateConnect/Front/src/app/shared/ui/header/header.component.html
+++ b/FateConnect/Front/src/app/shared/ui/header/header.component.html
@@ -15,10 +15,10 @@
     </a>
 
     <div class="desktop-menu">
-      <a mat-button routerLink="/inicio" fragment="servicos">Serviços</a>
-      <a mat-button routerLink="/inicio" fragment="como-funciona">Como Funciona</a>
-      <a mat-button routerLink="/inicio" fragment="contato">Entre em Contato</a>
-      <a mat-flat-button color="accent" routerLink="/inicio" fragment="login">Entrar</a>
+      <button type="button" mat-button (click)="landingAnchor.go('servicos')">Serviços</button>
+      <button type="button" mat-button (click)="landingAnchor.go('como-funciona')">Como Funciona</button>
+      <button type="button" mat-button (click)="landingAnchor.go('contato')">Entre em Contato</button>
+      <button type="button" mat-flat-button color="accent" (click)="landingAnchor.go('login')">Entrar</button>
     </div>
   }
 

--- a/FateConnect/Front/src/app/shared/ui/header/header.component.scss
+++ b/FateConnect/Front/src/app/shared/ui/header/header.component.scss
@@ -1,3 +1,13 @@
+// Shell (guest + logado): fixed — .mat-drawer-container tem overflow:hidden e quebra sticky.
+:host-context(.layout) {
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+
 mat-toolbar {
   transition: box-shadow 0.3s ease;
   height: 64px;

--- a/FateConnect/Front/src/app/shared/ui/header/header.component.spec.ts
+++ b/FateConnect/Front/src/app/shared/ui/header/header.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter, RouterLink } from '@angular/router';
 
+import { LandingAnchorService } from '../../../core/landing-anchor.service';
 import { HeaderComponent } from './header.component';
 
 @Component({ standalone: true, template: '' })
@@ -20,20 +21,9 @@ class CaronasStubComponent {}
 @Component({ standalone: true, template: '' })
 class ContatoStubComponent {}
 
-function findLinkByFragment(
-  fixture: ComponentFixture<HeaderComponent>,
-  fragment: string,
-): RouterLink | undefined {
-  const elements = fixture.debugElement.queryAll(By.directive(RouterLink));
-  for (const el of elements) {
-    const link = el.injector.get(RouterLink);
-    if (link.fragment === fragment) return link;
-  }
-  return undefined;
-}
-
 describe('HeaderComponent (guest / isLoggedIn=false)', () => {
   let fixture: ComponentFixture<HeaderComponent>;
+  let landingAnchor: LandingAnchorService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -41,22 +31,27 @@ describe('HeaderComponent (guest / isLoggedIn=false)', () => {
       providers: [provideRouter([{ path: 'inicio', component: InicioStubComponent }])],
     }).compileComponents();
 
+    landingAnchor = TestBed.inject(LandingAnchorService);
     fixture = TestBed.createComponent(HeaderComponent);
     fixture.componentRef.setInput('isLoggedIn', false);
     fixture.detectChanges();
     await fixture.whenStable();
   });
 
-  it('deve expor link para Serviços com fragment servicos', () => {
-    const link = findLinkByFragment(fixture, 'servicos');
-    expect(link).toBeTruthy();
-    expect(link?.fragment).toBe('servicos');
-  });
+  it('desktop: cada botão da landing chama landingAnchor.go com o fragmento esperado', () => {
+    spyOn(landingAnchor, 'go');
+    const menu = fixture.debugElement.query(By.css('.desktop-menu'));
+    expect(menu).not.toBeNull();
+    if (!menu) return;
 
-  it('deve expor link Entrar com fragment login', () => {
-    const link = findLinkByFragment(fixture, 'login');
-    expect(link).toBeTruthy();
-    expect(link?.fragment).toBe('login');
+    const buttons = menu.queryAll(By.css('button'));
+    expect(buttons.length).toBe(4);
+
+    const expected = ['servicos', 'como-funciona', 'contato', 'login'];
+    for (let i = 0; i < expected.length; i++) {
+      (buttons[i].nativeElement as HTMLButtonElement).click();
+      expect(landingAnchor.go).toHaveBeenCalledWith(expected[i]);
+    }
   });
 
   it('deve exibir o botão hambúrguer', () => {
@@ -71,22 +66,6 @@ describe('HeaderComponent (guest / isLoggedIn=false)', () => {
     const rl = logo.injector.get(RouterLink);
     expect(rl.fragment).toBeUndefined();
     expect((logo.nativeElement as HTMLAnchorElement).href).toContain('inicio');
-  });
-
-  it('links com fragment devem apontar para /inicio', () => {
-    const expectedFragments = ['servicos', 'como-funciona', 'contato', 'login'];
-    for (const f of expectedFragments) {
-      const link = findLinkByFragment(fixture, f);
-      expect(link).withContext(`fragment ${f}`).toBeTruthy();
-      if (!link) continue;
-      expect(link.href).toContain('inicio');
-    }
-  });
-
-  it('href dos links com fragment deve incluir /inicio e hash', () => {
-    const link = findLinkByFragment(fixture, 'servicos');
-    expect(link?.href).toContain('inicio');
-    expect(link?.href).toContain('servicos');
   });
 });
 

--- a/FateConnect/Front/src/app/shared/ui/header/header.component.ts
+++ b/FateConnect/Front/src/app/shared/ui/header/header.component.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { RouterModule } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
+import { LandingAnchorService } from '../../../core/landing-anchor.service';
 import { TypographyComponent } from '../typography/typography';
 
 @Component({
@@ -30,4 +31,6 @@ export class HeaderComponent {
   readonly drawer = input<MatSidenav | undefined>(undefined);
 
   readonly iconeMenu = faBars;
+
+  protected readonly landingAnchor = inject(LandingAnchorService);
 }

--- a/FateConnect/Front/src/styles.scss
+++ b/FateConnect/Front/src/styles.scss
@@ -42,6 +42,14 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Landing: offset sob a toolbar + scroll por fragmento (scrollIntoView). */
+#servicos,
+#como-funciona,
+#contato,
+#login {
+  scroll-margin-top: 5rem;
+}
+
 html,
 body,
 * {


### PR DESCRIPTION
## Objetivo

Entregar a experiência da landing em `/inicio` com seções reutilizáveis, navegação confiável para âncoras (incluindo scroll com container do Material) e barra superior fixa no layout guest e logado.

## Alterações

- **Home (`/inicio`):** template passa a usar `app-landing-description`, `app-landing-login-card`, `app-landing-services` e `app-landing-how-it-works`; estilos de layout (hero + serviços, responsivo).
- **`LandingAnchorService`:** navegação para `/inicio` com fragmento e `scrollIntoView` (com `setTimeout` para contornar rota igual só com hash e scroll fora da janela).
- **Header (guest):** botões da landing chamam o serviço em vez de `routerLink`+fragment; testes ajustados.
- **Layout guest:** itens do sidenav usam `navigateFragment` (fecha drawer + `landingAnchor.go`); testes cobrindo chamadas ao serviço e logo sem fragment.
- **Header fixo:** `:host-context(.layout)` com `position: fixed` e `z-index` para toolbar acima do conteúdo; **`layout-shell.shared.scss`:** `padding-top: 64px` em `.layout` para compensar a toolbar.
- **`styles.scss`:** `scroll-margin-top` nos ids `#servicos`, `#como-funciona`, `#contato`, `#login`.
- **Footer:** `id="contato"` no bloco de contato para alinhar à âncora.

## Issue

- #5

Closes #5

## Evidências

<img width="1505" height="950" alt="image" src="https://github.com/user-attachments/assets/6a414a63-a811-440d-a4a3-aaaf2bda9036" />
<img width="1505" height="950" alt="image" src="https://github.com/user-attachments/assets/525de129-bfe0-4320-8b45-3aeb62aa2ed8" />
<img width="1505" height="950" alt="image" src="https://github.com/user-attachments/assets/e95486d3-028a-4ba2-b07e-d049226f346c" />
<img width="1505" height="950" alt="image" src="https://github.com/user-attachments/assets/7ca2b93b-4124-4d13-a285-0297bbda2098" />
<img width="300" height="681" alt="image" src="https://github.com/user-attachments/assets/196a3d54-49a6-4fb6-b315-bac7d6eee0a1" /> <img width="300" height="674" alt="image" src="https://github.com/user-attachments/assets/9bed24c9-2220-477a-abb0-abb4c8c21961" />
<img width="300" height="674" alt="image" src="https://github.com/user-attachments/assets/3d1d1fba-612f-460d-9cc4-f55aad14e11a" /> <img width="300" height="674" alt="image" src="https://github.com/user-attachments/assets/8de7d7eb-cf26-4a59-a484-0bd475327f17" />
