### PR TITLE
feat(33): cadastro com cep, máscaras, maioridade e datas pt-br

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Runs Front unit tests (Karma, Chrome headless) before each push.
+# Enable for this clone: git config core.hooksPath .githooks
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+FRONT="$ROOT/FateConnect/Front"
+
+if [[ ! -f "$FRONT/package.json" ]]; then
+  echo "pre-push: expected $FRONT/package.json" >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "pre-push: npm not found on PATH" >&2
+  exit 1
+fi
+
+cd "$FRONT"
+npm run test:ci

--- a/FateConnect/Front/package-lock.json
+++ b/FateConnect/Front/package-lock.json
@@ -22,6 +22,7 @@
         "@fortawesome/free-brands-svg-icons": "^7.1.0",
         "@fortawesome/free-regular-svg-icons": "^7.1.0",
         "@fortawesome/free-solid-svg-icons": "^7.1.0",
+        "ngx-mask": "^20.0.3",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -7149,6 +7150,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ngx-mask": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/ngx-mask/-/ngx-mask-20.0.3.tgz",
+      "integrity": "sha512-5bmrgbFGudj0mFN6cPv/TI+cFJxT4l61mLIFskdvaXsJL/Oj7thRmWYqvqHXjCboOcx8gT6T/Zypl5u9l2J8Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=14.0.0",
+        "@angular/core": ">=14.0.0",
+        "@angular/forms": ">=14.0.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/FateConnect/Front/package.json
+++ b/FateConnect/Front/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadless"
   },
   "prettier": {
     "printWidth": 100,

--- a/FateConnect/Front/package.json
+++ b/FateConnect/Front/package.json
@@ -36,6 +36,7 @@
     "@fortawesome/free-brands-svg-icons": "^7.1.0",
     "@fortawesome/free-regular-svg-icons": "^7.1.0",
     "@fortawesome/free-solid-svg-icons": "^7.1.0",
+    "ngx-mask": "^20.0.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/FateConnect/Front/src/app/app.config.ts
+++ b/FateConnect/Front/src/app/app.config.ts
@@ -8,6 +8,7 @@ import { provideRouter, withInMemoryScrolling } from '@angular/router';
 
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { DateAdapter, MAT_DATE_LOCALE, provideNativeDateAdapter } from '@angular/material/core';
+import { provideEnvironmentNgxMask } from 'ngx-mask';
 import { PtBrDateAdapter } from './core/date/pt-br-date.adapter';
 import { routes } from './app.routes';
 
@@ -26,7 +27,8 @@ export const appConfig: ApplicationConfig = {
         scrollPositionRestoration: 'enabled',
       })
     ),
-    provideHttpClient(withFetch())
+    provideHttpClient(withFetch()),
+    provideEnvironmentNgxMask()
   ]
 };
 

