### PR TITLE
feat(51): add header footer and navigation drawer

### DIFF
--- a/FateConnect/Web/src/components/Footer/Footer.test.tsx
+++ b/FateConnect/Web/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { APP_CONTACT } from '@app/constants/appContact';
+import { LandingSection } from '@app/routes/paths';
+import { render, screen } from '@app/test/testing-library';
+import { Footer } from '.';
+
+describe('Footer', () => {
+  it('should render the institutional contact details', () => {
+    render(<Footer />);
+
+    expect(screen.getByRole('heading', { name: 'Entre em contato' })).toBeInTheDocument();
+    expect(screen.getByText(APP_CONTACT.email)).toBeInTheDocument();
+    expect(screen.getByText(APP_CONTACT.phone)).toBeInTheDocument();
+    expect(screen.getByText(APP_CONTACT.address)).toBeInTheDocument();
+  });
+
+  it('should expose the contact anchor targeted by the landing navigation', () => {
+    render(<Footer />);
+
+    expect(document.getElementById(LandingSection.CONTACT)).toBeInTheDocument();
+  });
+});

--- a/FateConnect/Web/src/components/Footer/index.tsx
+++ b/FateConnect/Web/src/components/Footer/index.tsx
@@ -1,0 +1,44 @@
+import EmailIcon from '@mui/icons-material/Email';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import PhoneIcon from '@mui/icons-material/Phone';
+import Typography from '@mui/material/Typography';
+
+import { APP_CONTACT } from '@app/constants/appContact';
+import { LandingSection } from '@app/routes/paths';
+import {
+  ContactItem,
+  ContactsContainer,
+  CopyrightContainer,
+  FooterDivider,
+  FooterRoot,
+} from './styles';
+
+export function Footer() {
+  return (
+    <FooterRoot>
+      <ContactsContainer id={LandingSection.CONTACT}>
+        <Typography variant="h2">Entre em contato</Typography>
+
+        <ContactItem>
+          <EmailIcon fontSize="small" />
+          <Typography variant="caption">{APP_CONTACT.email}</Typography>
+        </ContactItem>
+        <ContactItem>
+          <PhoneIcon fontSize="small" />
+          <Typography variant="caption">{APP_CONTACT.phone}</Typography>
+        </ContactItem>
+        <ContactItem>
+          <LocationOnIcon fontSize="small" />
+          <Typography variant="caption">{APP_CONTACT.address}</Typography>
+        </ContactItem>
+      </ContactsContainer>
+
+      <FooterDivider />
+
+      <CopyrightContainer>
+        <Typography variant="caption">© 2026 FateConnect. Todos os direitos reservados.</Typography>
+        <Typography variant="caption">Desenvolvido para facilitar a vida do Fatecano.</Typography>
+      </CopyrightContainer>
+    </FooterRoot>
+  );
+}

--- a/FateConnect/Web/src/components/Footer/styles.ts
+++ b/FateConnect/Web/src/components/Footer/styles.ts
@@ -1,0 +1,71 @@
+import { styled } from '@mui/material/styles';
+
+import { colorTokens, mobileMedia, spacing, spacingScale } from '@ds';
+
+const { md } = spacingScale;
+
+/**
+ * Porte fiel do rodapé do produto: linha no desktop (contatos à esquerda,
+ * assinatura à direita, divisor vertical entre eles) e coluna centralizada
+ * abaixo de 768px. Paddings em `vw`, como no original.
+ */
+export const FooterRoot = styled('footer')({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  backgroundColor: colorTokens.primary,
+  color: colorTokens.textOnAccent,
+  padding: '3vw 7vw',
+  gap: spacing(md),
+  width: '100%',
+
+  [mobileMedia]: {
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: '7vw',
+  },
+});
+
+export const ContactsContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  gap: spacing(md),
+  width: '100%',
+
+  [mobileMedia]: {
+    alignItems: 'center',
+  },
+});
+
+export const ContactItem = styled('div')({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing(spacingScale.xs),
+});
+
+/** Vertical no desktop, horizontal no mobile. */
+export const FooterDivider = styled('div')({
+  width: '1px',
+  height: 'auto',
+  backgroundColor: colorTokens.divider,
+
+  [mobileMedia]: {
+    width: '100%',
+    height: '1px',
+  },
+});
+
+export const CopyrightContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'flex-end',
+  gap: spacing(md),
+  width: '100%',
+
+  [mobileMedia]: {
+    alignItems: 'center',
+  },
+});

