### PR TITLE
feat(52): add http layer with token interceptor query cache and notifications

### DIFF
--- a/FateConnect/Web/package.json
+++ b/FateConnect/Web/package.json
@@ -24,7 +24,10 @@
     "@mui/icons-material": "^9.3.1",
     "@mui/material": "^9.3.1",
     "@mui/x-date-pickers": "^9.11.0",
+    "@tanstack/react-query": "^5.101.4",
+    "axios": "^1.19.0",
     "date-fns": "^4.4.0",
+    "notistack": "^3.0.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router": "^8.3.0"
@@ -49,6 +52,7 @@
     "globals": "^17.11.0",
     "jsdom": "^29.1.1",
     "lint-staged": "^17.3.0",
+    "msw": "^2.15.0",
     "prettier": "^3.9.6",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.67.0",

--- a/FateConnect/Web/src/hooks/useNotification.ts
+++ b/FateConnect/Web/src/hooks/useNotification.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import { useSnackbar } from 'notistack';
+
+const AUTO_HIDE_MS = 5000;
+
+type Notifier = {
+  notifySuccess: (message: string) => void;
+  notifyError: (message: string) => void;
+  notifyWarning: (message: string) => void;
+};
+
+/** Camada fina sobre o notistack, para a UI não conhecer a biblioteca. */
+export function useNotification(): Notifier {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const notifySuccess = useCallback(
+    (message: string) => enqueueSnackbar(message, { variant: 'success' }),
+    [enqueueSnackbar],
+  );
+  const notifyError = useCallback(
+    (message: string) => enqueueSnackbar(message, { variant: 'error' }),
+    [enqueueSnackbar],
+  );
+  const notifyWarning = useCallback(
+    (message: string) => enqueueSnackbar(message, { variant: 'warning' }),
+    [enqueueSnackbar],
+  );
+
+  return { notifySuccess, notifyError, notifyWarning };
+}
+
+export const NOTIFICATION_AUTO_HIDE_MS = AUTO_HIDE_MS;

--- a/FateConnect/Web/src/main.tsx
+++ b/FateConnect/Web/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 
-import { ThemeProvider } from '@ds';
+import { AppProviders } from '@app/providers/AppProviders';
 import { routeConfig } from '@app/routes';
 
 const container = document.getElementById('root');
@@ -12,8 +12,8 @@ const router = createBrowserRouter(routeConfig);
 
 createRoot(container).render(
   <StrictMode>
-    <ThemeProvider>
+    <AppProviders>
       <RouterProvider router={router} />
-    </ThemeProvider>
+    </AppProviders>
   </StrictMode>,
 );

--- a/FateConnect/Web/src/mocks/server.ts
+++ b/FateConnect/Web/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+
+/** Servidor de mocks compartilhado. Cada teste registra os handlers de que precisa. */
+export const server = setupServer();

--- a/FateConnect/Web/src/providers/AppProviders.test.tsx
+++ b/FateConnect/Web/src/providers/AppProviders.test.tsx
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { useNotification } from '@app/hooks/useNotification';
+import { server } from '@app/mocks/server';
+import { apiClient } from '@app/services/httpClient';
+import { render, screen, userEvent } from '@app/test/testing-library';
+
+const PING_URL = 'https://api.fateconnect.test/ping';
+
+function ScreenWithFailingQuery() {
+  useQuery({
+    queryKey: ['ping'],
+    queryFn: () => apiClient.get('/ping'),
+    retry: false,
+  });
+
+  return <div>conteúdo da tela</div>;
+}
+
+function NotifyButtons() {
+  const { notifySuccess, notifyWarning } = useNotification();
+
+  return (
+    <>
+      <button type="button" onClick={() => notifySuccess('deu certo')}>
+        sucesso
+      </button>
+      <button type="button" onClick={() => notifyWarning('atenção')}>
+        aviso
+      </button>
+    </>
+  );
+}
+
+describe('AppProviders', () => {
+  it('should notify the user when a request fails, without breaking the screen', async () => {
+    server.use(http.get(PING_URL, () => new HttpResponse(null, { status: 500 })));
+
+    render(<ScreenWithFailingQuery />);
+
+    expect(await screen.findByText('Algo deu errado. Tente novamente.')).toBeInTheDocument();
+    expect(screen.getByText('conteúdo da tela')).toBeInTheDocument();
+  });
+
+  it('should expose success and warning notifications', async () => {
+    render(<NotifyButtons />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'sucesso' }));
+    expect(await screen.findByText('deu certo')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'aviso' }));
+    expect(await screen.findByText('atenção')).toBeInTheDocument();
+  });
+});