--- a/FateConnect/Front/src/app/app.config.ts
+++ b/FateConnect/Front/src/app/app.config.ts
@@ -7,7 +7,8 @@ import {
 import { provideRouter, withInMemoryScrolling } from '@angular/router';
 
 import { provideHttpClient, withFetch } from '@angular/common/http';
-import { MAT_DATE_LOCALE } from '@angular/material/core';
+import { DateAdapter, MAT_DATE_LOCALE, provideNativeDateAdapter } from '@angular/material/core';
+import { PtBrDateAdapter } from './core/date/pt-br-date.adapter';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -16,6 +17,8 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     { provide: LOCALE_ID, useValue: 'pt-BR' },
     { provide: MAT_DATE_LOCALE, useValue: 'pt-BR' },
+    ...provideNativeDateAdapter(),
+    { provide: DateAdapter, useClass: PtBrDateAdapter },
     provideRouter(
       routes,
       withInMemoryScrolling({

--- a/FateConnect/Front/src/app/core/date/pt-br-date.adapter.spec.ts
+++ b/FateConnect/Front/src/app/core/date/pt-br-date.adapter.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed } from '@angular/core/testing';
+import { MAT_DATE_LOCALE } from '@angular/material/core';
+import { PtBrDateAdapter } from './pt-br-date.adapter';
+
+describe('PtBrDateAdapter', () => {
+  let adapter: PtBrDateAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: MAT_DATE_LOCALE, useValue: 'pt-BR' }, PtBrDateAdapter],
+    });
+    adapter = TestBed.inject(PtBrDateAdapter);
+  });
+
+  it('interpreta dd/mm/aaaa com barra como calendário brasileiro', () => {
+    const parsed = adapter.parse('22/05/1999', null);
+    expect(parsed).not.toBeNull();
+    if (parsed === null) return;
+    expect(adapter.isValid(parsed)).toBe(true);
+    expect(parsed.getFullYear()).toBe(1999);
+    expect(parsed.getMonth()).toBe(4);
+    expect(parsed.getDate()).toBe(22);
+  });
+
+  it('interpreta dd-mm-aaaa com hífen', () => {
+    const parsed = adapter.parse('03-12-2001', null);
+    expect(parsed).not.toBeNull();
+    if (parsed === null) return;
+    expect(adapter.isValid(parsed)).toBe(true);
+    expect(parsed.getFullYear()).toBe(2001);
+    expect(parsed.getMonth()).toBe(11);
+    expect(parsed.getDate()).toBe(3);
+  });
+
+  it('remove espaços antes e depois da string', () => {
+    const parsed = adapter.parse('  01/01/2000  ', null);
+    expect(parsed).not.toBeNull();
+    if (parsed === null) return;
+    expect(adapter.isValid(parsed)).toBe(true);
+    expect(parsed.getFullYear()).toBe(2000);
+    expect(parsed.getMonth()).toBe(0);
+    expect(parsed.getDate()).toBe(1);
+  });
+
+  it('retorna null para string vazia ou só espaços', () => {
+    expect(adapter.parse('', null)).toBeNull();
+    expect(adapter.parse('   ', null)).toBeNull();
+  });
+
+  it('retorna data inválida para dia inexistente no mês', () => {
+    const parsed = adapter.parse('31/04/2000', null);
+    expect(parsed).not.toBeNull();
+    if (parsed === null) return;
+    expect(adapter.isValid(parsed)).toBe(false);
+  });
+
+  it('retorna data inválida para 29/02 em ano não bissexto', () => {
+    const parsed = adapter.parse('29/02/2001', null);
+    expect(parsed).not.toBeNull();
+    if (parsed === null) return;
+    expect(adapter.isValid(parsed)).toBe(false);
+  });
+
+  it('aceita 29/02 em ano bissexto', () => {
+    const parsed = adapter.parse('29/02/2000', null);
+    expect(parsed).not.toBeNull();
+    if (parsed === null) return;
+    expect(adapter.isValid(parsed)).toBe(true);
+    expect(parsed.getMonth()).toBe(1);
+    expect(parsed.getDate()).toBe(29);
+  });
+
+  it('delega número ao adapter nativo (timestamp)', () => {
+    const parsed = adapter.parse(0, null);
+    expect(parsed).not.toBeNull();
+    if (parsed === null) return;
+    expect(adapter.isValid(parsed)).toBe(true);
+    expect(parsed.getTime()).toBe(0);
+  });
+
+  it('delega ISO 8601 ao adapter nativo quando não é padrão dd/mm/aaaa', () => {
+    const parsed = adapter.parse('1999-05-22', null);
+    expect(parsed).not.toBeNull();
+    if (parsed === null) return;
+    expect(adapter.isValid(parsed)).toBe(true);
+    expect(parsed.getUTCFullYear()).toBe(1999);
+    expect(parsed.getUTCMonth()).toBe(4);
+    expect(parsed.getUTCDate()).toBe(22);
+  });
+});