--- a/FateConnect/Web/src/components/Header/Header.test.tsx
+++ b/FateConnect/Web/src/components/Header/Header.test.tsx
@@ -1,0 +1,84 @@
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LandingSection, RoutePath } from '@app/routes/paths';
+import { render, screen, userEvent } from '@app/test/testing-library';
+import { Header } from '.';
+
+type RenderHeaderOptions = { isLoggedIn?: boolean; onMenuClick?: VoidFunction };
+
+function renderHeader({ isLoggedIn, onMenuClick = vi.fn() }: RenderHeaderOptions = {}) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: RoutePath.CONTACT,
+        element: <Header isLoggedIn={isLoggedIn} onMenuClick={onMenuClick} />,
+      },
+      { path: RoutePath.LANDING, element: <div>landing</div> },
+    ],
+    { initialEntries: [RoutePath.CONTACT] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+// O botão de menu só aparece abaixo de 768px, por CSS. O jsdom não avalia media
+// query, então ele fica com `display: none` e precisa ser buscado com `hidden`.
+describe('Header', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should point the logo to the landing page when logged out', () => {
+    renderHeader({ isLoggedIn: false });
+
+    expect(screen.getByRole('link', { name: 'FateConnect' })).toHaveAttribute(
+      'href',
+      RoutePath.LANDING,
+    );
+  });
+
+  it('should point the logo to the menu when logged in', () => {
+    renderHeader({ isLoggedIn: true });
+
+    expect(screen.getByRole('link', { name: 'FateConnect' })).toHaveAttribute(
+      'href',
+      RoutePath.MENU,
+    );
+  });
+
+  it('should show the landing navigation when logged out', () => {
+    renderHeader({ isLoggedIn: false });
+
+    ['Serviços', 'Como Funciona', 'Entre em Contato', 'Entrar'].forEach((label) => {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    });
+  });
+
+  it('should show the app navigation when logged in', () => {
+    renderHeader({ isLoggedIn: true });
+
+    ['Achados & Perdidos', 'Caronas', 'Entre em Contato'].forEach((label) => {
+      expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+    });
+  });
+
+  it('should navigate to the landing section when a landing button is clicked', async () => {
+    const router = renderHeader({ isLoggedIn: false });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Serviços' }));
+
+    expect(router.state.location.pathname).toBe(RoutePath.LANDING);
+    expect(router.state.location.hash).toBe(`#${LandingSection.SERVICES}`);
+  });
+
+  it('should call onMenuClick when the hamburger button is clicked', async () => {
+    const onMenuClick = vi.fn();
+    renderHeader({ onMenuClick });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir menu', hidden: true }));
+
+    expect(onMenuClick).toHaveBeenCalledOnce();
+  });
+});

--- a/FateConnect/Web/src/components/Header/LandingNavButton.tsx
+++ b/FateConnect/Web/src/components/Header/LandingNavButton.tsx
@@ -1,0 +1,29 @@
+import Button from '@mui/material/Button';
+import { useCallback } from 'react';
+
+import type { LandingSection } from '@app/routes/paths';
+
+type LandingNavButtonProps = {
+  section: LandingSection;
+  label: string;
+  highlighted: boolean;
+  onSelect: (section: LandingSection) => void;
+};
+
+/** Botão de seção da landing. Existe para não criar callback anônimo no JSX do header. */
+export function LandingNavButton({ section, label, highlighted, onSelect }: LandingNavButtonProps) {
+  const handleClick = useCallback(() => onSelect(section), [onSelect, section]);
+
+  if (highlighted)
+    return (
+      <Button type="button" variant="contained" color="secondary" onClick={handleClick}>
+        {label}
+      </Button>
+    );
+
+  return (
+    <Button type="button" color="inherit" onClick={handleClick}>
+      {label}
+    </Button>
+  );
+}

--- a/FateConnect/Web/src/components/Header/constants.ts
+++ b/FateConnect/Web/src/components/Header/constants.ts
@@ -1,0 +1,19 @@
+import { LandingSection, RoutePath } from '@app/routes/paths';
+
+export type LandingLink = { section: LandingSection; label: string; highlighted: boolean };
+export type AppLink = { path: RoutePath; label: string };
+
+/** Navegação da landing: rola até a seção correspondente. */
+export const LANDING_LINKS: LandingLink[] = [
+  { section: LandingSection.SERVICES, label: 'Serviços', highlighted: false },
+  { section: LandingSection.HOW_IT_WORKS, label: 'Como Funciona', highlighted: false },
+  { section: LandingSection.CONTACT, label: 'Entre em Contato', highlighted: false },
+  { section: LandingSection.LOGIN, label: 'Entrar', highlighted: true },
+];
+
+/** Navegação da área logada. */
+export const APP_LINKS: AppLink[] = [
+  { path: RoutePath.LOST_AND_FOUND, label: 'Achados & Perdidos' },
+  { path: RoutePath.RIDES, label: 'Caronas' },
+  { path: RoutePath.CONTACT, label: 'Entre em Contato' },
+];

