### PR TITLE
chore(62): adiciona verificacao de lint tipos e testes em pull request

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,71 @@
+name: Check Pull Request
+
+# Sem filtro de branch de destino: PR empilhado (base em outra feature branch)
+# também precisa ser validado.
+on: pull_request
+
+# Push novo na mesma PR cancela a execução anterior.
+concurrency:
+  group: check-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  web:
+    name: Front React (Web)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: FateConnect/Web
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: FateConnect/Web/.nvmrc
+          cache: yarn
+          cache-dependency-path: FateConnect/Web/yarn.lock
+
+      - name: Instalar dependências
+        run: yarn install --frozen-lockfile
+
+      - name: Tipos
+        run: yarn typecheck
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Testes
+        run: yarn test:ci
+
+      - name: Build
+        run: yarn build
+
+  front-angular:
+    name: Front Angular (legado)
+    # Remover este job junto com FateConnect/Front na issue #58.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: FateConnect/Front
+    env:
+      CHROME_BIN: /usr/bin/google-chrome
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: FateConnect/Front/package-lock.json
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Testes
+        run: npm run test:ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Objetivo

Adicionar verificação automática em Pull Request. Hoje o único gate é o `.githooks/pre-push`, que é local e opcional — só funciona em quem rodou `git config core.hooksPath .githooks` — e cobre apenas a suíte do Angular.

O custo disso apareceu na #60: três testes quebrados entraram na `develop` sem ninguém perceber e só apareceram quando alguém tentou dar push, bloqueando trabalho sem relação nenhuma com a causa. Com este workflow, a mesma quebra teria falhado na PR que a introduziu.

## Alterações

- `.github/workflows/check.yml`, disparado em `pull_request`, com dois jobs em paralelo:

| Job | Passos |
| --- | ------ |
| **Front React (Web)** | Node a partir do `.nvmrc` da pasta, cache de yarn, `yarn install --frozen-lockfile`, `typecheck`, `lint`, `test:ci`, `build` |
| **Front Angular (legado)** | Node 20, cache de npm, `npm ci`, `test:ci` em Chrome headless, `build` |

- `concurrency` com `cancel-in-progress`: push novo na mesma PR cancela a execução anterior.
- `permissions: contents: read`.
- Sem nenhuma action de terceiros — apenas `actions/checkout` e `actions/setup-node`.

Dois pontos que divergem do texto da issue, ambos deliberados:

1. **Sem filtro `branches:` no gatilho.** Com o filtro, uma PR empilhada — cuja base é outra feature branch, como esta — não seria validada. Rodar em toda PR é mais simples e não deixa buraco.
2. O job do Angular tem comentário lembrando de removê-lo junto com `FateConnect/Front` na #58.

## Issue

- #62

Closes #62

## Evidências

Os mesmos comandos rodados localmente antes de subir:

| Comando | Resultado |
| ------- | --------- |
| `yarn typecheck` / `yarn lint` / `yarn test:ci` / `yarn build` (Web) | exit 0 |
| `npm run test:ci` (Front) | `TOTAL: 43 SUCCESS` |

A primeira execução do próprio workflow nesta PR serve de evidência final.