--- a/FateConnect/Front/src/app/core/date/pt-br-date.adapter.ts
+++ b/FateConnect/Front/src/app/core/date/pt-br-date.adapter.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@angular/core';
+import { NativeDateAdapter } from '@angular/material/core';
+
+/** Padrão visual do placeholder (dia/mês/ano). */
+const SLASH_DMY = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
+const HYPHEN_DMY = /^(\d{1,2})-(\d{1,2})-(\d{4})$/;
+
+type DmyParts = { day: number; month: number; year: number };
+
+/**
+ * Estende o adapter nativo do Material: `Date.parse` não trata `22/05/1999` como dd/mm/aaaa,
+ * o que deixava o controle sem valor e o `required` permanecia ativo.
+ */
+@Injectable()
+export class PtBrDateAdapter extends NativeDateAdapter {
+  override parse(value: unknown, parseFormat: unknown): Date | null {
+    if (typeof value !== 'string') return super.parse(value, parseFormat);
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return null;
+
+    const fromDmy = this.tryParseDmyFormats(trimmed);
+    if (fromDmy) return fromDmy;
+    return super.parse(value, parseFormat);
+  }
+
+  /** `undefined` = string não está no formato dd/mm/aaaa (ou dd-mm-aaaa). */
+  private tryParseDmyFormats(trimmed: string): Date | undefined {
+    for (const regex of [SLASH_DMY, HYPHEN_DMY]) {
+      const matched = regex.exec(trimmed);
+      if (!matched) continue;
+      return this.dateFromDmyMatch(matched);
+    }
+    return undefined;
+  }
+
+  private dateFromDmyMatch(matched: RegExpExecArray): Date {
+    const parts = this.partsFromDmyMatch(matched);
+    if (!parts) return this.invalid();
+
+    try {
+      const date = this.createDate(parts.year, parts.month, parts.day);
+      const ok =
+        this.isValid(date) &&
+        this.getYear(date) === parts.year &&
+        this.getMonth(date) === parts.month &&
+        this.getDate(date) === parts.day;
+      return ok ? date : this.invalid();
+    } catch {
+      return this.invalid();
+    }
+  }
+
+  private partsFromDmyMatch(matched: RegExpExecArray): DmyParts | null {
+    const day = Number(matched[1]);
+    const month = Number(matched[2]) - 1;
+    const year = Number(matched[3]);
+    if (!Number.isFinite(day) || !Number.isFinite(month) || !Number.isFinite(year)) return null;
+
+    if (month < 0 || month > 11 || day < 1 || day > 31) return null;
+
+    return { day, month, year };
+  }
+}

