### PR TITLE
fix(60): adiciona providers de http no spec do card de login

### DIFF
--- a/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.spec.ts
+++ b/FateConnect/Front/src/app/pages/home/components/landing-login-card/landing-login-card.component.spec.ts
@@ -1,3 +1,5 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { LandingLoginCardComponent } from './landing-login-card.component';
@@ -8,7 +10,7 @@ describe('LandingLoginCardComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LandingLoginCardComponent],
-      providers: [provideRouter([])],
+      providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LandingLoginCardComponent);


### PR DESCRIPTION
## Objetivo

Destravar a suíte de testes do front Angular, que estava com 3 de 43 testes falhando na `develop` e, por consequência, bloqueando **qualquer `git push`** no repositório — o `.githooks/pre-push` roda `npm run test:ci`.

## Alterações

- `landing-login-card.component.spec.ts`: adiciona `provideHttpClient()` e `provideHttpClientTesting()` aos providers do `TestBed`.

O componente passou a injetar `AuthService` (que injeta `HttpClient`) no commit `37af4bd`, da integração entre back e front, e o spec não acompanhou. Sem o provider, a criação do componente estourava com `NG0201: No provider found for _HttpClient` antes de qualquer asserção, derrubando os três testes do arquivo.

Nenhuma alteração de comportamento no componente — só o setup do teste.

## Issue

- #60

Closes #60

## Evidências

Antes:

```
Executed 43 of 43 (3 FAILED)
TOTAL: 3 FAILED, 40 SUCCESS
```

Depois:

```
Executed 43 of 43 SUCCESS
TOTAL: 43 SUCCESS
```