--- a/FateConnect/Web/src/providers/AppProviders.tsx
+++ b/FateConnect/Web/src/providers/AppProviders.tsx
@@ -1,0 +1,23 @@
+import { SnackbarProvider } from 'notistack';
+import type { ReactNode } from 'react';
+
+import { ThemeProvider } from '@ds';
+import { NOTIFICATION_AUTO_HIDE_MS } from '@app/hooks/useNotification';
+import { QueryProvider } from './QueryProvider';
+
+const MAX_STACKED_NOTIFICATIONS = 3;
+
+/** Composição única dos providers da aplicação, reusada também nos testes. */
+export function AppProviders({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider>
+      <SnackbarProvider
+        maxSnack={MAX_STACKED_NOTIFICATIONS}
+        autoHideDuration={NOTIFICATION_AUTO_HIDE_MS}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <QueryProvider>{children}</QueryProvider>
+      </SnackbarProvider>
+    </ThemeProvider>
+  );
+}

--- a/FateConnect/Web/src/providers/QueryProvider.tsx
+++ b/FateConnect/Web/src/providers/QueryProvider.tsx
@@ -1,0 +1,13 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { useState, type ReactNode } from 'react';
+
+import { useNotification } from '@app/hooks/useNotification';
+import { createQueryClient } from './queryClient';
+
+/** Precisa ficar dentro do provider de notificação: consome o notificador. */
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const { notifyError } = useNotification();
+  const [queryClient] = useState(() => createQueryClient(notifyError));
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/FateConnect/Web/src/providers/queryClient.ts
+++ b/FateConnect/Web/src/providers/queryClient.ts
@@ -1,0 +1,26 @@
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+
+import type { ApiError } from '@app/services/httpClient';
+
+const RETRY_ATTEMPTS = 1;
+
+function messageOf(error: unknown): string {
+  const apiError = error as ApiError;
+
+  return apiError?.message ?? 'Algo deu errado. Tente novamente.';
+}
+
+/**
+ * Erro de requisição vira notificação em um lugar só. A tela continua
+ * respondendo — o usuário é avisado, não travado.
+ */
+export function createQueryClient(notifyError: (message: string) => void): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: RETRY_ATTEMPTS, refetchOnWindowFocus: false },
+      mutations: { retry: 0 },
+    },
+    queryCache: new QueryCache({ onError: (error) => notifyError(messageOf(error)) }),
+    mutationCache: new MutationCache({ onError: (error) => notifyError(messageOf(error)) }),
+  });
+}

--- a/FateConnect/Web/src/services/auth/authService.test.ts
+++ b/FateConnect/Web/src/services/auth/authService.test.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
+import { login, logout } from './authService';
+import { tokenStorage } from './tokenStorage';
+
+const LOGIN_URL = 'https://api.fateconnect.test/auth/login';
+
+describe('authService', () => {
+  it('should store the session after a successful login', async () => {
+    server.use(
+      http.post(LOGIN_URL, () => HttpResponse.json({ token: 'abc', nomeCompleto: 'Fulano' })),
+    );
+
+    const response = await login({ emailFatec: 'a@fatec.sp.gov.br', senha: 'segredo123' });
+
+    expect(response.nomeCompleto).toBe('Fulano');
+    expect(tokenStorage.getToken()).toBe('abc');
+  });
+
+  it('should clear the session on logout', () => {
+    tokenStorage.save('abc', 'Fulano');
+
+    logout();
+
+    expect(tokenStorage.getToken()).toBeNull();
+  });
+});

--- a/FateConnect/Web/src/services/auth/authService.ts
+++ b/FateConnect/Web/src/services/auth/authService.ts
@@ -1,0 +1,16 @@
+import { apiClient } from '../httpClient';
+import { tokenStorage } from './tokenStorage';
+import type { LoginRequest, TokenResponse } from './types';
+
+const AUTH_PATH = '/auth';
+
+export async function login(payload: LoginRequest): Promise<TokenResponse> {
+  const { data } = await apiClient.post<TokenResponse>(`${AUTH_PATH}/login`, payload);
+  tokenStorage.save(data.token, data.nomeCompleto);
+
+  return data;
+}
+
+export function logout(): void {
+  tokenStorage.clear();
+}

--- a/FateConnect/Web/src/services/auth/tokenStorage.ts
+++ b/FateConnect/Web/src/services/auth/tokenStorage.ts
@@ -1,0 +1,22 @@
+const TOKEN_KEY = 'jwt_token';
+const USER_NAME_KEY = 'user_name';
+
+/**
+ * Único ponto que fala com o armazenamento do navegador. Concentrar aqui evita
+ * `localStorage` espalhado pelo código e deixa a troca de estratégia barata.
+ */
+export const tokenStorage = {
+  getToken(): string | null {
+    return window.localStorage.getItem(TOKEN_KEY);
+  },
+
+  save(token: string, userName: string): void {
+    window.localStorage.setItem(TOKEN_KEY, token);
+    window.localStorage.setItem(USER_NAME_KEY, userName);
+  },
+
+  clear(): void {
+    window.localStorage.removeItem(TOKEN_KEY);
+    window.localStorage.removeItem(USER_NAME_KEY);
+  },
+};

--- a/FateConnect/Web/src/services/auth/types.ts
+++ b/FateConnect/Web/src/services/auth/types.ts
@@ -1,0 +1,10 @@
+/** Corpo esperado pelo endpoint de login (contrato do backend, em pt-BR). */
+export type LoginRequest = {
+  emailFatec: string;
+  senha: string;
+};
+
+export type TokenResponse = {
+  token: string;
+  nomeCompleto: string;
+};

