### PR TITLE
chore(66): adiciona codeowner do front react

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Frontend
 
+FateConnect/Web/ @victorfob
 FateConnect/Front/ @victorfob
 
 # Backend


### PR DESCRIPTION
## Objetivo

Declarar dono de código para o front React em `FateConnect/Web`, criado na #48 e até agora sem cobertura no `CODEOWNERS`.

## Alterações

- `.github/CODEOWNERS`: adiciona `FateConnect/Web/ @victorfob` na seção de frontend, acima da linha já existente de `FateConnect/Front/`.

O ruleset `Protected Branch` está com `require_code_owner_review: false`, então a regra **não** passa a bloquear merge — ela faz o GitHub sugerir o revisor automaticamente e documenta a responsabilidade por área.

A linha de `FateConnect/Front/` sai junto com a pasta na #58.

## Issue

- #66

Closes #66

## Evidências

Arquivo resultante:

```
# Frontend

FateConnect/Web/ @victorfob
FateConnect/Front/ @victorfob

# Backend

FateConnect/Carona/ @Lautones

# Database

LBD/ @pdorth
```