--- a/FateConnect/Front/src/app/core/services/cep-lookup.service.ts
+++ b/FateConnect/Front/src/app/core/services/cep-lookup.service.ts
@@ -1,0 +1,35 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, catchError } from 'rxjs';
+
+/**
+ * Endereço retornado por provedores de CEP (ViaCEP / OpenCEP).
+ * ViaCEP, quando o CEP não existe, responde 200 com `{ erro: "true" }`.
+ */
+export interface BrazilianCepAddressDto {
+  readonly cep?: string;
+  readonly logradouro?: string;
+  readonly complemento?: string;
+  readonly bairro?: string;
+  readonly localidade?: string;
+  readonly uf?: string;
+  readonly erro?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CepLookupService {
+  private readonly http = inject(HttpClient);
+
+  /**
+   * Consulta o CEP: primeiro [ViaCEP](https://viacep.com.br/); em falha HTTP (rede, erro 4xx/5xx),
+   * tenta [OpenCEP](https://opencep.com/) (`/v1/{cep}.json`).
+   * `zipDigits` deve conter exatamente 8 dígitos (somente números).
+   */
+  lookup(zipDigits: string): Observable<BrazilianCepAddressDto> {
+    const viaCepUrl = `https://viacep.com.br/ws/${zipDigits}/json/`;
+    const openCepUrl = `https://opencep.com/v1/${zipDigits}.json`;
+    return this.http.get<BrazilianCepAddressDto>(viaCepUrl).pipe(
+      catchError(() => this.http.get<BrazilianCepAddressDto>(openCepUrl))
+    );
+  }
+}

--- a/FateConnect/Front/src/app/pages/rides/components/ride-filter/ride-filter.component.ts
+++ b/FateConnect/Front/src/app/pages/rides/components/ride-filter/ride-filter.component.ts
@@ -6,7 +6,6 @@ import {
 } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
-import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -46,7 +45,6 @@ export type RideFilterFormGroup = FormGroup<{
     MatFormFieldModule,
     MatInputModule,
     MatDatepickerModule,
-    MatNativeDateModule,
     MatSelectModule,
     MatButtonModule,
     MatIconModule,

--- a/FateConnect/Front/src/app/pages/rides/screens/search-ride/search-ride.component.spec.ts
+++ b/FateConnect/Front/src/app/pages/rides/screens/search-ride/search-ride.component.spec.ts
@@ -1,9 +1,16 @@
+import { registerLocaleData } from '@angular/common';
+import localePt from '@angular/common/locales/pt';
+import { LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DateAdapter, MAT_DATE_LOCALE, provideNativeDateAdapter } from '@angular/material/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { of } from 'rxjs';
+import { PtBrDateAdapter } from '../../../../core/date/pt-br-date.adapter';
 import { SearchRideComponent } from './search-ride.component';
 import { RideService } from '../../services/ride.service';
 import { Ride } from '../../models/ride.model';
+
+registerLocaleData(localePt, 'pt-BR');
 
 describe('SearchRideComponent', () => {
   let fixture: ComponentFixture<SearchRideComponent>;
@@ -27,7 +34,14 @@ describe('SearchRideComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [SearchRideComponent],
-      providers: [MatSnackBar, { provide: RideService, useValue: rideService }],
+      providers: [
+        { provide: LOCALE_ID, useValue: 'pt-BR' },
+        { provide: MAT_DATE_LOCALE, useValue: 'pt-BR' },
+        ...provideNativeDateAdapter(),
+        { provide: DateAdapter, useClass: PtBrDateAdapter },
+        MatSnackBar,
+        { provide: RideService, useValue: rideService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SearchRideComponent);

--- a/FateConnect/Front/src/app/pages/signup/birth-date-slash-mask.directive.spec.ts
+++ b/FateConnect/Front/src/app/pages/signup/birth-date-slash-mask.directive.spec.ts
@@ -1,0 +1,115 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { BirthDateSlashMaskDirective } from './birth-date-slash-mask.directive';
+
+@Component({
+  standalone: true,
+  imports: [BirthDateSlashMaskDirective],
+  template: `<input #birth type="text" appBirthDateSlashMask />`,
+})
+class BirthDateMaskHostComponent {}
+
+let fixture: ComponentFixture<BirthDateMaskHostComponent>;
+let input: HTMLInputElement;
+
+function dispatchInput(): void {
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('BirthDateSlashMaskDirective', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BirthDateMaskHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BirthDateMaskHostComponent);
+    fixture.detectChanges();
+    const debugInput = fixture.debugElement.query(By.css('input'));
+    if (!debugInput) {
+      fail('esperado input com appBirthDateSlashMask');
+      return;
+    }
+    input = debugInput.nativeElement as HTMLInputElement;
+  });
+
+  it('não altera valor já igual ao formato esperado e não dispara input sintético', fakeAsync(() => {
+    input.value = '22/11/1999';
+    const dispatchSpy = spyOn(input, 'dispatchEvent').and.callThrough();
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('22/11/1999');
+    expect(dispatchSpy.calls.count()).toBe(1);
+  }));
+
+  it('formata oito dígitos seguidos como dd/mm/aaaa', fakeAsync(() => {
+    input.value = '22111999';
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('22/11/1999');
+  }));
+
+  it('corta a mais de oito dígitos e aplica máscara', fakeAsync(() => {
+    input.value = '1234567890123';
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('12/34/5678');
+  }));
+
+  it('mantém só dia quando há até dois dígitos', fakeAsync(() => {
+    input.value = '7';
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('7');
+  }));
+
+  it('insere barra após o dia com três ou quatro dígitos', fakeAsync(() => {
+    input.value = '221';
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('22/1');
+
+    input.value = '2211';
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('22/11');
+  }));
+
+  it('completa data com barras após cinco a oito dígitos', fakeAsync(() => {
+    input.value = '22111';
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('22/11/1');
+
+    input.value = '22111999';
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('22/11/1999');
+  }));
+
+  it('ignora caracteres não numéricos ao montar a máscara', fakeAsync(() => {
+    input.value = '22a11b1999';
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('22/11/1999');
+  }));
+
+  it('dispara input sintético após formatar para sincronizar o modelo', fakeAsync(() => {
+    input.value = '01012000';
+    const calls: string[] = [];
+    input.addEventListener('input', () => calls.push(input.value));
+    dispatchInput();
+    flushMicrotasks();
+    expect(input.value).toBe('01/01/2000');
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls).toContain('01/01/2000');
+  }));
+
+  it('paste agenda a mesma formatação em microtask', fakeAsync(() => {
+    input.value = '15121990';
+    input.dispatchEvent(new Event('paste', { bubbles: true }));
+    flushMicrotasks();
+    expect(input.value).toBe('15/12/1990');
+  }));
+});

--- a/FateConnect/Front/src/app/pages/signup/birth-date-slash-mask.directive.ts
+++ b/FateConnect/Front/src/app/pages/signup/birth-date-slash-mask.directive.ts
@@ -1,0 +1,89 @@
+import { DestroyRef, Directive, ElementRef, OnInit, inject } from '@angular/core';
+
+const MAX_DAY_MONTH_YEAR_DIGITS = 8;
+
+/** Monta `dd/mm/aaaa` a partir só de dígitos (máx. 8). */
+function toDdMmYyyy(digitsOnly: string): string {
+  const capped = digitsOnly.slice(0, MAX_DAY_MONTH_YEAR_DIGITS);
+  if (capped.length <= 2) return capped;
+  if (capped.length <= 4) return `${capped.slice(0, 2)}/${capped.slice(2)}`;
+  return `${capped.slice(0, 2)}/${capped.slice(2, 4)}/${capped.slice(4)}`;
+}
+
+/**
+ * Formata dd/mm/aaaa e limita a 8 dígitos. O ajuste roda em microtask após o `input`,
+ * para ficar depois do MatDatepicker e evitar que o valor volte sem barras.
+ */
+@Directive({
+  selector: '[appBirthDateSlashMask]',
+  standalone: true,
+})
+export class BirthDateSlashMaskDirective implements OnInit {
+  private readonly elementRef = inject(ElementRef<HTMLInputElement>);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Evita reagir ao `input` disparado ao sincronizar valor máscara → modelo. */
+  private isProgrammaticInputSync = false;
+
+  ngOnInit(): void {
+    const nativeInput = this.elementRef.nativeElement;
+
+    const enqueueFormatAfterCurrentTask = (): void => {
+      if (this.isProgrammaticInputSync) return;
+      queueMicrotask(() => this.applySlashMaskAndNotify(nativeInput));
+    };
+
+    nativeInput.addEventListener('input', enqueueFormatAfterCurrentTask);
+    nativeInput.addEventListener('paste', enqueueFormatAfterCurrentTask);
+
+    this.destroyRef.onDestroy(() => {
+      nativeInput.removeEventListener('input', enqueueFormatAfterCurrentTask);
+      nativeInput.removeEventListener('paste', enqueueFormatAfterCurrentTask);
+    });
+  }
+
+  private applySlashMaskAndNotify(nativeInput: HTMLInputElement): void {
+    const valueBefore = nativeInput.value;
+    const caretIndex = nativeInput.selectionStart ?? valueBefore.length;
+    const digitCountLeftOfCaret = valueBefore.slice(0, caretIndex).replaceAll(/\D/g, '').length;
+
+    const digitsOnly = valueBefore.replaceAll(/\D/g, '').slice(0, MAX_DAY_MONTH_YEAR_DIGITS);
+    const maskedValue = toDdMmYyyy(digitsOnly);
+    if (maskedValue === valueBefore) return;
+
+    this.isProgrammaticInputSync = true;
+    try {
+      nativeInput.value = maskedValue;
+      this.placeCaretAfterDigitIndex(nativeInput, maskedValue, digitCountLeftOfCaret);
+      nativeInput.dispatchEvent(new Event('input', { bubbles: true }));
+    } finally {
+      this.isProgrammaticInputSync = false;
+    }
+  }
+
+  /**
+   * Mantém o cursor alinhado à quantidade de dígitos que estavam à esquerda do caret
+   * antes da máscara (útil ao inserir ou apagar no meio do texto).
+   */
+  private placeCaretAfterDigitIndex(
+    nativeInput: HTMLInputElement,
+    maskedValue: string,
+    targetDigitCountFromStart: number,
+  ): void {
+    let digitsSeen = 0;
+    let caretAfterIndex = maskedValue.length;
+
+    for (let index = 0; index < maskedValue.length; index++) {
+      const character = maskedValue[index];
+      if (character === undefined || !/\d/.test(character)) continue;
+
+      digitsSeen++;
+      if (digitsSeen >= targetDigitCountFromStart) {
+        caretAfterIndex = index + 1;
+        break;
+      }
+    }
+
+    nativeInput.setSelectionRange(caretAfterIndex, caretAfterIndex);
+  }
+}

--- a/FateConnect/Front/src/app/pages/signup/gender-options.constant.ts
+++ b/FateConnect/Front/src/app/pages/signup/gender-options.constant.ts
@@ -1,7 +1,7 @@
-export type GenderValue = 'female' | 'male' | 'prefer_not_to_say';
+export type GenderValue = 'female' | 'male' | 'other';
 
 export const GENDER_OPTIONS: { readonly value: GenderValue; readonly label: string }[] = [
   { value: 'female', label: 'Feminino' },
   { value: 'male', label: 'Masculino' },
-  { value: 'prefer_not_to_say', label: 'Prefiro não informar' },
+  { value: 'other', label: 'Prefiro não informar' },
 ];

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.html
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.html
@@ -90,7 +90,11 @@
         class="signup-form__field signup-form__field--third">
         <mat-label>CEP</mat-label>
         <input matInput id="signup-zip" type="text" name="zipCode" formControlName="zipCode" inputmode="numeric"
-          autocomplete="postal-code" placeholder="00000-000" maxlength="9" />
+          autocomplete="postal-code" placeholder="00000-000" maxlength="9"
+          [attr.aria-busy]="cepLookupLoading()" />
+        @if (cepLookupLoading()) {
+        <mat-spinner matSuffix class="signup-form__cep-spinner" diameter="20" aria-label="Consultando CEP" />
+        }
       </mat-form-field>
 
       <mat-form-field appearance="outline" subscriptSizing="dynamic"

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.html
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.html
@@ -44,7 +44,7 @@
         <mat-error>Informe a data de nascimento</mat-error>
         }
         @if (form.controls.birthDate.hasError('matDatepickerMax') && form.controls.birthDate.touched) {
-        <mat-error>Data não pode ser futura</mat-error>
+        <mat-error>É necessário ter pelo menos 18 anos</mat-error>
         }
         @if (form.controls.birthDate.hasError('matDatepickerMin') && form.controls.birthDate.touched) {
         <mat-error>Data inválida</mat-error>

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.html
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.html
@@ -35,9 +35,9 @@
       <mat-form-field appearance="outline" subscriptSizing="dynamic"
         class="signup-form__field signup-form__field--third">
         <mat-label>Data de nascimento</mat-label>
-        <input matInput id="signup-birth-date" type="text" name="birthDate" [matDatepicker]="birthPicker"
-          formControlName="birthDate" placeholder="dd/mm/aaaa" [max]="maxBirthDate" [min]="minBirthDate"
-          autocomplete="bday" />
+        <input matInput id="signup-birth-date" type="text" name="birthDate" appBirthDateSlashMask
+          [matDatepicker]="birthPicker" formControlName="birthDate" placeholder="dd/mm/aaaa" [max]="maxBirthDate"
+          [min]="minBirthDate" autocomplete="bday" maxlength="10" />
         <mat-datepicker-toggle matIconSuffix [for]="birthPicker"></mat-datepicker-toggle>
         <mat-datepicker #birthPicker></mat-datepicker>
         @if (form.controls.birthDate.hasError('required') && form.controls.birthDate.touched) {
@@ -89,8 +89,8 @@
       <mat-form-field appearance="outline" subscriptSizing="dynamic"
         class="signup-form__field signup-form__field--third">
         <mat-label>CEP</mat-label>
-        <input matInput id="signup-zip" type="text" name="zipCode" formControlName="zipCode" inputmode="numeric"
-          autocomplete="postal-code" placeholder="00000-000" maxlength="9"
+        <input matInput id="signup-zip" type="text" name="zipCode" formControlName="zipCode" mask="00000-000"
+          inputmode="numeric" autocomplete="postal-code" placeholder="00000-000"
           [attr.aria-busy]="cepLookupLoading()" />
         @if (cepLookupLoading()) {
         <mat-spinner matSuffix class="signup-form__cep-spinner" diameter="20" aria-label="Consultando CEP" />
@@ -143,8 +143,9 @@
       <mat-form-field appearance="outline" subscriptSizing="dynamic"
         class="signup-form__field signup-form__field--half">
         <mat-label>Telefone</mat-label>
-        <input matInput id="signup-phone" name="phone" type="tel" formControlName="phone" inputmode="tel"
-          autocomplete="home tel" placeholder="(00) 00000-0000" />
+        <input matInput id="signup-phone" name="phone" type="tel" formControlName="phone"
+          mask="(00) 00000-0000||(00) 0000-0000" inputmode="tel" autocomplete="home tel"
+          placeholder="(00) 00000-0000" />
         @if (form.controls.phone.hasError('required') && form.controls.phone.touched) {
         <mat-error>Informe o telefone</mat-error>
         } @else if (form.controls.phone.hasError('brazilianPhone') && form.controls.phone.touched) {

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
@@ -38,6 +38,11 @@ app-typography#signup-title {
   flex-direction: column;
 }
 
+.signup-form__cep-spinner {
+  display: inline-block;
+  margin-right: 0.25rem;
+}
+
 .signup-form-divider {
   width: 100%;
   height: 1px;

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.scss
@@ -60,6 +60,8 @@ app-typography#signup-title {
   grid-template-columns: 1fr;
   gap: 1rem;
   margin-top: 1rem;
+  /* Evita que campos na mesma linha estiquem quando um vizinho exibe mat-error (altura dinâmica). */
+  align-items: start;
 }
 
 .signup-form__field {

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   AbstractControl,
   FormBuilder,
@@ -12,11 +13,14 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { EMPTY, catchError, debounceTime, distinctUntilChanged, filter, finalize, map, switchMap } from 'rxjs';
+import { CepLookupService } from '../../core/services/cep-lookup.service';
 import { TypographyComponent } from '../../shared/ui/typography/typography';
 import { BRAZILIAN_STATES } from './brazilian-states.constant';
 import { GENDER_OPTIONS, type GenderValue } from './gender-options.constant';
@@ -44,6 +48,7 @@ function brazilianPhoneValidator(control: AbstractControl): ValidationErrors | n
     MatNativeDateModule,
     MatCheckboxModule,
     MatSnackBarModule,
+    MatProgressSpinnerModule,
     FontAwesomeModule,
     TypographyComponent,
   ],
@@ -53,8 +58,11 @@ function brazilianPhoneValidator(control: AbstractControl): ValidationErrors | n
 export class SignupPageComponent {
   private readonly fb = inject(FormBuilder);
   private readonly snackBar = inject(MatSnackBar);
+  private readonly cepLookup = inject(CepLookupService);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly hidePassword = signal(true);
+  readonly cepLookupLoading = signal(false);
   readonly eyeIcon = faEye;
   readonly eyeSlashIcon = faEyeSlash;
 
@@ -82,6 +90,54 @@ export class SignupPageComponent {
     acceptTerms: [false, Validators.requiredTrue],
     acceptMarketing: [false],
   });
+
+  constructor() {
+    this.form.controls.zipCode.valueChanges
+      .pipe(
+        map((value) => String(value ?? '').replaceAll(/\D/g, '')),
+        debounceTime(400),
+        distinctUntilChanged(),
+        filter((digits) => digits.length === 8),
+        switchMap((digits) => {
+          this.cepLookupLoading.set(true);
+          return this.cepLookup.lookup(digits).pipe(
+            catchError(() => {
+              this.snackBar.open('Não foi possível consultar o CEP. Tente novamente.', 'OK', {
+                duration: 5000,
+                verticalPosition: 'top',
+                panelClass: ['snackbar-error'],
+              });
+              return EMPTY;
+            }),
+            finalize(() => this.cepLookupLoading.set(false))
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((data) => {
+        if (data.erro === 'true') {
+          this.form.patchValue(
+            { street: '', city: '', state: '' },
+            { emitEvent: false }
+          );
+          this.snackBar.open('CEP não encontrado.', 'OK', {
+            duration: 5000,
+            verticalPosition: 'top',
+            panelClass: ['snackbar-warning'],
+          });
+          return;
+        }
+        this.form.patchValue(
+          {
+            zipCode: data.cep ?? '',
+            street: data.logradouro ?? '',
+            city: data.localidade ?? '',
+            state: data.uf ?? '',
+          },
+          { emitEvent: false }
+        );
+      });
+  }
 
   togglePasswordVisibility(): void {
     this.hidePassword.update((v) => !v);

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
@@ -9,7 +9,6 @@ import {
 } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -45,7 +44,6 @@ function brazilianPhoneValidator(control: AbstractControl): ValidationErrors | n
     MatButtonModule,
     MatSelectModule,
     MatDatepickerModule,
-    MatNativeDateModule,
     MatCheckboxModule,
     MatSnackBarModule,
     MatProgressSpinnerModule,

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
@@ -18,9 +18,11 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { NgxMaskDirective } from 'ngx-mask';
 import { EMPTY, catchError, debounceTime, distinctUntilChanged, filter, finalize, map, switchMap } from 'rxjs';
 import { CepLookupService } from '../../core/services/cep-lookup.service';
 import { TypographyComponent } from '../../shared/ui/typography/typography';
+import { BirthDateSlashMaskDirective } from './birth-date-slash-mask.directive';
 import { BRAZILIAN_STATES } from './brazilian-states.constant';
 import { GENDER_OPTIONS, type GenderValue } from './gender-options.constant';
 
@@ -49,6 +51,8 @@ function brazilianPhoneValidator(control: AbstractControl): ValidationErrors | n
     MatProgressSpinnerModule,
     FontAwesomeModule,
     TypographyComponent,
+    NgxMaskDirective,
+    BirthDateSlashMaskDirective,
   ],
   templateUrl: './signup-page.component.html',
   styleUrl: './signup-page.component.scss',

--- a/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
+++ b/FateConnect/Front/src/app/pages/signup/signup-page.component.ts
@@ -67,7 +67,12 @@ export class SignupPageComponent {
   readonly genderOptions = GENDER_OPTIONS;
   readonly brazilianStates = BRAZILIAN_STATES;
 
-  readonly maxBirthDate = new Date();
+  /** Última data de nascimento permitida: quem completa 18 anos hoje ainda pode se cadastrar. */
+  readonly maxBirthDate = (() => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() - 18);
+    return d;
+  })();
   readonly minBirthDate = new Date(1900, 0, 1);
 
   readonly form = this.fb.nonNullable.group({

--- a/FateConnect/Front/src/styles.scss
+++ b/FateConnect/Front/src/styles.scss
@@ -130,7 +130,8 @@ body,
   padding-bottom: 32px;
 }
 
-.cdk-overlay-container .ride-filter-select-panel.mat-mdc-select-panel {
+/* mat-select (overlay): list-overrides globais usam texto claro (sidenav); opções em painel branco precisam de cor legível. */
+.cdk-overlay-container .mat-mdc-select-panel {
   .mat-mdc-option {
     color: var(--app-color-primary);
     font-size: 1rem;


### PR DESCRIPTION
## Objetivo

Documentar e entregar em `develop` o trabalho da branch `feat/33`. O texto abaixo descreve **apenas o que mudou entre `feat/26` e `feat/33`** (diff de referência solicitado); o merge no GitHub continua sendo `develop` ← `feat/33`.

## Alterações

- **Cadastro:** serviço `CepLookupService` (ViaCEP com fallback OpenCEP), preenchimento de endereço a partir do CEP, spinner durante a consulta.
- **Cadastro:** dependência `ngx-mask`, diretiva `BirthDateSlashMaskDirective` com testes; data de nascimento limitada a **maiores de 18 anos**; ajustes de template e estilo (grid alinhado ao topo com `mat-error`).
- **Cadastro:** constante de gênero com valor `other` (renomeação do valor enviado ao formulário).
- **Datas:** `PtBrDateAdapter` registrado em `app.config.ts` e testes; signup deixa de importar `MatNativeDateModule` isoladamente.
- **Tema:** cor legível das opções do `mat-select` no overlay (`styles.scss`).
- **Qualidade:** script `test:ci` no Front; hook `.githooks/pre-push` executando testes do Front no push.
- **Testes / misc:** `search-ride.component.spec.ts` corrigido; pequena limpeza em `ride-filter.component.ts`.

## Issue

- #33

Closes #33

## Evidências

<img width="1149" height="714" alt="image" src="https://github.com/user-attachments/assets/824f546e-0cb5-4721-bcde-a1c58b5a2e9b" />
<img width="1149" height="714" alt="image" src="https://github.com/user-attachments/assets/40828def-ec2c-4e76-84d4-399704fb9152" />