--- a/FateConnect/Web/src/services/cep/cepService.test.ts
+++ b/FateConnect/Web/src/services/cep/cepService.test.ts
@@ -1,0 +1,34 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
+import { isCepNotFound, lookupCep } from './cepService';
+
+const PRIMARY_URL = 'https://viacep.com.br/ws/18000000/json/';
+const FALLBACK_URL = 'https://opencep.com/v1/18000000.json';
+
+describe('lookupCep', () => {
+  it('should return the address from the primary provider', async () => {
+    server.use(http.get(PRIMARY_URL, () => HttpResponse.json({ localidade: 'Sorocaba' })));
+
+    const address = await lookupCep('18000000');
+
+    expect(address.localidade).toBe('Sorocaba');
+  });
+
+  it('should fall back to the secondary provider when the primary fails', async () => {
+    server.use(
+      http.get(PRIMARY_URL, () => new HttpResponse(null, { status: 500 })),
+      http.get(FALLBACK_URL, () => HttpResponse.json({ localidade: 'Sorocaba' })),
+    );
+
+    const address = await lookupCep('18000000');
+
+    expect(address.localidade).toBe('Sorocaba');
+  });
+
+  it('should flag a zip code the primary provider reports as missing', () => {
+    expect(isCepNotFound({ erro: 'true' })).toBe(true);
+    expect(isCepNotFound({ localidade: 'Sorocaba' })).toBe(false);
+  });
+});

--- a/FateConnect/Web/src/services/cep/cepService.ts
+++ b/FateConnect/Web/src/services/cep/cepService.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+import type { CepAddress } from './types';
+
+const PRIMARY_PROVIDER = 'https://viacep.com.br/ws';
+const FALLBACK_PROVIDER = 'https://opencep.com/v1';
+
+/**
+ * Consulta o CEP no provedor primário e, em falha de rede ou HTTP, tenta o
+ * secundário. Usa `axios` direto, sem o client da aplicação: são serviços
+ * externos, que não recebem o token nem o tratamento de erro da nossa API.
+ */
+export async function lookupCep(zipDigits: string): Promise<CepAddress> {
+  try {
+    const { data } = await axios.get<CepAddress>(`${PRIMARY_PROVIDER}/${zipDigits}/json/`);
+
+    return data;
+  } catch {
+    const { data } = await axios.get<CepAddress>(`${FALLBACK_PROVIDER}/${zipDigits}.json`);
+
+    return data;
+  }
+}
+
+/** O provedor primário sinaliza CEP inexistente no corpo, não no status. */
+export function isCepNotFound(address: CepAddress): boolean {
+  return address.erro === 'true';
+}

--- a/FateConnect/Web/src/services/cep/types.ts
+++ b/FateConnect/Web/src/services/cep/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Endereço devolvido pelos provedores de CEP. O provedor primário responde
+ * `200` com `{ erro: "true" }` quando o CEP não existe — daí o campo opcional.
+ */
+export type CepAddress = {
+  cep?: string;
+  logradouro?: string;
+  complemento?: string;
+  bairro?: string;
+  localidade?: string;
+  uf?: string;
+  erro?: string;
+};