--- a/FateConnect/Web/src/components/Header/index.tsx
+++ b/FateConnect/Web/src/components/Header/index.tsx
@@ -1,0 +1,63 @@
+import MenuIcon from '@mui/icons-material/Menu';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import { Link as RouterLink } from 'react-router';
+
+import { useLandingAnchor } from '@app/hooks/useLandingAnchor';
+import { RoutePath } from '@app/routes/paths';
+import { APP_LINKS, LANDING_LINKS } from './constants';
+import { LandingNavButton } from './LandingNavButton';
+import { DesktopNav, HeaderBar, HeaderToolbar, LogoLink, MenuButtonSlot } from './styles';
+
+type HeaderProps = {
+  /**
+   * `true` exibe a navegação da área logada; `false`, a da landing.
+   * TODO — ligar ao estado de sessão quando a autenticação real existir (#52).
+   */
+  isLoggedIn?: boolean;
+  onMenuClick: VoidFunction;
+};
+
+export function Header({ isLoggedIn = true, onMenuClick }: HeaderProps) {
+  const goToSection = useLandingAnchor();
+  const logoTarget = isLoggedIn ? RoutePath.MENU : RoutePath.LANDING;
+
+  return (
+    <HeaderBar position="fixed">
+      <HeaderToolbar disableGutters>
+        <LogoLink>
+          <RouterLink to={logoTarget} aria-label="FateConnect">
+            <Typography variant="logo">FateConnect</Typography>
+          </RouterLink>
+        </LogoLink>
+
+        <DesktopNav>
+          {isLoggedIn &&
+            APP_LINKS.map(({ path, label }) => (
+              <Button key={path} color="inherit" component={RouterLink} to={path}>
+                {label}
+              </Button>
+            ))}
+
+          {!isLoggedIn &&
+            LANDING_LINKS.map(({ section, label, highlighted }) => (
+              <LandingNavButton
+                key={section}
+                section={section}
+                label={label}
+                highlighted={highlighted}
+                onSelect={goToSection}
+              />
+            ))}
+        </DesktopNav>
+
+        <MenuButtonSlot>
+          <IconButton color="inherit" aria-label="Abrir menu" onClick={onMenuClick}>
+            <MenuIcon />
+          </IconButton>
+        </MenuButtonSlot>
+      </HeaderToolbar>
+    </HeaderBar>
+  );
+}

--- a/FateConnect/Web/src/components/Header/styles.ts
+++ b/FateConnect/Web/src/components/Header/styles.ts
@@ -1,0 +1,74 @@
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import { styled } from '@mui/material/styles';
+
+import { colorTokens, mobileMedia, shadowTokens, spacing, spacingScale } from '@ds';
+
+const { xs } = spacingScale;
+
+/** Altura do topo; a casca reserva esse espaço porque o header é fixo. */
+export const HEADER_HEIGHT_PX = 64;
+
+/** Tamanho e peso dos botões de navegação, iguais aos do produto. */
+const NAV_FONT_SIZE = '1rem';
+const NAV_FONT_WEIGHT = 500;
+const CTA_FONT_WEIGHT = 400;
+
+export const HeaderBar = styled(AppBar)({
+  boxShadow: shadowTokens.component,
+});
+
+export const HeaderToolbar = styled(Toolbar)({
+  height: `${HEADER_HEIGHT_PX}px`,
+  minHeight: `${HEADER_HEIGHT_PX}px`,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '0 7vw',
+  color: colorTokens.textOnAccent,
+});
+
+export const DesktopNav = styled('nav')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: `${spacing(xs)} 1.5vw`,
+
+  '& .MuiButton-root': {
+    fontSize: NAV_FONT_SIZE,
+    fontWeight: NAV_FONT_WEIGHT,
+    color: colorTokens.textOnAccent,
+  },
+  // O destaque não recebe o peso reforçado, como no produto.
+  '& .MuiButton-contained': {
+    fontWeight: CTA_FONT_WEIGHT,
+  },
+
+  [mobileMedia]: {
+    display: 'none',
+  },
+});
+
+export const MenuButtonSlot = styled('span')({
+  display: 'none',
+
+  [mobileMedia]: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '48px',
+  },
+});
+
+/** Marca: sem sublinhado e herdando a cor da barra, como no produto. */
+export const LogoLink = styled('span')({
+  '& a': {
+    textDecoration: 'none',
+    color: colorTokens.textOnAccent,
+    cursor: 'pointer',
+    transition: 'opacity 0.3s ease',
+  },
+  '& a:hover': {
+    opacity: 0.8,
+  },
+});

