### PR TITLE
feat(24): adiciona placeholder de cadastro e link na landing

### DIFF
--- a/FateConnect/Front/src/app/app.routes.ts
+++ b/FateConnect/Front/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import { HomeComponent } from './pages/home/home.component';
 import { MenuComponent } from './pages/menu/menu.component';
 import { LostAndFoundPageComponent } from './pages/lost-and-found/lost-and-found-page.component';
 import { ContactPageComponent } from './pages/contact/contact-page.component';
+import { SignupPageComponent } from './pages/signup/signup-page.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'inicio', pathMatch: 'full' },
@@ -22,6 +23,7 @@ export const routes: Routes = [
     children: [
       { path: 'menu', component: MenuComponent },
       { path: 'achados-perdidos', component: LostAndFoundPageComponent },
+      { path: 'cadastro', component: SignupPageComponent },
       { path: 'contato', component: ContactPageComponent },
       {
         path: 'caronas',

--- a/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.html
+++ b/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.html
@@ -32,8 +32,8 @@
 
   <p class="signup-row">
     <app-typography variant="caption">Não tem conta?</app-typography>
-    <button type="button" class="signup-link" (click)="$event.preventDefault()">
+    <a class="signup-link" routerLink="/cadastro">
       <app-typography variant="caption-bold" class="signup-link">Cadastre-se</app-typography>
-    </button>
+    </a>
   </p>
 </article>

--- a/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.scss
+++ b/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.scss
@@ -64,6 +64,7 @@ form {
   margin: 0;
   cursor: pointer;
   font: inherit;
+  color: inherit;
   text-decoration: none;
 
   &:hover {

--- a/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.ts
@@ -13,7 +13,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { NavigationEnd, Router } from '@angular/router';
+import { NavigationEnd, Router, RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import { filter } from 'rxjs/operators';
@@ -23,6 +23,7 @@ import { TypographyComponent } from '../../../../shared/ui/typography/typography
   selector: 'app-landing-login-card',
   standalone: true,
   imports: [
+    RouterLink,
     ReactiveFormsModule,
     MatFormFieldModule,
     MatInputModule,

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.html
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.html
@@ -1,0 +1,5 @@
+<div class="placeholder-page">
+  <app-typography variant="h1">Cadastro</app-typography>
+  <app-typography variant="subtitle">Esta área estará disponível em breve.</app-typography>
+  <a mat-flat-button color="accent" routerLink="/inicio">Voltar ao início</a>
+</div>

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
@@ -1,0 +1,16 @@
+:host {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.placeholder-page {
+  display: flex;
+  max-width: 28rem;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+}

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { RouterLink } from '@angular/router';
+import { TypographyComponent } from '../../shared/ui/typography/typography';
+
+@Component({
+  selector: 'app-signup-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, MatButtonModule, TypographyComponent],
+  templateUrl: './signup-page.component.html',
+  styleUrl: './signup-page.component.scss',
+})
+export class SignupPageComponent {}


### PR DESCRIPTION
## Objetivo

Expor rota e tela provisória de **cadastro**, alinhada ao padrão das demais placeholders do app, e ligar o fluxo a partir do link **Cadastre-se** no card de login da landing (`/inicio`).

## Alterações

- **Novo** `SignupPageComponent` em `pages/signup/` (standalone, OnPush): título *Cadastro*, subtítulo *Esta área estará disponível em breve.*, botão Material *Voltar ao início* com `routerLink="/inicio"`; estilos espelhando o layout centralizado das outras páginas placeholder.
- **`app.routes.ts`:** rota `cadastro` sob o layout principal, import de `SignupPageComponent`.
- **`landing-login-card`:** substituição do `button` com `preventDefault` por `<a routerLink="/cadastro">`; inclusão de `RouterLink` nos `imports`; em SCSS, `color: inherit` em `.signup-link` para manter a aparência do texto do link.

## Issue

- #24

Closes #24

## Evidências

<img width="1509" height="826" alt="image" src="https://github.com/user-attachments/assets/1048fe69-1197-4b46-8d49-794a3fa60e21" />