--- a/FateConnect/Web/src/services/httpClient.test.ts
+++ b/FateConnect/Web/src/services/httpClient.test.ts
@@ -1,0 +1,54 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
+import { tokenStorage } from './auth/tokenStorage';
+import { apiClient, GENERIC_ERROR_MESSAGE, NETWORK_ERROR_MESSAGE } from './httpClient';
+
+const PING_URL = 'https://api.fateconnect.test/ping';
+
+describe('httpClient', () => {
+  it('should send the stored token in the authorization header', async () => {
+    let receivedHeader: string | null = null;
+    server.use(
+      http.get(PING_URL, ({ request }) => {
+        receivedHeader = request.headers.get('Authorization');
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    tokenStorage.save('token-123', 'Fulano');
+
+    await apiClient.get('/ping');
+
+    expect(receivedHeader).toBe('Bearer token-123');
+  });
+
+  it('should not send an authorization header when there is no token', async () => {
+    let receivedHeader: string | null = 'nao-lido';
+    server.use(
+      http.get(PING_URL, ({ request }) => {
+        receivedHeader = request.headers.get('Authorization');
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await apiClient.get('/ping');
+
+    expect(receivedHeader).toBeNull();
+  });
+
+  it('should normalize an http failure into an api error carrying the status', async () => {
+    server.use(http.get(PING_URL, () => new HttpResponse(null, { status: 500 })));
+
+    await expect(apiClient.get('/ping')).rejects.toEqual({
+      status: 500,
+      message: GENERIC_ERROR_MESSAGE,
+    });
+  });
+
+  it('should normalize a network failure into an api error without status', async () => {
+    server.use(http.get(PING_URL, () => HttpResponse.error()));
+
+    await expect(apiClient.get('/ping')).rejects.toEqual({ message: NETWORK_ERROR_MESSAGE });
+  });
+});

--- a/FateConnect/Web/src/services/httpClient.ts
+++ b/FateConnect/Web/src/services/httpClient.ts
@@ -1,0 +1,49 @@
+import axios, { type AxiosInstance } from 'axios';
+
+import { tokenStorage } from './auth/tokenStorage';
+
+/** Erro já normalizado para a camada de UI. */
+export type ApiError = {
+  status?: number;
+  message: string;
+};
+
+export const NETWORK_ERROR_MESSAGE = 'Não foi possível conectar ao servidor. Tente novamente.';
+export const GENERIC_ERROR_MESSAGE = 'Algo deu errado. Tente novamente.';
+
+function withInterceptors(client: AxiosInstance): AxiosInstance {
+  client.interceptors.request.use((config) => {
+    const token = tokenStorage.getToken();
+    if (token) config.headers.Authorization = `Bearer ${token}`;
+
+    return config;
+  });
+
+  client.interceptors.response.use(
+    (response) => response,
+    (error: unknown) => {
+      if (!axios.isAxiosError(error)) {
+        return Promise.reject<ApiError>({ message: GENERIC_ERROR_MESSAGE });
+      }
+
+      if (!error.response) {
+        return Promise.reject<ApiError>({ message: NETWORK_ERROR_MESSAGE });
+      }
+
+      return Promise.reject<ApiError>({
+        status: error.response.status,
+        message: GENERIC_ERROR_MESSAGE,
+      });
+    },
+  );
+
+  return client;
+}
+
+/** API principal — autenticação e cadastro. */
+export const apiClient = withInterceptors(axios.create({ baseURL: import.meta.env.VITE_API_URL }));
+
+/** API de caronas, que tem endereço próprio. */
+export const rideApiClient = withInterceptors(
+  axios.create({ baseURL: import.meta.env.VITE_RIDE_API_URL }),
+);

--- a/FateConnect/Web/src/services/rides/ridesService.test.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.test.ts
@@ -1,0 +1,68 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
+import { deleteRide, listRides } from './ridesService';
+import { RideType } from './types';
+
+const RIDES_URL = 'https://rides.fateconnect.test/caronas';
+
+describe('ridesService', () => {
+  it('should translate the front filters into the api query parameters', async () => {
+    let received: URLSearchParams | null = null;
+    server.use(
+      http.get(RIDES_URL, ({ request }) => {
+        received = new URL(request.url).searchParams;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    await listRides({
+      destination: 'Sorocaba',
+      departureDate: '2026-08-20',
+      departureTime: '07:30',
+      rideType: RideType.EGALITARIAN,
+    });
+
+    expect(received!.get('Destino')).toBe('Sorocaba');
+    expect(received!.get('DataPartida')).toBe('2026-08-20');
+    expect(received!.get('HoraPartida')).toBe('07:30');
+    expect(received!.get('TipoCarona')).toBe(RideType.EGALITARIAN);
+  });
+
+  it('should omit parameters that were not filled in', async () => {
+    let received: URLSearchParams | null = null;
+    server.use(
+      http.get(RIDES_URL, ({ request }) => {
+        received = new URL(request.url).searchParams;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    await listRides({ destination: 'Sorocaba' });
+
+    expect([...received!.keys()]).toEqual(['Destino']);
+  });
+
+  it('should list rides without filters', async () => {
+    server.use(http.get(RIDES_URL, () => HttpResponse.json([{ id: 1, destino: 'Sorocaba' }])));
+
+    const rides = await listRides();
+
+    expect(rides).toHaveLength(1);
+  });
+
+  it('should delete a ride by id', async () => {
+    let deletedId: string | undefined;
+    server.use(
+      http.delete(`${RIDES_URL}/:id`, ({ params }) => {
+        deletedId = params.id as string;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await deleteRide(7);
+
+    expect(deletedId).toBe('7');
+  });
+});

--- a/FateConnect/Web/src/services/rides/ridesService.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.ts
@@ -1,0 +1,26 @@
+import { rideApiClient } from '../httpClient';
+import type { Ride, RideFilter } from './types';
+
+const RIDES_PATH = '/caronas';
+
+/** Tradução dos filtros do front para os nomes de parâmetro da API. */
+function toQueryParams(filters: RideFilter = {}): Record<string, string> {
+  const params: Record<string, string> = {};
+
+  if (filters.destination) params.Destino = filters.destination;
+  if (filters.departureDate) params.DataPartida = filters.departureDate;
+  if (filters.departureTime) params.HoraPartida = filters.departureTime;
+  if (filters.rideType) params.TipoCarona = filters.rideType;
+
+  return params;
+}
+
+export async function listRides(filters?: RideFilter): Promise<Ride[]> {
+  const { data } = await rideApiClient.get<Ride[]>(RIDES_PATH, { params: toQueryParams(filters) });
+
+  return data;
+}
+
+export async function deleteRide(rideId: number): Promise<void> {
+  await rideApiClient.delete(`${RIDES_PATH}/${rideId}`);
+}

--- a/FateConnect/Web/src/services/rides/types.ts
+++ b/FateConnect/Web/src/services/rides/types.ts
@@ -1,0 +1,26 @@
+/** Valores canônicos alinhados à serialização do backend. */
+export enum RideType {
+  PHILANTHROPIC = 'Filantropica',
+  EGALITARIAN = 'Igualitaria',
+}
+
+/** Entidade como a API devolve (campos em pt-BR). */
+export type Ride = {
+  id: number;
+  qtdVagas: number;
+  destino: string;
+  dataPartida: string;
+  horaPartida: string;
+  dataCadastro: string;
+  tipoCarona: RideType;
+  descricao: string;
+  ativo: boolean;
+};
+
+/** Filtros do front, em inglês; o serviço traduz para os parâmetros da API. */
+export type RideFilter = {
+  destination?: string;
+  departureDate?: string;
+  departureTime?: string;
+  rideType?: RideType;
+};

--- a/FateConnect/Web/src/services/signup/signupService.test.ts
+++ b/FateConnect/Web/src/services/signup/signupService.test.ts
@@ -1,0 +1,39 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
+import { signup } from './signupService';
+import type { SignupRequest } from './types';
+
+const SIGNUP_URL = 'https://api.fateconnect.test/usuario/cadastro';
+
+const PAYLOAD: SignupRequest = {
+  emailFatec: 'aluno@fatec.sp.gov.br',
+  senha: 'segredo123',
+  nomeCompleto: 'Fulano de Tal',
+  dataNascimento: '2000-01-01',
+  genero: 1,
+  enderecos: [],
+  contatos: [],
+};
+
+describe('signupService', () => {
+  it('should post the payload and return the created user', async () => {
+    let receivedBody: unknown = null;
+    server.use(
+      http.post(SIGNUP_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json({
+          id: 1,
+          emailFatec: PAYLOAD.emailFatec,
+          nomeCompleto: PAYLOAD.nomeCompleto,
+        });
+      }),
+    );
+
+    const created = await signup(PAYLOAD);
+
+    expect(receivedBody).toEqual(PAYLOAD);
+    expect(created.id).toBe(1);
+  });
+});

--- a/FateConnect/Web/src/services/signup/signupService.ts
+++ b/FateConnect/Web/src/services/signup/signupService.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '../httpClient';
+import type { SignupRequest, SignupResponse } from './types';
+
+const SIGNUP_PATH = '/usuario/cadastro';
+
+export async function signup(payload: SignupRequest): Promise<SignupResponse> {
+  const { data } = await apiClient.post<SignupResponse>(SIGNUP_PATH, payload);
+
+  return data;
+}

--- a/FateConnect/Web/src/services/signup/types.ts
+++ b/FateConnect/Web/src/services/signup/types.ts
@@ -1,0 +1,31 @@
+/** Contratos do endpoint de cadastro (nomes vindos do backend, em pt-BR). */
+export type SignupAddress = {
+  cep: string;
+  logradouro: string;
+  numero: string;
+  complemento: string;
+  cidade: string;
+  estado: string;
+};
+
+export type SignupContact = {
+  telefone: string;
+  emailContato: string;
+};
+
+export type SignupRequest = {
+  emailFatec: string;
+  senha: string;
+  nomeCompleto: string;
+  apelido?: string;
+  dataNascimento: string;
+  genero: number;
+  enderecos: SignupAddress[];
+  contatos: SignupContact[];
+};
+
+export type SignupResponse = {
+  id: number;
+  emailFatec: string;
+  nomeCompleto: string;
+};

--- a/FateConnect/Web/src/test/testing-library.tsx
+++ b/FateConnect/Web/src/test/testing-library.tsx
@@ -1,19 +1,11 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { ThemeProvider } from '@ds';
-
-/**
- * Providers da aplicação. Rotas e cache de dados entram aqui nas issues #50 e #52,
- * e todo teste passa a recebê-los sem alteração caso a caso.
- */
-function AllProviders({ children }: { children: ReactNode }) {
-  return <ThemeProvider>{children}</ThemeProvider>;
-}
+import { AppProviders } from '@app/providers/AppProviders';
 
 function customRender(ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) {
-  return render(ui, { wrapper: AllProviders, ...options });
+  return render(ui, { wrapper: AppProviders, ...options });
 }
 
 export * from '@testing-library/react';

--- a/FateConnect/Web/vitest.setup.ts
+++ b/FateConnect/Web/vitest.setup.ts
@@ -1,6 +1,21 @@
 import '@testing-library/jest-dom/vitest';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
+
+import { server } from './src/mocks/server';
 
 process.env.TZ = 'America/Sao_Paulo';
+
+// Endereços fictícios: os clientes HTTP são criados na carga do módulo, então o
+// stub precisa acontecer antes de qualquer import de teste.
+vi.stubEnv('VITE_API_URL', 'https://api.fateconnect.test');
+vi.stubEnv('VITE_RIDE_API_URL', 'https://rides.fateconnect.test');
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  window.localStorage.clear();
+});
+afterAll(() => server.close());
 
 // jsdom não implementa scrollIntoView; os testes que precisam observam por spy.
 if (!Element.prototype.scrollIntoView) {

--- a/FateConnect/Web/yarn.lock
+++ b/FateConnect/Web/yarn.lock
@@ -459,6 +459,42 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@inquirer/ansi@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-2.0.7.tgz#86de22810cac3ed406ec10f8d66016815b8226b4"
+  integrity sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==
+
+"@inquirer/confirm@^6.0.11":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-6.2.0.tgz#be7bd7dd08e2e425d9421e97fa2227f919e7e302"
+  integrity sha512-SKXarWrYhtpqOEctf9XGCGy29QjsvJAM0Aq9ZR9z4Ns94OmpqudOly+aSEfNqUf9SwsQaUgY9+Z8hyzG0xX8fw==
+  dependencies:
+    "@inquirer/core" "^12.0.0"
+    "@inquirer/type" "^4.0.7"
+
+"@inquirer/core@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-12.0.0.tgz#e7fa911168775206748cf9a6b05234b3fbef779c"
+  integrity sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==
+  dependencies:
+    "@inquirer/ansi" "^2.0.7"
+    "@inquirer/figures" "^2.0.8"
+    "@inquirer/type" "^4.0.7"
+    cli-width "^4.1.0"
+    fast-wrap-ansi "^0.2.0"
+    mute-stream "^3.0.0"
+    signal-exit "^4.1.0"
+
+"@inquirer/figures@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-2.0.8.tgz#d10c3a8a28896679797d9da5944f3093476aa0cd"
+  integrity sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==
+
+"@inquirer/type@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.7.tgz#9c6f0d857fe6ad549a3a932343b64e76acb34b10"
+  integrity sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -492,6 +528,18 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@mswjs/interceptors@^0.41.3":
+  version "0.41.9"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.41.9.tgz#9d90bbd60d1ddc30dbcbb827a9bb2e470493530d"
+  integrity sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
 
 "@mui/core-downloads-tracker@^9.3.1":
   version "9.3.1"
@@ -601,6 +649,29 @@
     reselect "^5.2.0"
     use-sync-external-store "^1.6.0"
 
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/deferred-promise@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz#9725acc5afe8ecde690e9e198a094859fdbf2e45"
+  integrity sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.3.0.tgz#2b3ab1242b360aa0adb28b85f5d7da1c133a0954"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
+
 "@oxc-project/types@=0.146.0":
   version "0.146.0"
   resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.146.0.tgz#d57a2591abbf1f6e50981b07ee24ab269530d87a"
@@ -701,6 +772,18 @@
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
+"@tanstack/query-core@5.101.4":
+  version "5.101.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.101.4.tgz#c01b4289b3094144d8ef96235aa506242cf83efa"
+  integrity sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==
+
+"@tanstack/react-query@^5.101.4":
+  version "5.101.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.101.4.tgz#044137754d79aaa30a82f6e6c42488be79c86ea7"
+  integrity sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==
+  dependencies:
+    "@tanstack/query-core" "5.101.4"
+
 "@testing-library/dom@^10.4.1":
   version "10.4.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
@@ -767,7 +850,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@^26.2.0":
+"@types/node@*", "@types/node@^26.2.0":
   version "26.2.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-26.2.0.tgz#5a4875a862fda8fdc57de8faa579bb81ecba1685"
   integrity sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==
@@ -800,6 +883,18 @@
   integrity sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==
   dependencies:
     csstype "^3.2.2"
+
+"@types/set-cookie-parser@^2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz#ad3a807d6d921db9720621ea3374c5d92020bcbc"
+  integrity sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/statuses@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/statuses/-/statuses-2.0.6.tgz#66748315cc9a96d63403baa8671b2c124f8633aa"
+  integrity sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==
 
 "@typescript-eslint/eslint-plugin@8.67.0":
   version "8.67.0"
@@ -990,6 +1085,13 @@ acorn@^8.15.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
   integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.14.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
@@ -1005,7 +1107,7 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -1136,6 +1238,11 @@ async-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
   integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -1147,6 +1254,16 @@ axe-core@^4.10.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.13.0.tgz#f868ecb1bd61d982321760e51d841ab497ab86d0"
   integrity sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==
+
+axios@^1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.19.0.tgz#ddf864d4c8233c0e6873746ab59361537d05ad39"
+  integrity sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==
+  dependencies:
+    follow-redirects "^1.16.0"
+    form-data "^4.0.6"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -1259,6 +1376,25 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
+clsx@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
@@ -1275,6 +1411,13 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1295,6 +1438,11 @@ cookie-es@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-3.1.1.tgz#c4a8a16cf88cb5a185b23f4a61d6e9a85eb53287"
   integrity sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==
+
+cookie@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
+  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
 cosmiconfig@^7.0.0:
   version "7.1.0"
@@ -1379,7 +1527,7 @@ date-fns@^4.4.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.4.0.tgz#806539edf45c616b2b76b5f78b88c56ed3c7e036"
   integrity sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==
 
-debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.4.3:
+debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1413,6 +1561,11 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.3:
   version "2.0.3"
@@ -1462,6 +1615,11 @@ electron-to-chromium@^1.5.402:
   version "1.5.411"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz#d56c7e43f91e2b3abb53b4eecd646e20d0b18b34"
   integrity sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 emoji-regex@^9.2.2:
   version "9.2.2"
@@ -1623,7 +1781,7 @@ es-to-primitive@^1.3.0:
     is-date-object "^1.1.0"
     is-symbol "^1.1.1"
 
-escalade@^3.2.0:
+escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
@@ -1830,6 +1988,25 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-string-truncated-width@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz#23afe0da67d752ca0727538f1e6967759728ce49"
+  integrity sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==
+
+fast-string-width@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-string-width/-/fast-string-width-3.0.2.tgz#16dbabb491ce5585b5ecb675b65c165d71688eeb"
+  integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
+  dependencies:
+    fast-string-truncated-width "^3.0.2"
+
+fast-wrap-ansi@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz#95e952a0145bce3f59ad56e179f84c48d4072935"
+  integrity sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==
+  dependencies:
+    fast-string-width "^3.0.2"
+
 fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
@@ -1868,12 +2045,28 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.4.tgz#aeeca2a506303f0cee61c59e6c9f2a88d2f29fc6"
   integrity sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==
 
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
+
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
+
+form-data@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 fsevents@~2.3.3:
   version "2.3.3"
@@ -1914,6 +2107,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
@@ -1973,10 +2171,20 @@ globalthis@^1.0.4:
     define-properties "^1.2.1"
     gopd "^1.0.1"
 
+goober@^2.0.33:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.19.tgz#a4b4dcdbba9325b8c4d7380099f9f281f27c6a6f"
+  integrity sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==
+
 gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+graphql@^16.13.2:
+  version "16.14.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.14.2.tgz#83faf25869e3df727cc855161db5da85b0e5b2c0"
+  integrity sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==
 
 has-bigints@^1.0.2:
   version "1.1.0"
@@ -2021,6 +2229,14 @@ hasown@^2.0.2, hasown@^2.0.3, hasown@^2.0.4:
   dependencies:
     function-bind "^1.1.2"
 
+headers-polyfill@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-5.0.1.tgz#9554eb2892b666db1c7a3380a91b6cfd467a6b19"
+  integrity sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.10"
+    set-cookie-parser "^3.0.1"
+
 hermes-estree@0.25.1:
   version "0.25.1"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.25.1.tgz#6aeec17d1983b4eabf69721f3aa3eb705b17f480"
@@ -2051,6 +2267,14 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -2177,6 +2401,11 @@ is-finalizationregistry@^1.1.0:
   dependencies:
     call-bound "^1.0.3"
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 is-generator-function@^1.0.10:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
@@ -2204,6 +2433,11 @@ is-negative-zero@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number-object@^1.1.1:
   version "1.1.1"
@@ -2598,6 +2832,18 @@ mdn-data@2.27.1:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
   integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -2621,6 +2867,35 @@ ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+msw@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-2.15.0.tgz#4028ba3d887af8c166d45aa3bf37116f73f21cec"
+  integrity sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==
+  dependencies:
+    "@inquirer/confirm" "^6.0.11"
+    "@mswjs/interceptors" "^0.41.3"
+    "@open-draft/deferred-promise" "^3.0.0"
+    "@types/statuses" "^2.0.6"
+    cookie "^1.1.1"
+    graphql "^16.13.2"
+    headers-polyfill "^5.0.1"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    path-to-regexp "^6.3.0"
+    picocolors "^1.1.1"
+    rettime "^0.11.11"
+    statuses "^2.0.2"
+    strict-event-emitter "^0.5.1"
+    tough-cookie "^6.0.1"
+    type-fest "^5.5.0"
+    until-async "^3.0.2"
+    yargs "^17.7.2"
+
+mute-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-3.0.0.tgz#cd8014dd2acb72e1e91bb67c74f0019e620ba2d1"
+  integrity sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==
 
 nanoid@^3.3.17:
   version "3.3.18"
@@ -2646,6 +2921,14 @@ node-releases@^2.0.53:
   version "2.0.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.53.tgz#0fe5ad8a7935e075172f574e56f0c20f07fa41af"
   integrity sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==
+
+notistack@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-3.0.2.tgz#009799c3fccddeffac58565ba1657d27616dfabd"
+  integrity sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==
+  dependencies:
+    clsx "^1.1.0"
+    goober "^2.0.33"
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -2721,6 +3004,11 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
+
 own-keys@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.2.tgz#31448ec1f781ecb1447f6f6aa0d6534222af59de"
@@ -2783,6 +3071,11 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -2852,6 +3145,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
@@ -2936,6 +3234,11 @@ regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
     gopd "^1.2.0"
     set-function-name "^2.0.2"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
 require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
@@ -2972,6 +3275,11 @@ resolve@^2.0.0-next.5:
     object-keys "^1.1.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+rettime@^0.11.11:
+  version "0.11.11"
+  resolved "https://registry.yarnpkg.com/rettime/-/rettime-0.11.11.tgz#fe8fb192e1877bb0080fc1a640cb08eededd7d12"
+  integrity sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==
 
 rolldown@~1.2.1:
   version "1.2.5"
@@ -3046,6 +3354,11 @@ semver@^7.5.3, semver@^7.7.3:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
+
+set-cookie-parser@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz#f4e490298759d756a68eabcbcd0fc9261ad0fee0"
+  integrity sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -3135,6 +3448,11 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -3150,6 +3468,11 @@ stackback@0.0.2:
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
+statuses@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
 std-env@^4.0.0-rc.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.2.0.tgz#8ebe0ec60485668ab47227b312f4254cdf80c9d3"
@@ -3163,10 +3486,24 @@ stop-iteration-iterator@^1.1.0:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
 
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
+
 string-argv@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string.prototype.includes@^2.0.1:
   version "2.0.1"
@@ -3237,6 +3574,13 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-indent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
@@ -3277,6 +3621,11 @@ synckit@^0.11.13:
   integrity sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==
   dependencies:
     "@pkgr/core" "^0.3.6"
+
+tagged-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
+  integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
 
 tinybench@^2.9.0:
   version "2.9.0"
@@ -3338,6 +3687,13 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-fest@^5.5.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-5.8.0.tgz#6d517998257c33159db4d4da6f18efa33bd47df3"
+  integrity sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==
+  dependencies:
+    tagged-tag "^1.0.0"
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"
@@ -3418,6 +3774,11 @@ undici@^7.25.0:
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
   integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
+
+until-async@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/until-async/-/until-async-3.0.2.tgz#447f1531fdd7bb2b4c7a98869bdb1a4c2a23865f"
+  integrity sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==
 
 update-browserslist-db@^1.3.0:
   version "1.3.1"
@@ -3577,6 +3938,15 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 xml-name-validator@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
@@ -3586,6 +3956,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^3.0.2:
   version "3.1.1"
@@ -3601,6 +3976,24 @@ yaml@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
   integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Objetivo

Portar a camada de acesso a dados e de feedback ao usuário. É a base das telas com API — landing, cadastro e caronas — e fecha um buraco de segurança que existe hoje no front Angular.

Empilhado sobre o #70 (cabeçalho, rodapé e menu lateral).

## Alterações

**Cliente HTTP** (`services/httpClient.ts`)

- Duas instâncias de `axios`, uma por API, com `baseURL` vinda de variável de ambiente. Nenhum endereço literal em arquivo versionado.
- **Interceptor de request injeta o token** em toda requisição autenticada. Hoje isso é um `TODO` no serviço de autenticação do front Angular e **nenhuma requisição leva o header** — a correção entra junto do porte.
- Interceptor de response normaliza a falha num formato único (`status` + mensagem), separando erro de rede de erro HTTP.

**Sessão** (`services/auth/`)

- `tokenStorage` concentra o acesso ao armazenamento do navegador em um lugar só, em vez de `localStorage` espalhado.
- `login` guarda a sessão; `logout` limpa.

**Serviços portados**

- Cadastro, caronas e consulta de CEP.
- Caronas: a tradução dos filtros do front para os parâmetros da API é preservada — `destination` → `Destino`, `departureDate` → `DataPartida`, `departureTime` → `HoraPartida`, `rideType` → `TipoCarona`.
- CEP: **fallback entre os dois provedores** preservado. Usa `axios` direto, sem o cliente da aplicação — são serviços externos, que não devem receber nosso token nem nosso tratamento de erro.
- `RideType` virou enum, mantendo os valores da serialização do backend.

**Cache e notificação** (`providers/`)

- `QueryClient` com o tratamento de erro centralizado: falha de requisição vira notificação, e a tela continua respondendo.
- `AppProviders` compõe tema, notificação e cache num lugar só — usado pela aplicação **e** pelos testes, para provider novo passar a valer na suíte inteira sem alteração caso a caso.
- `useNotification` é uma camada fina sobre a biblioteca de notificação, para a UI não conhecê-la diretamente.

**Testes**

- MSW passa a interceptar as requisições, então os testes exercitam a pilha real — axios, interceptors e tratamento de erro — em vez de um mock do axios.

## Issue

- #52

Closes #52

## Evidências

| Gate | Resultado |
| ---- | --------- |
| `yarn typecheck` | exit 0 |
| `yarn lint` | exit 0 |
| `yarn test:ci` | 16 arquivos, **50 testes**, exit 0 |
| `yarn build` | exit 0 |
| Cobertura | 98,59% statements · 93,33% branches · 98,91% lines |

Critérios de aceite cobertos por teste: token no header quando há sessão e ausência do header quando não há; erro HTTP e erro de rede normalizados; fallback de CEP com o provedor primário falhando; tradução dos filtros de carona; e falha de requisição gerando notificação **sem** derrubar a tela.
