### PR TITLE
feat(26): implementa formulário de cadastro no layout visitante e atualiza e-mail institucional

### DIFF
--- a/FateConnect/Front/src/app/app.routes.ts
+++ b/FateConnect/Front/src/app/app.routes.ts
@@ -18,12 +18,16 @@ export const routes: Routes = [
     children: [{ path: '', component: HomeComponent }],
   },
   {
+    path: 'cadastro',
+    component: LayoutGuestComponent,
+    children: [{ path: '', component: SignupPageComponent }],
+  },
+  {
     path: '',
     component: LayoutComponent,
     children: [
       { path: 'menu', component: MenuComponent },
       { path: 'achados-perdidos', component: LostAndFoundPageComponent },
-      { path: 'cadastro', component: SignupPageComponent },
       { path: 'contato', component: ContactPageComponent },
       {
         path: 'caronas',

--- a/FateConnect/Front/src/app/pages/signup/brazilian-states.constant.ts
+++ b/FateConnect/Front/src/app/pages/signup/brazilian-states.constant.ts
@@ -1,0 +1,35 @@
+/** Unidades federativas (código IBGE + nome em pt-BR) para o formulário de cadastro. */
+export interface BrazilianStateOption {
+  readonly code: string;
+  readonly name: string;
+}
+
+export const BRAZILIAN_STATES: readonly BrazilianStateOption[] = [
+  { code: 'AC', name: 'Acre' },
+  { code: 'AL', name: 'Alagoas' },
+  { code: 'AP', name: 'Amapá' },
+  { code: 'AM', name: 'Amazonas' },
+  { code: 'BA', name: 'Bahia' },
+  { code: 'CE', name: 'Ceará' },
+  { code: 'DF', name: 'Distrito Federal' },
+  { code: 'ES', name: 'Espírito Santo' },
+  { code: 'GO', name: 'Goiás' },
+  { code: 'MA', name: 'Maranhão' },
+  { code: 'MT', name: 'Mato Grosso' },
+  { code: 'MS', name: 'Mato Grosso do Sul' },
+  { code: 'MG', name: 'Minas Gerais' },
+  { code: 'PA', name: 'Pará' },
+  { code: 'PB', name: 'Paraíba' },
+  { code: 'PR', name: 'Paraná' },
+  { code: 'PE', name: 'Pernambuco' },
+  { code: 'PI', name: 'Piauí' },
+  { code: 'RJ', name: 'Rio de Janeiro' },
+  { code: 'RN', name: 'Rio Grande do Norte' },
+  { code: 'RS', name: 'Rio Grande do Sul' },
+  { code: 'RO', name: 'Rondônia' },
+  { code: 'RR', name: 'Roraima' },
+  { code: 'SC', name: 'Santa Catarina' },
+  { code: 'SP', name: 'São Paulo' },
+  { code: 'SE', name: 'Sergipe' },
+  { code: 'TO', name: 'Tocantins' },
+];

--- a/FateConnect/Front/src/app/pages/signup/gender-options.constant.ts
+++ b/FateConnect/Front/src/app/pages/signup/gender-options.constant.ts
@@ -1,0 +1,7 @@
+export type GenderValue = 'female' | 'male' | 'prefer_not_to_say';
+
+export const GENDER_OPTIONS: { readonly value: GenderValue; readonly label: string }[] = [
+  { value: 'female', label: 'Feminino' },
+  { value: 'male', label: 'Masculino' },
+  { value: 'prefer_not_to_say', label: 'Prefiro não informar' },
+];

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.html
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.html
@@ -1,5 +1,198 @@
-<div class="placeholder-page">
-  <app-typography variant="h1">Cadastro</app-typography>
-  <app-typography variant="subtitle">Esta área estará disponível em breve.</app-typography>
-  <a mat-flat-button color="accent" routerLink="/inicio">Voltar ao início</a>
-</div>
+<article class="signup-card" aria-labelledby="signup-title">
+  <app-typography variant="h2" id="signup-title">Crie sua Conta</app-typography>
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate class="signup-form">
+    <div class="signup-form__grid">
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--full">
+        <mat-label>Nome completo</mat-label>
+        <input matInput id="signup-full-name" type="text" name="fullName" formControlName="fullName"
+          autocomplete="name" />
+        @if (form.controls.fullName.hasError('required') && form.controls.fullName.touched) {
+        <mat-error>Informe o nome completo</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--third">
+        <mat-label>Apelido</mat-label>
+        <input matInput id="signup-nickname" type="text" name="nickname" formControlName="nickname"
+          autocomplete="nickname" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--third">
+        <mat-label>E-mail Fatec</mat-label>
+        <input matInput id="signup-fatec-email" name="fatecEmail" type="email" formControlName="fatecEmail"
+          autocomplete="work email" placeholder="nome.sobrenome@aluno.cps.sp.gov.br" />
+        @if (form.controls.fatecEmail.hasError('required') && form.controls.fatecEmail.touched) {
+        <mat-error>Informe o e-mail Fatec</mat-error>
+        } @else if (form.controls.fatecEmail.hasError('email') && form.controls.fatecEmail.touched) {
+        <mat-error>E-mail inválido</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--third">
+        <mat-label>Data de nascimento</mat-label>
+        <input matInput id="signup-birth-date" type="text" name="birthDate" [matDatepicker]="birthPicker"
+          formControlName="birthDate" placeholder="dd/mm/aaaa" [max]="maxBirthDate" [min]="minBirthDate"
+          autocomplete="bday" />
+        <mat-datepicker-toggle matIconSuffix [for]="birthPicker"></mat-datepicker-toggle>
+        <mat-datepicker #birthPicker></mat-datepicker>
+        @if (form.controls.birthDate.hasError('required') && form.controls.birthDate.touched) {
+        <mat-error>Informe a data de nascimento</mat-error>
+        }
+        @if (form.controls.birthDate.hasError('matDatepickerMax') && form.controls.birthDate.touched) {
+        <mat-error>Data não pode ser futura</mat-error>
+        }
+        @if (form.controls.birthDate.hasError('matDatepickerMin') && form.controls.birthDate.touched) {
+        <mat-error>Data inválida</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--third">
+        <mat-label>Gênero</mat-label>
+        <mat-select id="signup-gender" formControlName="gender" placeholder="Selecione..." autocomplete="sex">
+          <mat-option value="">Selecione...</mat-option>
+          @for (opt of genderOptions; track opt.value) {
+          <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
+          }
+        </mat-select>
+        @if (form.controls.gender.hasError('required') && form.controls.gender.touched) {
+        <mat-error>Selecione o gênero</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--third">
+        <mat-label>Senha</mat-label>
+        <input matInput id="signup-password" name="password" formControlName="password"
+          [type]="hidePassword() ? 'password' : 'text'" [attr.autocomplete]="hidePassword() ? 'new-password' : 'off'" />
+        <button matIconSuffix mat-icon-button type="button" [attr.aria-pressed]="!hidePassword()"
+          aria-label="Mostrar ou ocultar senha" (click)="togglePasswordVisibility()">
+          <fa-icon [icon]="hidePassword() ? eyeIcon : eyeSlashIcon"></fa-icon>
+        </button>
+        @if (form.controls.password.hasError('required') && form.controls.password.touched) {
+        <mat-error>Informe a senha</mat-error>
+        } @else if (form.controls.password.hasError('minlength') && form.controls.password.touched) {
+        <mat-error>Mínimo de 8 caracteres</mat-error>
+        }
+      </mat-form-field>
+    </div>
+
+    <div class="signup-form-divider"></div>
+
+    <app-typography variant="subtitle-bold" class="signup-form__section-title">Endereço</app-typography>
+    <div class="signup-form__grid">
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--third">
+        <mat-label>CEP</mat-label>
+        <input matInput id="signup-zip" type="text" name="zipCode" formControlName="zipCode" inputmode="numeric"
+          autocomplete="postal-code" placeholder="00000-000" maxlength="9" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--third">
+        <mat-label>Estado</mat-label>
+        <mat-select id="signup-state" formControlName="state" autocomplete="address-level1">
+          <mat-option value="">Selecione...</mat-option>
+          @for (st of brazilianStates; track st.code) {
+          <mat-option [value]="st.code">{{ st.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--third">
+        <mat-label>Cidade</mat-label>
+        <input matInput id="signup-city" type="text" name="city" formControlName="city" autocomplete="address-level2" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--street">
+        <mat-label>Logradouro</mat-label>
+        <input matInput id="signup-street" type="text" name="street" formControlName="street"
+          autocomplete="address-line1" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--number">
+        <mat-label>Número</mat-label>
+        <input matInput id="signup-street-number" type="text" name="streetNumber" formControlName="streetNumber"
+          autocomplete="off" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--full">
+        <mat-label>Complemento</mat-label>
+        <input matInput id="signup-complement" type="text" name="complement" formControlName="complement"
+          autocomplete="address-line2" />
+      </mat-form-field>
+    </div>
+
+    <div class="signup-form-divider"></div>
+
+    <app-typography variant="subtitle-bold" class="signup-form__section-title">Dados para contato</app-typography>
+    <div class="signup-form__grid">
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--half">
+        <mat-label>Telefone</mat-label>
+        <input matInput id="signup-phone" name="phone" type="tel" formControlName="phone" inputmode="tel"
+          autocomplete="home tel" placeholder="(00) 00000-0000" />
+        @if (form.controls.phone.hasError('required') && form.controls.phone.touched) {
+        <mat-error>Informe o telefone</mat-error>
+        } @else if (form.controls.phone.hasError('brazilianPhone') && form.controls.phone.touched) {
+        <mat-error>Telefone com DDD: 10 ou 11 dígitos</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" subscriptSizing="dynamic"
+        class="signup-form__field signup-form__field--half">
+        <mat-label>E-mail para contato</mat-label>
+        <input matInput id="signup-contact-email" name="contactEmail" type="email" formControlName="contactEmail"
+          autocomplete="home email" />
+        @if (form.controls.contactEmail.hasError('required') && form.controls.contactEmail.touched) {
+        <mat-error>Informe o e-mail</mat-error>
+        } @else if (form.controls.contactEmail.hasError('email') && form.controls.contactEmail.touched) {
+        <mat-error>E-mail inválido</mat-error>
+        }
+      </mat-form-field>
+    </div>
+
+    <div class="signup-form-divider"></div>
+
+    <div class="signup-form__consent">
+      <mat-checkbox formControlName="acceptTerms">
+        Eu concordo com os
+        <button type="button" class="signup-form__inline-link" (click)="notifyLegalSoon($event, 'terms')">
+          Termos de Uso
+        </button>
+        e
+        <button type="button" class="signup-form__inline-link" (click)="notifyLegalSoon($event, 'privacy')">
+          Política de Privacidade
+        </button>
+      </mat-checkbox>
+      @if (form.controls.acceptTerms.hasError('required') && form.controls.acceptTerms.touched) {
+      <span class="signup-form__consent-error" role="alert">É necessário aceitar os termos de uso e política de
+        privacidade para continuar.</span>
+      }
+
+      <mat-checkbox formControlName="acceptMarketing">
+        Eu concordo em receber e-mails e notificações do aplicativo
+      </mat-checkbox>
+    </div>
+
+    <div class="signup-form-submit-container">
+      <button mat-raised-button color="warn" type="submit" class="signup-form__submit">Cadastrar</button>
+
+      <p class="signup-form__login-row">
+        <app-typography variant="caption">Já tem uma conta?</app-typography>
+        <a routerLink="/inicio" fragment="login" class="signup-form__login-link">
+          <app-typography variant="caption-bold" class="signup-form__login-link-text">Faça login</app-typography>
+        </a>
+      </p>
+    </div>
+  </form>
+</article>

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
@@ -1,16 +1,195 @@
+@use '@angular/material' as mat;
+
+/**
+ * Cadastro — layout do formulário
+ * - < 768px: uma coluna (regras base de .signup-form__grid, sem media query).
+ * - ≥ 768px: grade de 6 colunas; meia largura (3 cols), terços (2 cols), rua 4 + número 2.
+ */
+
 :host {
   display: flex;
   flex: 1;
-  align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: 2rem 1rem 2.5rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
-.placeholder-page {
+.signup-card {
   display: flex;
-  max-width: 28rem;
   flex-direction: column;
-  align-items: center;
   gap: 1rem;
+  width: 100%;
+  max-width: 75%;
+  padding: 2rem;
+  background: var(--app-surface-white);
+  border-radius: var(--app-radius-component);
+  box-shadow: var(--app-shadow-component);
+  box-sizing: border-box;
+}
+
+app-typography#signup-title {
+  --app-typography-text-color: var(--app-color-primary);
   text-align: center;
+}
+
+.signup-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.signup-form-divider {
+  width: 100%;
+  height: 1px;
+  background-color: #d9d9d9;
+  margin: 2rem 0 1rem;
+}
+
+.signup-form__section-title {
+  --app-typography-text-color: var(--app-color-primary);
+}
+
+/* Uma coluna: aplica-se onde nenhum min-width abaixo corresponde (largura < 768px). */
+.signup-form__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.signup-form__field {
+  width: 100%;
+
+  fa-icon {
+    color: var(--app-text-muted);
+  }
+}
+
+/* Ocupa a linha inteira quando há várias colunas na grade. */
+.signup-form__field--full {
+  grid-column: 1 / -1;
+}
+
+.signup-form__consent {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+
+  @include mat.checkbox-overrides(
+    (
+      state-layer-size: 24px,
+    )
+  );
+}
+
+.signup-form__inline-link {
+  display: inline;
+  border: none;
+  background: none;
+  font: inherit;
+  color: var(--app-color-accent);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-color: var(--app-color-accent);
+  }
+}
+
+.signup-form__consent-error {
+  font-size: 0.65rem;
+  color: var(--app-danger-text);
+  padding-left: 1rem;
+}
+
+.signup-form-submit-container {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.signup-form__submit {
+  width: 100%;
+  max-width: 20rem;
+  align-self: center;
+  height: 40px;
+  border-radius: var(--app-radius-component);
+}
+
+.signup-form__login-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: center;
+  text-align: center;
+
+  app-typography {
+    --app-typography-text-color: var(--app-text-muted);
+  }
+}
+
+.signup-form__login-link {
+  text-decoration: none;
+  color: inherit;
+
+  app-typography {
+    --app-typography-text-color: var(--app-color-accent);
+  }
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-color: var(--app-color-accent);
+  }
+}
+
+/* Desktop: 6 colunas para combinar meias, terços e proporção rua/número. */
+@media (min-width: 768px) {
+  .signup-card {
+    padding: 2rem 3rem;
+  }
+
+  .signup-form__consent {
+    font-size: inherit;
+
+    @include mat.checkbox-overrides(
+      (
+        state-layer-size: 32px,
+      )
+    );
+  }
+
+  .signup-form__consent-error {
+    font-size: 0.75rem;
+  }
+
+  /* Grade de 6 colunas iguais: permite “metade” (3+3), “terço” (2+2+2) e 4+2 na linha do endereço. */
+  .signup-form__grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  /* Campo que deve ocupar a linha inteira (ex.: nome completo, senha, complemento). */
+  .signup-form__field--full {
+    grid-column: 1 / -1;
+  }
+
+  /* Meia largura da linha: 3 de 6 colunas (~50%). */
+  .signup-form__field--half {
+    grid-column: span 3;
+  }
+
+  /* Um terço da linha: 2 de 6 colunas (~33%); três campos cabem na mesma linha. */
+  .signup-form__field--third {
+    grid-column: span 2;
+  }
+
+  /* Logradouro ocupa 4/6 da linha; número fica ao lado com 2/6 (proporção mais larga na rua). */
+  .signup-form__field--street {
+    grid-column: 1 / span 4;
+  }
+
+  /* Número ocupa 2/6 da linha; fica ao lado do logradouro. */
+  .signup-form__field--number {
+    grid-column: 5 / span 2;
+  }
 }

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
@@ -20,7 +20,7 @@
   flex-direction: column;
   gap: 1rem;
   width: 100%;
-  max-width: 75%;
+  max-width: 90%;
   padding: 2rem;
   background: var(--app-surface-white);
   border-radius: var(--app-radius-component);
@@ -147,6 +147,7 @@ app-typography#signup-title {
 @media (min-width: 768px) {
   .signup-card {
     padding: 2rem 3rem;
+    max-width: 80%;
   }
 
   .signup-form__consent {

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
@@ -1,14 +1,116 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterLink } from '@angular/router';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import { TypographyComponent } from '../../shared/ui/typography/typography';
+import { BRAZILIAN_STATES } from './brazilian-states.constant';
+import { GENDER_OPTIONS, type GenderValue } from './gender-options.constant';
+
+function brazilianPhoneValidator(control: AbstractControl): ValidationErrors | null {
+  const raw = String(control.value ?? '').replaceAll(/\D/g, '');
+  if (!raw.length) return null;
+  if (raw.length < 10 || raw.length > 11) return { brazilianPhone: true };
+
+  return null;
+}
 
 @Component({
   selector: 'app-signup-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, MatButtonModule, TypographyComponent],
+  imports: [
+    ReactiveFormsModule,
+    RouterLink,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSelectModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatCheckboxModule,
+    MatSnackBarModule,
+    FontAwesomeModule,
+    TypographyComponent,
+  ],
   templateUrl: './signup-page.component.html',
   styleUrl: './signup-page.component.scss',
 })
-export class SignupPageComponent {}
+export class SignupPageComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly snackBar = inject(MatSnackBar);
+
+  readonly hidePassword = signal(true);
+  readonly eyeIcon = faEye;
+  readonly eyeSlashIcon = faEyeSlash;
+
+  readonly genderOptions = GENDER_OPTIONS;
+  readonly brazilianStates = BRAZILIAN_STATES;
+
+  readonly maxBirthDate = new Date();
+  readonly minBirthDate = new Date(1900, 0, 1);
+
+  readonly form = this.fb.nonNullable.group({
+    fullName: ['', Validators.required],
+    nickname: [''],
+    fatecEmail: ['', [Validators.required, Validators.email]],
+    birthDate: [null as Date | null, Validators.required],
+    gender: ['' as GenderValue | '', Validators.required],
+    password: ['', [Validators.required, Validators.minLength(8)]],
+    zipCode: [''],
+    state: [''],
+    city: [''],
+    street: [''],
+    streetNumber: [''],
+    complement: [''],
+    phone: ['', [Validators.required, brazilianPhoneValidator]],
+    contactEmail: ['', [Validators.required, Validators.email]],
+    acceptTerms: [false, Validators.requiredTrue],
+    acceptMarketing: [false],
+  });
+
+  togglePasswordVisibility(): void {
+    this.hidePassword.update((v) => !v);
+  }
+
+  notifyLegalSoon(event: Event, kind: 'terms' | 'privacy'): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const message =
+      kind === 'terms'
+        ? 'Termos de uso estarão disponíveis em breve.'
+        : 'Política de privacidade estará disponível em breve.';
+    this.snackBar.open(message, 'OK', {
+      duration: 5000,
+      verticalPosition: 'top',
+      panelClass: ['snackbar-warning'],
+    });
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.snackBar.open('Cadastro será integrado à API em breve.', 'OK', {
+      duration: 5000,
+      verticalPosition: 'top',
+      panelClass: ['snackbar-warning'],
+    });
+    /* UI antecipada: persistência e auth virão com o backend. */
+  }
+}

--- a/FateConnect/Front/src/app/shared/constants/app-contact.ts
+++ b/FateConnect/Front/src/app/shared/constants/app-contact.ts
@@ -1,6 +1,6 @@
 /** Dados de contato institucionais (footer, landing #contato). */
 export const APP_CONTACT = {
-  email: 'f003.alunos@fatec.sp.gov.br',
+  email: 'f003alunos@cps.sp.gov.br',
   phone: '(15) 3238-5266',
   address: 'Av. Eng. Carlos Reinaldo Mendes, 2015',
 };


### PR DESCRIPTION
## Objetivo

Integrar a tela de cadastro no layout visitante (formulário completo, validações e layout responsivo), as constantes de apoio aos selects e a correção do e-mail institucional em `APP_CONTACT`.

## Alterações

- **`app.routes.ts`**: rota `/cadastro` passa a ser filha de `LayoutGuestComponent`; removida do conjunto de rotas do layout principal autenticado.
- **`signup-page.component.ts` / `.html` / `.scss`**: formulário reativo (Angular Material) com dados pessoais (nome, apelido, e-mail Fatec, data de nascimento com datepicker, gênero, senha com ícone mostrar/ocultar), bloco de endereço (CEP, UF, cidade, logradouro, número, complemento), contato (telefone com validação de DDD/dígitos, e-mail), aceite de termos e opt-in de marketing; `MatSnackBar` para submissão antecipada e avisos de termos/privacidade; grade CSS em uma coluna no mobile e seis colunas a partir de 768px, alinhada a tokens `--app-*`.
- **`brazilian-states.constant.ts`** e **`gender-options.constant.ts`**: listas para estado e gênero.
- **`app-contact.ts`**: atualização do e-mail institucional para `f003alunos@cps.sp.gov.br`.

## Issue

- #26

Closes #26

## Evidências

### Desktop

<img width="1509" height="831" alt="image" src="https://github.com/user-attachments/assets/676cb739-65ae-4466-aa49-2890a5961f93" />
<img width="1509" height="831" alt="image" src="https://github.com/user-attachments/assets/faed81eb-e7de-4272-b05c-d82140030090" />

### Mobile

<img width="250" height="746" alt="image" src="https://github.com/user-attachments/assets/80a5c252-fc32-44ff-b83c-a4223f4994ed" /> <img width="250" height="746" alt="image" src="https://github.com/user-attachments/assets/963c64e4-6de1-4cf1-8bac-7301ccd73f86" /> <img width="250" height="746" alt="image" src="https://github.com/user-attachments/assets/42e6b918-c877-4b81-a70c-83d27620d6ef" />