--- a/FateConnect/Web/src/constants/appContact.ts
+++ b/FateConnect/Web/src/constants/appContact.ts
@@ -1,0 +1,6 @@
+/** Dados de contato institucionais, exibidos no rodapé e na seção `#contato` da landing. */
+export const APP_CONTACT = {
+  email: 'f003alunos@cps.sp.gov.br',
+  phone: '(15) 3238-5266',
+  address: 'Av. Eng. Carlos Reinaldo Mendes, 2015',
+};

--- a/FateConnect/Web/src/design-system/GlobalStyles.tsx
+++ b/FateConnect/Web/src/design-system/GlobalStyles.tsx
@@ -8,6 +8,9 @@ export function GlobalStyles() {
     <GlobalStylesBase
       styles={{
         '*, *::before, *::after': { boxSizing: 'border-box' },
+        html: { scrollBehavior: 'smooth' },
+        // Compensa o topo fixo ao rolar até uma seção pelo fragmento da URL.
+        '[id]': { scrollMarginTop: '5rem' },
         'html, body, #root': { height: '100%' },
         body: {
           margin: 0,

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -15,5 +15,7 @@ export {
   iconSizeTokens,
   fontFamily,
   typographyTokens,
+  MOBILE_MAX_WIDTH_PX,
+  mobileMedia,
 } from './tokens';
 export type { SpacingToken, RadiusToken, TypographyToken } from './tokens';

--- a/FateConnect/Web/src/design-system/theme/components.ts
+++ b/FateConnect/Web/src/design-system/theme/components.ts
@@ -8,10 +8,8 @@ export const components: Components<Theme> = {
   MuiButton: {
     defaultProps: { disableElevation: true },
     styleOverrides: {
-      root: {
-        textTransform: 'none',
-        borderRadius: radius(radiusScale.component),
-      },
+      // Sem override de raio: o produto usa o padrão do Material nos botões.
+      root: { textTransform: 'none' },
     },
   },
   MuiCard: {

--- a/FateConnect/Web/src/design-system/theme/components.ts
+++ b/FateConnect/Web/src/design-system/theme/components.ts
@@ -7,33 +7,19 @@ import { radius } from './helpers/radius';
 export const components: Components<Theme> = {
   MuiButton: {
     defaultProps: { disableElevation: true },
-    styleOverrides: {
-      // Sem override de raio: o produto usa o padrão do Material nos botões.
-      root: { textTransform: 'none' },
-    },
+    styleOverrides: { root: { textTransform: 'none' } },
   },
   MuiCard: {
     styleOverrides: {
-      root: {
-        borderRadius: radius(radiusScale.lg),
-        boxShadow: shadowTokens.component,
-      },
+      root: { borderRadius: radius(radiusScale.lg), boxShadow: shadowTokens.component },
     },
   },
   MuiOutlinedInput: {
-    styleOverrides: {
-      root: { borderRadius: radius(radiusScale.component) },
-    },
+    styleOverrides: { root: { borderRadius: radius(radiusScale.component) } },
   },
-  MuiDialog: {
-    styleOverrides: {
-      paper: { borderRadius: radius(radiusScale.lg) },
-    },
-  },
+  MuiDialog: { styleOverrides: { paper: { borderRadius: radius(radiusScale.lg) } } },
   MuiAppBar: {
     defaultProps: { elevation: 0 },
-    styleOverrides: {
-      root: { backgroundColor: colorTokens.primary },
-    },
+    styleOverrides: { root: { backgroundColor: colorTokens.primary } },
   },
 };

--- a/FateConnect/Web/src/design-system/theme/createAppTheme.test.ts
+++ b/FateConnect/Web/src/design-system/theme/createAppTheme.test.ts
@@ -2,15 +2,21 @@ import { describe, expect, it } from 'vitest';
 
 import { colorTokens, spacingScale, typographyTokens } from '../tokens';
 import { createAppTheme } from './createAppTheme';
+import { spacing } from './helpers/spacing';
 
 describe('createAppTheme', () => {
-  it('should use the token scale in rem instead of the default 8px multiplier', () => {
+  it('should keep the mui spacing untouched so its own components are not shrunk', () => {
     const theme = createAppTheme();
 
-    // Sem o override, theme.spacing(16) devolveria '128px' e o layout ficaria 8x errado.
-    expect(theme.spacing(spacingScale.md)).toBe('1rem');
-    expect(theme.spacing(spacingScale.xs)).toBe('0.5rem');
-    expect(theme.spacing(spacingScale.md)).not.toBe('128px');
+    // O MUI chama theme.spacing(1..3) internamente — gutters do Toolbar, padding
+    // de Dialog e de Card. Sobrescrever isso encolhia as gutters de 24px para 3px.
+    expect(theme.spacing(1)).toBe('8px');
+    expect(theme.spacing(3)).toBe('24px');
+  });
+
+  it('should convert our px tokens to rem through the design system helper', () => {
+    expect(spacing(spacingScale.md)).toBe('1rem');
+    expect(spacing(spacingScale.xs)).toBe('0.5rem');
   });
 
   it('should expose the product typography variants with the current scale values', () => {

--- a/FateConnect/Web/src/design-system/theme/createAppTheme.ts
+++ b/FateConnect/Web/src/design-system/theme/createAppTheme.ts
@@ -4,7 +4,6 @@ import { ptBR as pickersPtBR } from '@mui/x-date-pickers/locales';
 
 import { colorTokens, fontFamily, typographyTokens } from '../tokens';
 import { components } from './components';
-import { spacing } from './helpers/spacing';
 
 /** Acima deste ponto o `h1` usa o tamanho cheio; abaixo, o reduzido. */
 const NARROW_BREAKPOINT = 'sm';
@@ -39,7 +38,6 @@ export function createAppTheme(): Theme {
 
   return createTheme(
     {
-      spacing,
       components,
       palette: {
         primary: { main: colorTokens.primary, contrastText: colorTokens.textOnAccent },

--- a/FateConnect/Web/src/design-system/theme/helpers/spacing.ts
+++ b/FateConnect/Web/src/design-system/theme/helpers/spacing.ts
@@ -4,9 +4,11 @@ const ROOT_FONT_SIZE = 16;
 /**
  * Converte token de espaçamento (px) para `rem`.
  *
- * Substitui a função padrão do MUI, que é **multiplicador de 8px**: sem este
- * override, `theme.spacing(16)` devolveria `128px` em vez de `1rem`. Trocar isso
- * não quebra build nem teste de tipo — só o layout, silenciosamente.
+ * **Não** substitui o `spacing` do tema. O MUI chama `theme.spacing(1..3)`
+ * internamente — gutters do Toolbar, padding de Dialog, de Card — esperando o
+ * multiplicador de 8px dele. Sobrescrever aquilo encolhe todos esses
+ * componentes silenciosamente: as gutters do Toolbar viravam 3px no lugar de
+ * 24px. Nossos estilos usam este helper; o MUI continua com o dele.
  */
 export function spacing(...values: number[]): string {
   return values.map((value) => `${value / ROOT_FONT_SIZE}rem`).join(' ');

--- a/FateConnect/Web/src/design-system/tokens/breakpoints.ts
+++ b/FateConnect/Web/src/design-system/tokens/breakpoints.ts
@@ -1,0 +1,8 @@
+/**
+ * Largura máxima tratada como mobile. Reproduz o breakpoint já usado no produto
+ * (`max-width: 768px`), que não coincide com o `md` padrão do MUI (900px).
+ */
+export const MOBILE_MAX_WIDTH_PX = 768;
+
+/** Media query de mobile, para uso direto nos arquivos de estilo. */
+export const mobileMedia = `@media (max-width: ${MOBILE_MAX_WIDTH_PX}px)`;

--- a/FateConnect/Web/src/design-system/tokens/index.ts
+++ b/FateConnect/Web/src/design-system/tokens/index.ts
@@ -4,4 +4,5 @@ export { radiusScale } from './radius';
 export type { RadiusToken } from './radius';
 export { colorTokens, shadowTokens, iconSizeTokens } from './palette';
 export { fontFamily, typographyTokens } from './typography';
+export { MOBILE_MAX_WIDTH_PX, mobileMedia } from './breakpoints';
 export type { TypographyToken } from './typography';

--- a/FateConnect/Web/src/layouts/GuestLayout/DrawerSectionItem.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/DrawerSectionItem.tsx
@@ -1,0 +1,22 @@
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import { useCallback } from 'react';
+
+import type { LandingSection } from '@app/routes/paths';
+
+type DrawerSectionItemProps = {
+  section: LandingSection;
+  label: string;
+  onSelect: (section: LandingSection) => void;
+};
+
+/** Item do menu lateral que rola até uma seção da landing. */
+export function DrawerSectionItem({ section, label, onSelect }: DrawerSectionItemProps) {
+  const handleClick = useCallback(() => onSelect(section), [onSelect, section]);
+
+  return (
+    <ListItemButton onClick={handleClick}>
+      <ListItemText primary={label} />
+    </ListItemButton>
+  );
+}

--- a/FateConnect/Web/src/layouts/GuestLayout/GuestLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/GuestLayout.test.tsx
@@ -1,0 +1,55 @@
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { LandingSection, RoutePath } from '@app/routes/paths';
+import { render, screen, userEvent, within } from '@app/test/testing-library';
+import { GuestLayout } from '.';
+
+function renderLayout() {
+  const router = createMemoryRouter(
+    [
+      {
+        element: <GuestLayout />,
+        children: [{ path: RoutePath.LANDING, element: <div>landing</div> }],
+      },
+    ],
+    { initialEntries: [RoutePath.LANDING] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+// O botão de menu só aparece abaixo de 768px, por CSS. O jsdom não avalia media
+// query, então ele fica com `display: none` e precisa ser buscado com `hidden`.
+describe('GuestLayout', () => {
+  it('should render the guest header and the footer around the routed content', () => {
+    renderLayout();
+
+    expect(screen.getByRole('button', { name: 'Entrar' })).toBeInTheDocument();
+    expect(screen.getByText('landing')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Entre em contato' })).toBeInTheDocument();
+  });
+
+  it('should open the navigation drawer from the hamburger button', async () => {
+    renderLayout();
+
+    expect(screen.queryByRole('presentation')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir menu', hidden: true }));
+
+    const drawer = screen.getByRole('presentation');
+    expect(within(drawer).getByRole('button', { name: 'Como Funciona' })).toBeInTheDocument();
+  });
+
+  it('should close the drawer and go to the section when a drawer item is selected', async () => {
+    const router = renderLayout();
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir menu', hidden: true }));
+
+    const drawer = screen.getByRole('presentation');
+    await userEvent.click(within(drawer).getByRole('button', { name: 'Serviços' }));
+
+    expect(router.state.location.hash).toBe('');
+    expect(document.getElementById(LandingSection.SERVICES)).not.toBeInTheDocument();
+  });
+});

--- a/FateConnect/Web/src/layouts/GuestLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/index.tsx
@@ -1,14 +1,59 @@
-import { Outlet } from 'react-router';
+import Typography from '@mui/material/Typography';
+import { useCallback, useState } from 'react';
+import { Link as RouterLink, Outlet } from 'react-router';
 
+import { Footer } from '@app/components/Footer';
+import { Header } from '@app/components/Header';
+import { LANDING_LINKS } from '@app/components/Header/constants';
+import { useLandingAnchor } from '@app/hooks/useLandingAnchor';
+import { RoutePath, type LandingSection } from '@app/routes/paths';
+import { NavigationDrawer } from '../NavigationDrawer';
 import { ShellContent, ShellRoot } from '../shell.styles';
+import { DrawerSectionItem } from './DrawerSectionItem';
 
-/** Casca das rotas públicas (`/inicio`, `/cadastro`). Header, rodapé e menu lateral chegam na #51. */
+/** Casca das rotas públicas (`/inicio`, `/cadastro`). */
 export function GuestLayout() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const goToSection = useLandingAnchor();
+
+  const handleMenuClick = useCallback(() => setDrawerOpen(true), []);
+  const handleDrawerClose = useCallback(() => setDrawerOpen(false), []);
+  const handleSectionSelect = useCallback(
+    (section: LandingSection) => {
+      setDrawerOpen(false);
+      goToSection(section);
+    },
+    [goToSection],
+  );
+
   return (
     <ShellRoot>
+      <Header isLoggedIn={false} onMenuClick={handleMenuClick} />
+
+      <NavigationDrawer
+        open={drawerOpen}
+        onClose={handleDrawerClose}
+        header={
+          <RouterLink to={RoutePath.LANDING} aria-label="FateConnect">
+            <Typography variant="logo">FateConnect</Typography>
+          </RouterLink>
+        }
+      >
+        {LANDING_LINKS.map(({ section, label }) => (
+          <DrawerSectionItem
+            key={section}
+            section={section}
+            label={label}
+            onSelect={handleSectionSelect}
+          />
+        ))}
+      </NavigationDrawer>
+
       <ShellContent>
         <Outlet />
       </ShellContent>
+
+      <Footer />
     </ShellRoot>
   );
 }

--- a/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
@@ -1,0 +1,46 @@
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { RoutePath } from '@app/routes/paths';
+import { render, screen, userEvent, within } from '@app/test/testing-library';
+import { MainLayout } from '.';
+
+function renderLayout() {
+  const router = createMemoryRouter(
+    [
+      {
+        element: <MainLayout />,
+        children: [
+          { path: RoutePath.MENU, element: <div>menu</div> },
+          { path: RoutePath.RIDES, element: <div>caronas</div> },
+        ],
+      },
+    ],
+    { initialEntries: [RoutePath.MENU] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+// O botão de menu só aparece abaixo de 768px, por CSS. O jsdom não avalia media
+// query, então ele fica com `display: none` e precisa ser buscado com `hidden`.
+describe('MainLayout', () => {
+  it('should render the logged header and the footer around the routed content', () => {
+    renderLayout();
+
+    expect(screen.getByRole('link', { name: 'Caronas' })).toBeInTheDocument();
+    expect(screen.getByText('menu')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Entre em contato' })).toBeInTheDocument();
+  });
+
+  it('should navigate from a drawer item and close the drawer', async () => {
+    const router = renderLayout();
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir menu', hidden: true }));
+
+    const drawer = screen.getByRole('presentation');
+    await userEvent.click(within(drawer).getByRole('link', { name: 'Caronas' }));
+
+    expect(router.state.location.pathname).toBe(RoutePath.RIDES);
+  });
+});

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -1,14 +1,48 @@
-import { Outlet } from 'react-router';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+import { useCallback, useState } from 'react';
+import { Link as RouterLink, Outlet } from 'react-router';
 
+import { Footer } from '@app/components/Footer';
+import { Header } from '@app/components/Header';
+import { APP_LINKS } from '@app/components/Header/constants';
+import { RoutePath } from '@app/routes/paths';
+import { NavigationDrawer } from '../NavigationDrawer';
 import { ShellContent, ShellRoot } from '../shell.styles';
 
-/** Casca das rotas internas (`/menu`, `/caronas`, …). Header, rodapé e menu lateral chegam na #51. */
+/** Casca das rotas internas (`/menu`, `/caronas`, …). */
 export function MainLayout() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const handleMenuClick = useCallback(() => setDrawerOpen(true), []);
+  const handleDrawerClose = useCallback(() => setDrawerOpen(false), []);
+
   return (
     <ShellRoot>
+      <Header onMenuClick={handleMenuClick} />
+
+      <NavigationDrawer
+        open={drawerOpen}
+        onClose={handleDrawerClose}
+        header={
+          <RouterLink to={RoutePath.MENU} aria-label="FateConnect">
+            <Typography variant="logo">FateConnect</Typography>
+          </RouterLink>
+        }
+      >
+        {APP_LINKS.map(({ path, label }) => (
+          <ListItemButton key={path} component={RouterLink} to={path} onClick={handleDrawerClose}>
+            <ListItemText primary={label} />
+          </ListItemButton>
+        ))}
+      </NavigationDrawer>
+
       <ShellContent>
         <Outlet />
       </ShellContent>
+
+      <Footer />
     </ShellRoot>
   );
 }

--- a/FateConnect/Web/src/layouts/NavigationDrawer/index.tsx
+++ b/FateConnect/Web/src/layouts/NavigationDrawer/index.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+import { DrawerHeader, DrawerList, DrawerRoot } from './styles';
+
+type NavigationDrawerProps = {
+  open: boolean;
+  onClose: VoidFunction;
+  header: ReactNode;
+  children: ReactNode;
+};
+
+/** Menu lateral das duas cascas. Cada layout monta os próprios itens. */
+export function NavigationDrawer({ open, onClose, header, children }: NavigationDrawerProps) {
+  return (
+    <DrawerRoot anchor="right" open={open} onClose={onClose}>
+      <DrawerHeader>{header}</DrawerHeader>
+      <DrawerList>{children}</DrawerList>
+    </DrawerRoot>
+  );
+}

--- a/FateConnect/Web/src/layouts/NavigationDrawer/styles.ts
+++ b/FateConnect/Web/src/layouts/NavigationDrawer/styles.ts
@@ -1,0 +1,59 @@
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import { styled } from '@mui/material/styles';
+
+import { colorTokens } from '@ds';
+
+/** Largura do menu lateral no produto. */
+const DRAWER_WIDTH_PX = 300;
+
+/** Recuo do conteúdo dentro do menu, em `vw`, como no original. */
+const DRAWER_VERTICAL_PADDING = '7vw';
+const LOGO_INSET = '3vw';
+
+/** Altura e recuo padrão de item de lista do Material, preservados. */
+const ITEM_MIN_HEIGHT_PX = 48;
+const ITEM_INLINE_PADDING_PX = 16;
+
+export const DrawerRoot = styled(Drawer)({
+  '& .MuiDrawer-paper': {
+    width: `${DRAWER_WIDTH_PX}px`,
+    backgroundColor: colorTokens.primary,
+    color: colorTokens.textOnAccent,
+    padding: `${DRAWER_VERTICAL_PADDING} 0`,
+    overflowX: 'hidden',
+  },
+});
+
+export const DrawerHeader = styled('div')({
+  display: 'flex',
+  justifyContent: 'start',
+  alignItems: 'center',
+  width: '100%',
+  paddingLeft: LOGO_INSET,
+  marginBottom: LOGO_INSET,
+
+  '& a': {
+    textDecoration: 'none',
+    color: colorTokens.textOnAccent,
+    cursor: 'pointer',
+  },
+});
+
+export const DrawerList = styled(List)({
+  paddingLeft: 0,
+
+  '& .MuiListItemButton-root': {
+    minHeight: `${ITEM_MIN_HEIGHT_PX}px`,
+    paddingLeft: `${ITEM_INLINE_PADDING_PX}px`,
+    paddingRight: `${ITEM_INLINE_PADDING_PX}px`,
+  },
+  '& .MuiListItemButton-root:hover': {
+    backgroundColor: colorTokens.surfaceHover,
+  },
+  '& .MuiListItemText-primary': {
+    color: colorTokens.textOnAccent,
+    fontSize: '1rem',
+    fontWeight: 400,
+  },
+});

--- a/FateConnect/Web/src/layouts/shell.styles.ts
+++ b/FateConnect/Web/src/layouts/shell.styles.ts
@@ -1,19 +1,20 @@
 import { styled } from '@mui/material/styles';
 
-import { spacingScale } from '@ds';
+import { HEADER_HEIGHT_PX } from '@app/components/Header/styles';
 
-const { none } = spacingScale;
-
-/** Casca comum aos dois layouts: ocupa a altura toda e empilha topo, conteúdo e rodapé. */
+/**
+ * Casca comum às duas rotas. O topo é fixo, então o conteúdo reserva a altura
+ * dele — mesmo comportamento do produto.
+ */
 export const ShellRoot = styled('div')({
-  minHeight: '100%',
+  minHeight: '100vh',
+  paddingTop: `${HEADER_HEIGHT_PX}px`,
   display: 'flex',
   flexDirection: 'column',
 });
 
-export const ShellContent = styled('main')(({ theme }) => ({
-  flex: 1,
+export const ShellContent = styled('main')({
   display: 'flex',
+  flex: 1,
   flexDirection: 'column',
-  padding: theme.spacing(none),
-}));
+});


### PR DESCRIPTION
## Objetivo

Portar o shell visual do produto — cabeçalho, rodapé e menu lateral — para o front React, com **paridade visual verificada por medição**.

## Alterações

Dois commits, um por mudança lógica:

**1. `fix: stop overriding mui spacing so its own components keep their scale`**

O tema deixa de sobrescrever o `spacing` do MUI. Os componentes do próprio MUI chamam `theme.spacing(1..3)` internamente — gutters do `Toolbar`, padding de `Dialog` e de `Card` — esperando o multiplicador de 8px dele. O override que existia encolhia todos eles em silêncio: **as gutters do Toolbar estavam em 3px onde deviam ser 24px**. Nossos tokens em px passam agora pelo helper `spacing()` do design system, e há teste travando as duas pontas.

**2. `feat: add header footer and navigation drawer`**

- **Cabeçalho:** barra fixa de 64px com sombra, padding `0 7vw`, marca sem sublinhado herdando a cor da barra, navegação desktop com `gap 0.5rem 1.5vw`, e botão de menu que só aparece abaixo de 768px.
- **Rodapé:** linha no desktop — contatos à esquerda, divisor vertical, assinatura à direita — e coluna centralizada com divisor horizontal abaixo de 768px.
- **Menu lateral:** 300px, fundo escuro, padding `7vw 0`, marca com recuo de `3vw` e itens de 48px com rótulo claro.
- Ícones do MUI no lugar do Font Awesome, para não trazer outra biblioteca de ícones.

## Paridade medida

`getComputedStyle` dos elementos equivalentes nos dois apps, em 1440px e 700px:

| Métrica | Referência | Migrado |
| ------- | ---------- | ------- |
| Header — posição / sombra | `fixed` / `0 2px 5px rgba(0,0,0,.08)` | idêntico |
| Toolbar — altura / padding | `64px` / `0 100.8px` | idêntico |
| Marca — tamanho / peso / decoração | `20.8px` / `600` / `none` | idêntico |
| Botão de navegação | `16px` / `500` / raio `4px` | idêntico |
| Botão de destaque | `16px` / **`400`** / raio `4px` | idêntico |
| Rodapé — fundo / direção | `rgb(67,84,92)` / `row` | idêntico |
| Rodapé — padding / gap | `43.2px 100.8px` / `16px` | idêntico |
| Divisor — desktop / mobile | vertical `0.48px` / horizontal `1px` | idêntico |
| Assinatura — alinhamento | `flex-end` (desktop) / `center` (mobile) | idêntico |
| Menu lateral — largura / fundo / padding | `300px` / `rgb(67,84,92)` / `49px` | idêntico |
| Menu lateral — item / rótulo | `48px`, `16px` / `rgba(255,255,255,.9)` `16px/400` | idêntico |
| Mobile — navegação / botão de menu | `none` / `flex` | idêntico |

## Issue

- #51

Closes #51

## Evidências

| Gate | Resultado |
| ---- | --------- |
| `yarn typecheck` | exit 0 |
| `yarn lint` | exit 0 |
| `yarn test:ci` | 10 arquivos, **35 testes**, exit 0 |
| `yarn build` | exit 0 |

Nota de teste: o botão de menu nasce com `display: none` e aparece por media query, como no produto. O jsdom não avalia media query, então os testes o buscam com `hidden: true` — está comentado nos arquivos.
