### PR TITLE
feat(53): add the landing page with light and dark themes

### DIFF
--- a/FateConnect/Web/README.md
+++ b/FateConnect/Web/README.md
@@ -1,0 +1,100 @@
+# FateConnect — Web
+
+Front-end do FateConnect em React + Vite. Substitui gradualmente o front Angular em `FateConnect/Front`, acompanhado pela issue [#47](https://github.com/victorfob/FateConnect/issues/47).
+
+## Requisitos
+
+- **Node** na versão do `.nvmrc` (`nvm use` na pasta resolve)
+- **Yarn** 1.x
+
+O projeto **não roda em Node 20**: as ferramentas de teste exigem 22 ou superior.
+
+## Começando
+
+```bash
+nvm use
+yarn
+cp .env.example .env.development   # preencha os endereços do seu ambiente
+yarn dev
+```
+
+Nenhum endereço de API é versionado — só o `.env.example`, com as chaves vazias.
+
+## Scripts
+
+| Comando | O que faz |
+| ------- | --------- |
+| `yarn dev` | Sobe o servidor de desenvolvimento |
+| `yarn build` | Verifica tipos e gera o pacote de produção |
+| `yarn typecheck` | Só a checagem de tipos |
+| `yarn lint` / `yarn lint:fix` | Lint (é o gate de estilo de código) |
+| `yarn test` | Testes em modo observador |
+| `yarn test:ci` | Testes com cobertura — **reprova abaixo de 80%** |
+
+## Estrutura
+
+```
+src/
+  design-system/     tokens, tema e componentes compartilhados
+    tokens/          valores brutos: cor, espaçamento, raio, tipografia, breakpoints
+    theme/           paletas clara e escura, overrides do MUI, contraste
+    components/      cromo e UI reutilizável (topo, rodapé, menu lateral, seletor de tema)
+    index.ts         ponto de entrada público — a aplicação importa só daqui
+  pages/             uma pasta por tela
+  layouts/           cascas de visitante e de área interna
+  components/        composições que conhecem o domínio da aplicação
+  services/          cliente HTTP, sessão e serviços de API
+  providers/         tema, cache de dados e notificação
+  hooks/  utils/     hooks e funções auxiliares
+  routes/            caminhos e configuração de rotas
+  test/              render de teste com os providers da aplicação
+```
+
+## Convenções
+
+O lint aplica as principais; as demais estão nas regras do projeto.
+
+### Design system é a única porta
+
+A aplicação importa UI **somente** de `@design-system` — nunca de `@mui/*`, nunca de um caminho interno do design system. Precisa de um componente que o barrel não expõe? Adicione ao barrel.
+
+### Cor vem da paleta
+
+Os tokens alimentam a paleta em `theme/`; componente lê `theme.palette.*`. Importar token de cor fora do tema **reprova no lint**.
+
+### Estilo em `styles.ts`
+
+Um arquivo por componente, importado como namespace:
+
+```ts
+import * as S from './styles';
+// <S.PageContainer>
+```
+
+`styled(Stack)` quando o elemento for flex, `styled(Box)` no resto — nunca tag HTML crua. A semântica vem da prop `component`:
+
+```tsx
+<S.FooterRoot component="footer">
+```
+
+> O `Stack` é flex em **coluna** por padrão, enquanto `display: flex` cru é linha. Declare `flexDirection` explicitamente.
+
+### Espaçamento
+
+Tokens em pixels passam pelo helper `spacing()` do design system. **Não** sobrescreva o `spacing` do tema: os componentes do MUI o usam internamente, e alterá-lo encolhe todos eles em silêncio.
+
+## Temas
+
+Claro e escuro, construídos a partir do sistema de cor do Material Design. O seletor fica no topo. As razões de contraste são verificadas por teste em **todos** os pares de conteúdo e fundo, com o mínimo AA (4,5:1) — cor nova sem o par correspondente reprova a suíte.
+
+## Testes
+
+Vitest, Testing Library e MSW. Sempre `screen.*`, consultas por papel de acessibilidade, descrições em inglês no padrão `should …`.
+
+Use o `render` de `@app/test/testing-library`, que já monta tema, rotas e cache — importar `@testing-library/react` direto reprova no lint.
+
+## Paridade visual
+
+Enquanto o front Angular existir, **toda tela migrada precisa provar paridade por medição**: comparar `getComputedStyle` dos elementos equivalentes nos dois apps, em 1440px e 700px, e registrar a tabela no corpo do PR. Captura de tela não conta como prova — ela esconde diferenças de poucos pixels.
+
+Estilo de tela migrada se traduz do arquivo de origem, valor a valor. Nada de escrever de memória.

--- a/FateConnect/Web/eslint.config.js
+++ b/FateConnect/Web/eslint.config.js
@@ -31,5 +31,71 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
     },
   },
+
+  // A aplicação fala com a UI por uma porta só: o barrel do design system.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/design-system/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@mui/*'],
+              message:
+                'Importe pelo barrel: `@design-system`. Se o componente ainda não é exportado, adicione-o ao barrel.',
+            },
+            {
+              group: ['@design-system/*'],
+              message: 'Importe do barrel `@design-system`, nunca de um caminho interno dele.',
+            },
+            {
+              group: ['@emotion/*'],
+              message: 'Use `styled`, `css` e `keyframes` do barrel `@design-system`.',
+            },
+          ],
+          paths: [
+            {
+              name: '@design-system',
+              importNames: ['colorTokens', 'colorVariants', 'darkColorTokens'],
+              message:
+                'Token de cor alimenta a paleta; componente lê `theme.palette`. Se falta um slot, declare-o na paleta.',
+            },
+            {
+              name: '@testing-library/react',
+              message:
+                'Use o render de `@app/test/testing-library`, que já monta os providers da aplicação.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // Dentro do design system o MUI é a fronteira, e o tema pode ler os tokens.
+  {
+    files: ['src/design-system/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@testing-library/react',
+              message: 'Use o render de `@app/test/testing-library`.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // O próprio test-utils e os testes de contexto precisam da biblioteca crua.
+  {
+    files: ['src/test/**', 'src/**/*.test.{ts,tsx}'],
+    rules: { 'no-restricted-imports': 'off' },
+  },
+
   prettierRecommended,
 );

--- a/FateConnect/Web/eslint.config.js
+++ b/FateConnect/Web/eslint.config.js
@@ -97,5 +97,72 @@ export default tseslint.config(
     rules: { 'no-restricted-imports': 'off' },
   },
 
+  // Convenções de estilo aplicadas, não apenas documentadas.
+  // Testes ficam de fora: eles precisam citar as APIs que o código de produção evita.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/**/*.test.{ts,tsx}', 'src/test/**'],
+    rules: {
+      'react-hooks/exhaustive-deps': 'error',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "JSXAttribute[name.name='sx']",
+          message:
+            'Sem `sx` inline. Declare o estilo em `styles.ts` com `styled(...)` e use `<S.Componente>`.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='theme'][callee.property.name='spacing']",
+          message:
+            'Use o helper `spacing()` do design system. O `theme.spacing` é do MUI e sobrescrevê-lo encolhe os componentes dele (as gutters do Toolbar viraram 3px).',
+        },
+        {
+          selector: "CallExpression[callee.name='styled'] > Literal:first-child",
+          message:
+            'Sem tag HTML crua: use `styled(Stack)` quando for flex e `styled(Box)` no resto, com a semântica na prop `component`.',
+        },
+      ],
+    },
+  },
+
+  // Cor literal só pode existir nos tokens.
+  {
+    files: ['src/**/styles.ts', 'src/**/*.styles.ts', 'src/**/GlobalStyles.tsx'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Literal[value=/^#[0-9a-fA-F]{3,8}$/]',
+          message: 'Sem cor literal. Leia de `theme.palette`; se falta um slot, declare-o na paleta.',
+        },
+        {
+          selector: 'Literal[value=/^rgba?\\(/]',
+          message: 'Sem cor literal. Leia de `theme.palette`; se falta um slot, declare-o na paleta.',
+        },
+      ],
+    },
+  },
+
+  // O design system não conhece a aplicação — é o que o mantém extraível.
+  {
+    files: ['src/design-system/**/*.{ts,tsx}'],
+    ignores: ['src/design-system/**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@app/*'],
+              message:
+                'O design system não importa da aplicação. Receba o que precisa por propriedade ou slot.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   prettierRecommended,
 );

--- a/FateConnect/Web/package.json
+++ b/FateConnect/Web/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@hookform/resolvers": "^5.9.1",
     "@mui/icons-material": "^9.3.1",
     "@mui/material": "^9.3.1",
     "@mui/x-date-pickers": "^9.11.0",
@@ -30,7 +31,9 @@
     "notistack": "^3.0.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-router": "^8.3.0"
+    "react-hook-form": "^7.85.0",
+    "react-router": "^8.3.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/FateConnect/Web/package.json
+++ b/FateConnect/Web/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src --report-unused-disable-directives",
+    "lint": "eslint src --report-unused-disable-directives --max-warnings=0",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "test": "vitest",

--- a/FateConnect/Web/src/design-system/GlobalStyles.tsx
+++ b/FateConnect/Web/src/design-system/GlobalStyles.tsx
@@ -7,7 +7,8 @@ export function GlobalStyles() {
   return (
     <GlobalStylesBase
       styles={{
-        '*, *::before, *::after': { boxSizing: 'border-box' },
+        // Mesmo reset do produto: zera margem e recuo de todo elemento.
+        '*, *::before, *::after': { boxSizing: 'border-box', margin: 0, padding: 0 },
         html: { scrollBehavior: 'smooth' },
         // Compensa o topo fixo ao rolar até uma seção pelo fragmento da URL.
         '[id]': { scrollMarginTop: '5rem' },

--- a/FateConnect/Web/src/design-system/GlobalStyles.tsx
+++ b/FateConnect/Web/src/design-system/GlobalStyles.tsx
@@ -1,12 +1,12 @@
 import GlobalStylesBase from '@mui/material/GlobalStyles';
 
-import { colorTokens, fontFamily } from './tokens';
+import { fontFamily } from './tokens';
 
 /** Reset mínimo e base tipográfica do documento. */
 export function GlobalStyles() {
   return (
     <GlobalStylesBase
-      styles={{
+      styles={(theme) => ({
         // Mesmo reset do produto: zera margem e recuo de todo elemento.
         '*, *::before, *::after': { boxSizing: 'border-box', margin: 0, padding: 0 },
         html: { scrollBehavior: 'smooth' },
@@ -15,13 +15,16 @@ export function GlobalStyles() {
         'html, body, #root': { height: '100%' },
         body: {
           margin: 0,
+          // O CssBaseline do MUI aplica `antialiased`, que afina o texto. O produto
+          // usa o padrão do navegador — sem isso, todo peso parece um grau menor.
+          WebkitFontSmoothing: 'auto',
+          MozOsxFontSmoothing: 'auto',
           fontFamily,
-          color: colorTokens.primary,
-          backgroundColor: colorTokens.surfaceGray,
-          WebkitFontSmoothing: 'antialiased',
+          color: theme.palette.text.primary,
+          backgroundColor: theme.palette.background.default,
         },
         'a, button': { fontFamily },
-      }}
+      })}
     />
   );
 }

--- a/FateConnect/Web/src/design-system/ThemeProvider/ThemeModeContext.test.tsx
+++ b/FateConnect/Web/src/design-system/ThemeProvider/ThemeModeContext.test.tsx
@@ -1,0 +1,10 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useThemeMode } from './ThemeModeContext';
+
+describe('useThemeMode', () => {
+  it('should fail loudly when used outside the provider', () => {
+    expect(() => renderHook(() => useThemeMode())).toThrow(/ThemeProvider/);
+  });
+});

--- a/FateConnect/Web/src/design-system/ThemeProvider/ThemeModeContext.ts
+++ b/FateConnect/Web/src/design-system/ThemeProvider/ThemeModeContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+
+import type { ThemeMode } from '../theme';
+
+type ThemeModeContextValue = {
+  mode: ThemeMode;
+  toggleMode: VoidFunction;
+};
+
+export const ThemeModeContext = createContext<ThemeModeContextValue | null>(null);
+
+/** Modo de tema corrente e a ação de alternar. Só funciona sob o `ThemeProvider`. */
+export function useThemeMode(): ThemeModeContextValue {
+  const contexto = useContext(ThemeModeContext);
+  if (!contexto) throw new Error('useThemeMode precisa estar dentro do ThemeProvider');
+
+  return contexto;
+}

--- a/FateConnect/Web/src/design-system/ThemeProvider/index.tsx
+++ b/FateConnect/Web/src/design-system/ThemeProvider/index.tsx
@@ -1,21 +1,35 @@
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
-import { useMemo, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
 
 import { GlobalStyles } from '../GlobalStyles';
-import { createAppTheme } from '../theme';
+import { createAppTheme, type ThemeMode } from '../theme';
+import { ThemeModeContext } from './ThemeModeContext';
 
-type ThemeProviderProps = { children: ReactNode };
+type ThemeProviderProps = {
+  children: ReactNode;
+  /** Modo inicial; o usuário alterna a partir daí. */
+  defaultMode?: ThemeMode;
+};
 
 /** Único ponto onde o tema é criado e injetado na árvore. */
-export function ThemeProvider({ children }: ThemeProviderProps) {
-  const theme = useMemo(() => createAppTheme(), []);
+export function ThemeProvider({ children, defaultMode = 'light' }: ThemeProviderProps) {
+  const [mode, setMode] = useState<ThemeMode>(defaultMode);
+
+  const toggleMode = useCallback(() => {
+    setMode((atual) => (atual === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const theme = useMemo(() => createAppTheme(mode), [mode]);
+  const contexto = useMemo(() => ({ mode, toggleMode }), [mode, toggleMode]);
 
   return (
-    <MuiThemeProvider theme={theme}>
-      <CssBaseline />
-      <GlobalStyles />
-      {children}
-    </MuiThemeProvider>
+    <ThemeModeContext.Provider value={contexto}>
+      <MuiThemeProvider theme={theme}>
+        <CssBaseline />
+        <GlobalStyles />
+        {children}
+      </MuiThemeProvider>
+    </ThemeModeContext.Provider>
   );
 }

--- a/FateConnect/Web/src/design-system/components/Footer/index.tsx
+++ b/FateConnect/Web/src/design-system/components/Footer/index.tsx
@@ -3,13 +3,7 @@ import LocationOnIcon from '@mui/icons-material/LocationOn';
 import PhoneIcon from '@mui/icons-material/Phone';
 import Typography from '@mui/material/Typography';
 
-import {
-  ContactItem,
-  ContactsContainer,
-  CopyrightContainer,
-  FooterDivider,
-  FooterRoot,
-} from './styles';
+import * as S from './styles';
 
 type FooterProps = {
   /** Id da âncora usada pela navegação da aplicação. */
@@ -21,33 +15,33 @@ type FooterProps = {
 
 export function Footer({ anchorId, title, contact, copyrightLines }: FooterProps) {
   return (
-    <FooterRoot>
-      <ContactsContainer id={anchorId}>
+    <S.FooterRoot>
+      <S.ContactsContainer id={anchorId}>
         <Typography variant="h2">{title}</Typography>
 
-        <ContactItem>
+        <S.ContactItem>
           <EmailIcon fontSize="small" />
           <Typography variant="caption">{contact.email}</Typography>
-        </ContactItem>
-        <ContactItem>
+        </S.ContactItem>
+        <S.ContactItem>
           <PhoneIcon fontSize="small" />
           <Typography variant="caption">{contact.phone}</Typography>
-        </ContactItem>
-        <ContactItem>
+        </S.ContactItem>
+        <S.ContactItem>
           <LocationOnIcon fontSize="small" />
           <Typography variant="caption">{contact.address}</Typography>
-        </ContactItem>
-      </ContactsContainer>
+        </S.ContactItem>
+      </S.ContactsContainer>
 
-      <FooterDivider />
+      <S.FooterDivider />
 
-      <CopyrightContainer>
+      <S.CopyrightContainer>
         {copyrightLines.map((line) => (
           <Typography key={line} variant="caption">
             {line}
           </Typography>
         ))}
-      </CopyrightContainer>
-    </FooterRoot>
+      </S.CopyrightContainer>
+    </S.FooterRoot>
   );
 }

--- a/FateConnect/Web/src/design-system/components/Footer/index.tsx
+++ b/FateConnect/Web/src/design-system/components/Footer/index.tsx
@@ -15,7 +15,7 @@ type FooterProps = {
 
 export function Footer({ anchorId, title, contact, copyrightLines }: FooterProps) {
   return (
-    <S.FooterRoot>
+    <S.FooterRoot component="footer">
       <S.ContactsContainer id={anchorId}>
         <Typography variant="h2">{title}</Typography>
 

--- a/FateConnect/Web/src/design-system/components/Footer/styles.ts
+++ b/FateConnect/Web/src/design-system/components/Footer/styles.ts
@@ -1,5 +1,9 @@
 import { styled } from '../../styled';
-import { colorTokens, mobileMedia, spacingScale } from '../../tokens';
+import { chromeSurface, onChromeSurface } from '../../theme/chromeSurface';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import type { PolymorphicProps } from '../../styled';
+import { mobileMedia, spacingScale } from '../../tokens';
 import { spacing } from '../../theme/helpers/spacing';
 
 const { md, xs } = spacingScale;
@@ -9,12 +13,11 @@ const { md, xs } = spacingScale;
  * assinatura à direita, divisor vertical entre eles) e coluna centralizada
  * abaixo do breakpoint mobile. Paddings em `vw`, como no original.
  */
-export const FooterRoot = styled('footer')({
-  display: 'flex',
+export const FooterRoot = styled(Stack)<PolymorphicProps>(({ theme }) => ({
   flexDirection: 'row',
   justifyContent: 'space-between',
-  backgroundColor: colorTokens.primary,
-  color: colorTokens.textOnAccent,
+  backgroundColor: chromeSurface(theme),
+  color: onChromeSurface(theme),
   padding: '3vw 7vw',
   gap: spacing(md),
   width: '100%',
@@ -24,10 +27,9 @@ export const FooterRoot = styled('footer')({
     alignItems: 'center',
     padding: '7vw',
   },
-});
+}));
 
-export const ContactsContainer = styled('div')({
-  display: 'flex',
+export const ContactsContainer = styled(Stack)<PolymorphicProps>({
   flexDirection: 'column',
   justifyContent: 'center',
   gap: spacing(md),
@@ -36,24 +38,22 @@ export const ContactsContainer = styled('div')({
   [mobileMedia]: { alignItems: 'center' },
 });
 
-export const ContactItem = styled('div')({
-  display: 'flex',
+export const ContactItem = styled(Stack)<PolymorphicProps>({
   flexDirection: 'row',
   alignItems: 'center',
   gap: spacing(xs),
 });
 
 /** Vertical no desktop, horizontal no mobile. */
-export const FooterDivider = styled('div')({
+export const FooterDivider = styled(Box)<PolymorphicProps>(({ theme }) => ({
   width: '1px',
   height: 'auto',
-  backgroundColor: colorTokens.divider,
+  backgroundColor: theme.palette.divider,
 
   [mobileMedia]: { width: '100%', height: '1px' },
-});
+}));
 
-export const CopyrightContainer = styled('div')({
-  display: 'flex',
+export const CopyrightContainer = styled(Stack)<PolymorphicProps>({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'flex-end',

--- a/FateConnect/Web/src/design-system/components/Header/index.tsx
+++ b/FateConnect/Web/src/design-system/components/Header/index.tsx
@@ -10,6 +10,8 @@ type HeaderProps = {
   logo: ReactNode;
   /** Navegação exibida acima do breakpoint mobile. */
   navigation: ReactNode;
+  /** Ações fixas à direita, visíveis em qualquer largura. */
+  actions?: ReactNode;
   onMenuClick: VoidFunction;
   menuButtonLabel: string;
 };
@@ -18,19 +20,23 @@ type HeaderProps = {
  * Cromo do topo: barra fixa, faixa de navegação responsiva e botão de menu.
  * Recebe conteúdo por slot para não depender de rotas nem de hooks da aplicação.
  */
-export function Header({ logo, navigation, onMenuClick, menuButtonLabel }: HeaderProps) {
+export function Header({ logo, navigation, actions, onMenuClick, menuButtonLabel }: HeaderProps) {
   return (
     <S.HeaderBar position="fixed">
       <S.HeaderToolbar disableGutters>
-        <S.LogoSlot>{logo}</S.LogoSlot>
+        <S.LogoSlot component="span">{logo}</S.LogoSlot>
 
-        <S.DesktopNav>{navigation}</S.DesktopNav>
+        <S.DesktopNav component="nav">{navigation}</S.DesktopNav>
 
-        <S.MenuButtonSlot>
-          <IconButton color="inherit" aria-label={menuButtonLabel} onClick={onMenuClick}>
-            <MenuIcon />
-          </IconButton>
-        </S.MenuButtonSlot>
+        <S.ActionsSlot component="span">
+          {actions}
+
+          <S.MenuButtonSlot component="span">
+            <IconButton color="inherit" aria-label={menuButtonLabel} onClick={onMenuClick}>
+              <MenuIcon />
+            </IconButton>
+          </S.MenuButtonSlot>
+        </S.ActionsSlot>
       </S.HeaderToolbar>
     </S.HeaderBar>
   );

--- a/FateConnect/Web/src/design-system/components/Header/index.tsx
+++ b/FateConnect/Web/src/design-system/components/Header/index.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 
-import { DesktopNav, HeaderBar, HeaderToolbar, LogoSlot, MenuButtonSlot } from './styles';
+import * as S from './styles';
 
 type HeaderProps = {
   /** Marca à esquerda. A aplicação decide para onde ela navega. */
@@ -20,18 +20,18 @@ type HeaderProps = {
  */
 export function Header({ logo, navigation, onMenuClick, menuButtonLabel }: HeaderProps) {
   return (
-    <HeaderBar position="fixed">
-      <HeaderToolbar disableGutters>
-        <LogoSlot>{logo}</LogoSlot>
+    <S.HeaderBar position="fixed">
+      <S.HeaderToolbar disableGutters>
+        <S.LogoSlot>{logo}</S.LogoSlot>
 
-        <DesktopNav>{navigation}</DesktopNav>
+        <S.DesktopNav>{navigation}</S.DesktopNav>
 
-        <MenuButtonSlot>
+        <S.MenuButtonSlot>
           <IconButton color="inherit" aria-label={menuButtonLabel} onClick={onMenuClick}>
             <MenuIcon />
           </IconButton>
-        </MenuButtonSlot>
-      </HeaderToolbar>
-    </HeaderBar>
+        </S.MenuButtonSlot>
+      </S.HeaderToolbar>
+    </S.HeaderBar>
   );
 }

--- a/FateConnect/Web/src/design-system/components/Header/styles.ts
+++ b/FateConnect/Web/src/design-system/components/Header/styles.ts
@@ -2,7 +2,11 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 
 import { styled } from '../../styled';
-import { colorTokens, mobileMedia, shadowTokens, spacingScale } from '../../tokens';
+import { onChromeSurface } from '../../theme/chromeSurface';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import type { PolymorphicProps } from '../../styled';
+import { mobileMedia, shadowTokens, spacingScale } from '../../tokens';
 import { spacing } from '../../theme/helpers/spacing';
 
 const { xs } = spacingScale;
@@ -15,53 +19,65 @@ const NAV_FONT_SIZE = '1rem';
 const NAV_FONT_WEIGHT = 500;
 const CTA_FONT_WEIGHT = 400;
 
+/** Espaço horizontal entre os itens do topo — vale também entre a navegação e as ações. */
+const NAV_COLUMN_GAP = '1.5vw';
+
 export const HeaderBar = styled(AppBar)({
   boxShadow: shadowTokens.component,
 });
 
-export const HeaderToolbar = styled(Toolbar)({
+export const HeaderToolbar = styled(Toolbar)(({ theme }) => ({
   height: `${HEADER_HEIGHT_PX}px`,
   minHeight: `${HEADER_HEIGHT_PX}px`,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: '0 7vw',
-  color: colorTokens.textOnAccent,
-});
+  color: onChromeSurface(theme),
+}));
 
 /** Marca: sem sublinhado e herdando a cor da barra, como no produto. */
-export const LogoSlot = styled('span')({
+export const LogoSlot = styled(Box)<PolymorphicProps>(({ theme }) => ({
   '& a': {
     textDecoration: 'none',
-    color: colorTokens.textOnAccent,
+    color: onChromeSurface(theme),
     cursor: 'pointer',
     transition: 'opacity 0.3s ease',
   },
   '& a:hover': { opacity: 0.8 },
-});
+}));
 
-export const DesktopNav = styled('nav')({
-  display: 'flex',
+export const DesktopNav = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
   flexWrap: 'wrap',
   alignItems: 'center',
-  gap: `${spacing(xs)} 1.5vw`,
+  gap: `${spacing(xs)} ${NAV_COLUMN_GAP}`,
+  // Empurra navegação e ações para a direita, mantendo só a marca à esquerda.
+  // Sem isso, o `space-between` distribui os três blocos e centraliza a navegação.
+  marginLeft: 'auto',
 
   '& .MuiButton-root': {
     fontSize: NAV_FONT_SIZE,
     fontWeight: NAV_FONT_WEIGHT,
-    color: colorTokens.textOnAccent,
+    color: onChromeSurface(theme),
   },
   // O destaque não recebe o peso reforçado, como no produto.
   '& .MuiButton-contained': { fontWeight: CTA_FONT_WEIGHT },
 
   [mobileMedia]: { display: 'none' },
+}));
+
+export const ActionsSlot = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  alignItems: 'center',
+  marginLeft: NAV_COLUMN_GAP,
 });
 
-export const MenuButtonSlot = styled('span')({
+export const MenuButtonSlot = styled(Stack)<PolymorphicProps>({
   display: 'none',
 
   [mobileMedia]: {
-    display: 'flex',
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     width: '48px',

--- a/FateConnect/Web/src/design-system/components/NavigationDrawer/index.tsx
+++ b/FateConnect/Web/src/design-system/components/NavigationDrawer/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { DrawerHeader, DrawerList, DrawerRoot } from './styles';
+import * as S from './styles';
 
 type NavigationDrawerProps = {
   open: boolean;
@@ -12,9 +12,9 @@ type NavigationDrawerProps = {
 /** Menu lateral. Quem usa monta o cabeçalho e os itens. */
 export function NavigationDrawer({ open, onClose, header, children }: NavigationDrawerProps) {
   return (
-    <DrawerRoot anchor="right" open={open} onClose={onClose}>
-      <DrawerHeader>{header}</DrawerHeader>
-      <DrawerList>{children}</DrawerList>
-    </DrawerRoot>
+    <S.DrawerRoot anchor="right" open={open} onClose={onClose}>
+      <S.DrawerHeader>{header}</S.DrawerHeader>
+      <S.DrawerList>{children}</S.DrawerList>
+    </S.DrawerRoot>
   );
 }

--- a/FateConnect/Web/src/design-system/components/NavigationDrawer/styles.ts
+++ b/FateConnect/Web/src/design-system/components/NavigationDrawer/styles.ts
@@ -2,7 +2,9 @@ import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
 
 import { styled } from '../../styled';
-import { colorTokens } from '../../tokens';
+import { chromeSurface, onChromeSurface } from '../../theme/chromeSurface';
+import Stack from '@mui/material/Stack';
+import type { PolymorphicProps } from '../../styled';
 
 /** Largura do menu lateral no produto. */
 const DRAWER_WIDTH_PX = 300;
@@ -15,18 +17,18 @@ const LOGO_INSET = '3vw';
 const ITEM_MIN_HEIGHT_PX = 48;
 const ITEM_INLINE_PADDING_PX = 16;
 
-export const DrawerRoot = styled(Drawer)({
+export const DrawerRoot = styled(Drawer)(({ theme }) => ({
   '& .MuiDrawer-paper': {
     width: `${DRAWER_WIDTH_PX}px`,
-    backgroundColor: colorTokens.primary,
-    color: colorTokens.textOnAccent,
+    backgroundColor: chromeSurface(theme),
+    color: onChromeSurface(theme),
     padding: `${DRAWER_VERTICAL_PADDING} 0`,
     overflowX: 'hidden',
   },
-});
+}));
 
-export const DrawerHeader = styled('div')({
-  display: 'flex',
+export const DrawerHeader = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
   justifyContent: 'start',
   alignItems: 'center',
   width: '100%',
@@ -35,12 +37,12 @@ export const DrawerHeader = styled('div')({
 
   '& a': {
     textDecoration: 'none',
-    color: colorTokens.textOnAccent,
+    color: onChromeSurface(theme),
     cursor: 'pointer',
   },
-});
+}));
 
-export const DrawerList = styled(List)({
+export const DrawerList = styled(List)(({ theme }) => ({
   paddingLeft: 0,
 
   '& .MuiListItemButton-root': {
@@ -48,10 +50,10 @@ export const DrawerList = styled(List)({
     paddingLeft: `${ITEM_INLINE_PADDING_PX}px`,
     paddingRight: `${ITEM_INLINE_PADDING_PX}px`,
   },
-  '& .MuiListItemButton-root:hover': { backgroundColor: colorTokens.surfaceHover },
+  '& .MuiListItemButton-root:hover': { backgroundColor: theme.palette.action.hover },
   '& .MuiListItemText-primary': {
-    color: colorTokens.textOnAccent,
+    color: onChromeSurface(theme),
     fontSize: '1rem',
     fontWeight: 400,
   },
-});
+}));

--- a/FateConnect/Web/src/design-system/components/ThemeToggleButton/ThemeToggleButton.test.tsx
+++ b/FateConnect/Web/src/design-system/components/ThemeToggleButton/ThemeToggleButton.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen, userEvent } from '@app/test/testing-library';
+import { ThemeToggleButton } from '.';
+
+const PARA_ESCURO = 'Ativar tema escuro';
+const PARA_CLARO = 'Ativar tema claro';
+
+/** Lê a cor de fundo aplicada pelo tema ao corpo do documento. */
+function fundoDoDocumento() {
+  return getComputedStyle(document.body).backgroundColor;
+}
+
+describe('ThemeToggleButton', () => {
+  it('should offer the dark theme while the light one is active', () => {
+    render(<ThemeToggleButton />);
+
+    expect(screen.getByRole('button', { name: PARA_ESCURO })).toBeInTheDocument();
+  });
+
+  it('should show an icon that reflects the active mode', async () => {
+    render(<ThemeToggleButton />);
+
+    // Modo claro: sol. O ícone mostra o modo atual, não o destino do clique.
+    expect(screen.getByTestId('LightModeIcon')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: PARA_ESCURO }));
+
+    expect(screen.getByTestId('DarkModeIcon')).toBeInTheDocument();
+  });
+
+  it('should switch the theme and flip its own label when clicked', async () => {
+    render(<ThemeToggleButton />);
+    const fundoClaro = fundoDoDocumento();
+
+    await userEvent.click(screen.getByRole('button', { name: PARA_ESCURO }));
+
+    expect(screen.getByRole('button', { name: PARA_CLARO })).toBeInTheDocument();
+    expect(fundoDoDocumento()).not.toBe(fundoClaro);
+  });
+
+  it('should return to the light theme on a second click', async () => {
+    render(<ThemeToggleButton />);
+    const fundoClaro = fundoDoDocumento();
+
+    await userEvent.click(screen.getByRole('button', { name: PARA_ESCURO }));
+    await userEvent.click(screen.getByRole('button', { name: PARA_CLARO }));
+
+    expect(fundoDoDocumento()).toBe(fundoClaro);
+  });
+});

--- a/FateConnect/Web/src/design-system/components/ThemeToggleButton/index.tsx
+++ b/FateConnect/Web/src/design-system/components/ThemeToggleButton/index.tsx
@@ -1,0 +1,24 @@
+import IconButton from '@mui/material/IconButton';
+
+import { useThemeMode } from '../../ThemeProvider/ThemeModeContext';
+import { DarkModeIcon, LightModeIcon } from '../../ui';
+
+const LABEL_PARA_ESCURO = 'Ativar tema escuro';
+const LABEL_PARA_CLARO = 'Ativar tema claro';
+
+/** Alterna entre o tema claro e o escuro. */
+export function ThemeToggleButton() {
+  const { mode, toggleMode } = useThemeMode();
+  const estaClaro = mode === 'light';
+
+  return (
+    <IconButton
+      color="inherit"
+      aria-label={estaClaro ? LABEL_PARA_ESCURO : LABEL_PARA_CLARO}
+      onClick={toggleMode}
+    >
+      {/* O ícone mostra o modo atual; o rótulo descreve a ação do clique. */}
+      {estaClaro ? <LightModeIcon /> : <DarkModeIcon />}
+    </IconButton>
+  );
+}

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -5,7 +5,7 @@
  * é o que mantém barato extrair esta camada para um pacote no futuro.
  */
 export * from './ui';
-export { styled, css, keyframes } from './styled';
+export { styled, css, keyframes, darken, lighten, alpha } from './styled';
 
 export { Header } from './components/Header';
 export { HEADER_HEIGHT_PX } from './components/Header/styles';
@@ -24,6 +24,8 @@ export {
   fontFamily,
   typographyTokens,
   MOBILE_MAX_WIDTH_PX,
+  TABLET_MAX_WIDTH_PX,
   mobileMedia,
+  tabletMedia,
 } from './tokens';
 export type { SpacingToken, RadiusToken, TypographyToken } from './tokens';

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -6,6 +6,7 @@
  */
 export * from './ui';
 export { styled, css, keyframes, darken, lighten, alpha } from './styled';
+export type { PolymorphicProps } from './styled';
 
 export { Header } from './components/Header';
 export { HEADER_HEIGHT_PX } from './components/Header/styles';
@@ -13,6 +14,8 @@ export { Footer } from './components/Footer';
 export { NavigationDrawer } from './components/NavigationDrawer';
 
 export { ThemeProvider } from './ThemeProvider';
+export { useThemeMode } from './ThemeProvider/ThemeModeContext';
+export { ThemeToggleButton } from './components/ThemeToggleButton';
 export { GlobalStyles } from './GlobalStyles';
 export { createAppTheme, spacing, radius, components } from './theme';
 export {

--- a/FateConnect/Web/src/design-system/styled.ts
+++ b/FateConnect/Web/src/design-system/styled.ts
@@ -2,6 +2,7 @@ import type { Theme as AppTheme } from '@mui/material/styles';
 
 export { css, keyframes } from '@emotion/react';
 export { default as styled } from '@emotion/styled';
+export { darken, lighten, alpha } from '@mui/material/styles';
 
 /**
  * O `styled` do Emotion tipa `theme` como `Theme` do `@emotion/react`, que é

--- a/FateConnect/Web/src/design-system/styled.ts
+++ b/FateConnect/Web/src/design-system/styled.ts
@@ -13,3 +13,12 @@ declare module '@emotion/react' {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   export interface Theme extends AppTheme {}
 }
+
+import type { ElementType } from 'react';
+
+/**
+ * O `styled` do Emotion não preserva a assinatura polimórfica do `Box`, então a
+ * prop `component` some da tipagem. Declarar este genérico devolve a prop:
+ * `styled(Box)<PolymorphicProps>({ ... })`.
+ */
+export type PolymorphicProps = { component?: ElementType };

--- a/FateConnect/Web/src/design-system/theme/chromeSurface.ts
+++ b/FateConnect/Web/src/design-system/theme/chromeSurface.ts
@@ -1,0 +1,24 @@
+import type { Theme } from '@mui/material/styles';
+
+/**
+ * Cor de fundo do cromo da aplicação — topo, rodapé e menu lateral.
+ *
+ * No tema claro é a cor de marca, como no produto. No escuro, o sistema de cor
+ * do Material Design pede superfície neutra elevada em vez da cor de marca:
+ * marca saturada em área grande cansa a vista e reduz a hierarquia.
+ */
+export function chromeSurface(theme: Theme): string {
+  if (theme.palette.mode === 'dark') return theme.palette.background.paper;
+
+  return theme.palette.primary.main;
+}
+
+/**
+ * Cor do conteúdo sobre o cromo. Acompanha `chromeSurface`: no claro é o texto
+ * sobre a cor de marca; no escuro, o texto de alta ênfase sobre superfície.
+ */
+export function onChromeSurface(theme: Theme): string {
+  if (theme.palette.mode === 'dark') return theme.palette.text.primary;
+
+  return theme.palette.primary.contrastText;
+}

--- a/FateConnect/Web/src/design-system/theme/components.ts
+++ b/FateConnect/Web/src/design-system/theme/components.ts
@@ -1,6 +1,7 @@
 import type { Components, Theme } from '@mui/material/styles';
 
-import { colorTokens, radiusScale, shadowTokens } from '../tokens';
+import { radiusScale, shadowTokens } from '../tokens';
+import { chromeSurface } from './chromeSurface';
 import { radius } from './helpers/radius';
 
 /** Overrides de componente do MUI alinhados ao visual já implementado no produto. */
@@ -20,6 +21,8 @@ export const components: Components<Theme> = {
   MuiDialog: { styleOverrides: { paper: { borderRadius: radius(radiusScale.lg) } } },
   MuiAppBar: {
     defaultProps: { elevation: 0 },
-    styleOverrides: { root: { backgroundColor: colorTokens.primary } },
+    styleOverrides: {
+      root: ({ theme }) => ({ backgroundColor: chromeSurface(theme) }),
+    },
   },
 };

--- a/FateConnect/Web/src/design-system/theme/contrast.test.ts
+++ b/FateConnect/Web/src/design-system/theme/contrast.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { AA_NORMAL_TEXT, contrastRatio } from './contrast';
+import { chromeSurface, onChromeSurface } from './chromeSurface';
+import { createAppTheme } from './createAppTheme';
+
+const lightTheme = createAppTheme('light');
+const darkTheme = createAppTheme('dark');
+
+describe('contrastRatio', () => {
+  it('should return the known ratios for the reference pairs', () => {
+    expect(contrastRatio('#FFFFFF', '#000000')).toBeCloseTo(21, 1);
+    expect(contrastRatio('#FFFFFF', '#FFFFFF')).toBeCloseTo(1, 1);
+  });
+
+  it('should flatten a translucent colour over its background before measuring', () => {
+    // Branco a 50% sobre preto equivale a um cinza médio, não a branco puro.
+    const meioBranco = contrastRatio('rgba(255, 255, 255, 0.5)', '#000000');
+
+    expect(meioBranco).toBeLessThan(contrastRatio('#FFFFFF', '#000000'));
+    expect(meioBranco).toBeGreaterThan(1);
+  });
+
+  it('should accept an rgb colour without an alpha channel', () => {
+    expect(contrastRatio('rgb(255, 255, 255)', '#000000')).toBeCloseTo(21, 1);
+  });
+
+  it('should reject a colour it cannot read', () => {
+    expect(() => contrastRatio('vermelho', '#FFFFFF')).toThrow(/não reconhecida/);
+  });
+});
+
+describe('light theme contrast', () => {
+  const { palette } = lightTheme;
+
+  it.each([
+    ['body text on the page background', palette.text.primary, palette.background.default],
+    ['body text on a surface', palette.text.primary, palette.background.paper],
+    ['secondary text on a surface', palette.text.secondary, palette.background.paper],
+    ['content on the primary colour', palette.primary.contrastText, palette.primary.main],
+    ['content on the secondary colour', palette.secondary.contrastText, palette.secondary.main],
+    ['content on the error colour', palette.error.contrastText, palette.error.main],
+    ['content on the app chrome', onChromeSurface(lightTheme), chromeSurface(lightTheme)],
+  ])('should meet AA for %s', (_, foreground, background) => {
+    expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+  });
+});
+
+describe('dark theme contrast', () => {
+  const { palette } = darkTheme;
+
+  it.each([
+    ['body text on the page background', palette.text.primary, palette.background.default],
+    ['body text on an elevated surface', palette.text.primary, palette.background.paper],
+    ['secondary text on the page background', palette.text.secondary, palette.background.default],
+    ['the primary colour on the background', palette.primary.main, palette.background.default],
+    ['the secondary colour on the background', palette.secondary.main, palette.background.default],
+    ['the error colour on the background', palette.error.main, palette.background.default],
+    ['content on the app chrome', onChromeSurface(darkTheme), chromeSurface(darkTheme)],
+  ])('should meet AA for %s', (_, foreground, background) => {
+    expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+  });
+});

--- a/FateConnect/Web/src/design-system/theme/contrast.ts
+++ b/FateConnect/Web/src/design-system/theme/contrast.ts
@@ -1,0 +1,61 @@
+/** Canal linearizado, conforme a definição de luminância relativa da WCAG. */
+function canalLinear(valor: number): number {
+  const normalizado = valor / 255;
+
+  if (normalizado <= 0.03928) return normalizado / 12.92;
+  return ((normalizado + 0.055) / 1.055) ** 2.4;
+}
+
+function canaisDe(texto: string): number[] {
+  return texto.split(',').map((parte) => Number(parte));
+}
+
+function toRgb(color: string): [number, number, number] {
+  const hex = /^#([0-9a-f]{6})$/i.exec(color.trim())?.[1];
+  if (hex) {
+    const [r, g, b] = [0, 2, 4].map((i) => parseInt(hex.slice(i, i + 2), 16));
+    return [r ?? 0, g ?? 0, b ?? 0];
+  }
+
+  const conteudo = /rgba?\(([^)]+)\)/.exec(color)?.[1];
+  if (!conteudo) throw new Error(`Cor não reconhecida: ${color}`);
+
+  const [r, g, b] = canaisDe(conteudo);
+  return [r ?? 0, g ?? 0, b ?? 0];
+}
+
+/**
+ * Achata uma cor com transparência sobre um fundo opaco. As "on colors" do
+ * tema escuro usam alfa, e o contraste precisa ser medido na cor resultante.
+ */
+function achatar(color: string, background: string): [number, number, number] {
+  const conteudo = /rgba\(([^)]+)\)/.exec(color)?.[1];
+  if (!conteudo) return toRgb(color);
+
+  const partes = canaisDe(conteudo);
+  const alfa = partes[3] ?? 1;
+  const fundo = toRgb(background);
+  const [r, g, b] = [0, 1, 2].map((i) => (partes[i] ?? 0) * alfa + (fundo[i] ?? 0) * (1 - alfa));
+
+  return [r ?? 0, g ?? 0, b ?? 0];
+}
+
+export function relativeLuminance(color: string, background = '#FFFFFF'): number {
+  const [r, g, b] = achatar(color, background);
+
+  return 0.2126 * canalLinear(r) + 0.7152 * canalLinear(g) + 0.0722 * canalLinear(b);
+}
+
+/** Razão de contraste da WCAG entre duas cores, de 1:1 a 21:1. */
+export function contrastRatio(foreground: string, background: string): number {
+  const luminanciaTexto = relativeLuminance(foreground, background);
+  const luminanciaFundo = relativeLuminance(background, background);
+  const clara = Math.max(luminanciaTexto, luminanciaFundo);
+  const escura = Math.min(luminanciaTexto, luminanciaFundo);
+
+  return (clara + 0.05) / (escura + 0.05);
+}
+
+/** Mínimos da WCAG nível AA. */
+export const AA_NORMAL_TEXT = 4.5;
+export const AA_LARGE_TEXT = 3;

--- a/FateConnect/Web/src/design-system/theme/createAppTheme.ts
+++ b/FateConnect/Web/src/design-system/theme/createAppTheme.ts
@@ -2,7 +2,8 @@ import { ptBR as corePtBR } from '@mui/material/locale';
 import { createTheme, type Theme } from '@mui/material/styles';
 import { ptBR as pickersPtBR } from '@mui/x-date-pickers/locales';
 
-import { colorTokens, fontFamily, typographyTokens } from '../tokens';
+import { fontFamily, typographyTokens } from '../tokens';
+import { darkPalette, lightPalette } from './palettes';
 import { components } from './components';
 
 /** Acima deste ponto o `h1` usa o tamanho cheio; abaixo, o reduzido. */
@@ -33,22 +34,16 @@ declare module '@mui/material/Typography' {
   }
 }
 
-export function createAppTheme(): Theme {
+export type ThemeMode = 'light' | 'dark';
+
+/** Modo claro é o padrão; o escuro segue o sistema de cor do Material Design. */
+export function createAppTheme(mode: ThemeMode = 'light'): Theme {
   const base = createTheme();
 
   return createTheme(
     {
       components,
-      palette: {
-        primary: { main: colorTokens.primary, contrastText: colorTokens.textOnAccent },
-        secondary: { main: colorTokens.accent, contrastText: colorTokens.textOnAccent },
-        error: { main: colorTokens.dangerText },
-        success: { main: colorTokens.successText },
-        warning: { main: colorTokens.warningText },
-        background: { default: colorTokens.surfaceGray, paper: colorTokens.surfaceWhite },
-        text: { primary: colorTokens.primary, secondary: colorTokens.textMuted },
-        divider: colorTokens.divider,
-      },
+      palette: mode === 'dark' ? darkPalette : lightPalette,
       typography: {
         fontFamily,
         h1: {

--- a/FateConnect/Web/src/design-system/theme/index.ts
+++ b/FateConnect/Web/src/design-system/theme/index.ts
@@ -1,4 +1,8 @@
 export { createAppTheme } from './createAppTheme';
+export type { ThemeMode } from './createAppTheme';
+export { contrastRatio, AA_NORMAL_TEXT, AA_LARGE_TEXT } from './contrast';
+export { lightPalette, darkPalette } from './palettes';
+export { chromeSurface, onChromeSurface } from './chromeSurface';
 export { spacing } from './helpers/spacing';
 export { radius } from './helpers/radius';
 export { components } from './components';

--- a/FateConnect/Web/src/design-system/theme/palettes.ts
+++ b/FateConnect/Web/src/design-system/theme/palettes.ts
@@ -1,0 +1,72 @@
+import type { PaletteOptions } from '@mui/material/styles';
+
+import { colorTokens, colorVariants, darkColorTokens } from '../tokens';
+
+/**
+ * Paletas construídas segundo o sistema de cor do Material Design: cada cor de
+ * marca tem `light`, `main` e `dark`, e cada superfície declara a cor do
+ * conteúdo que vai sobre ela (`contrastText`, `text.*`).
+ *
+ * As razões de contraste são verificadas em `contrast.test.ts`.
+ */
+export const lightPalette: PaletteOptions = {
+  mode: 'light',
+  primary: {
+    light: colorVariants.primaryLight,
+    main: colorTokens.primary,
+    dark: colorVariants.primaryDark,
+    contrastText: colorTokens.textOnAccent,
+  },
+  secondary: {
+    light: colorVariants.secondaryLight,
+    main: colorTokens.accent,
+    dark: colorVariants.secondaryDark,
+    // Branco puro: o branco a 90% do produto ficava em 4.42:1, abaixo de AA.
+    contrastText: colorTokens.surfaceWhite,
+  },
+  error: {
+    light: colorTokens.errorInherited,
+    main: colorTokens.error,
+    dark: colorVariants.errorDark,
+    contrastText: colorTokens.surfaceWhite,
+  },
+  success: { main: colorTokens.successText, light: colorTokens.successBackground },
+  warning: { main: colorTokens.warningText, light: colorTokens.warningBackground },
+  background: { default: colorTokens.surfaceGray, paper: colorTokens.surfaceWhite },
+  text: {
+    primary: colorTokens.primary,
+    secondary: colorTokens.textMuted,
+    disabled: colorTokens.textOnGray,
+  },
+  action: { hover: colorTokens.surfaceHover },
+  divider: colorTokens.divider,
+};
+
+export const darkPalette: PaletteOptions = {
+  mode: 'dark',
+  primary: {
+    main: darkColorTokens.primary,
+    contrastText: darkColorTokens.surface,
+  },
+  secondary: {
+    main: darkColorTokens.secondary,
+    contrastText: darkColorTokens.surface,
+  },
+  error: {
+    main: darkColorTokens.error,
+    contrastText: darkColorTokens.surface,
+  },
+  success: { main: colorTokens.successBackground },
+  warning: { main: colorTokens.warningBackground },
+  background: {
+    default: darkColorTokens.surface,
+    paper: darkColorTokens.surfaceElevated,
+  },
+  text: {
+    primary: darkColorTokens.onSurfaceHigh,
+    secondary: darkColorTokens.onSurfaceMedium,
+    disabled: darkColorTokens.onSurfaceDisabled,
+  },
+  action: { hover: darkColorTokens.hover },
+  divider: darkColorTokens.divider,
+};

--- a/FateConnect/Web/src/design-system/tokens/breakpoints.ts
+++ b/FateConnect/Web/src/design-system/tokens/breakpoints.ts
@@ -1,8 +1,12 @@
 /**
- * Largura máxima tratada como mobile. Reproduz o breakpoint já usado no produto
- * (`max-width: 768px`), que não coincide com o `md` padrão do MUI (900px).
+ * Larguras máximas dos breakpoints do produto. Não coincidem com os do MUI
+ * (`md` = 900px), por isso são declaradas aqui e usadas direto nos estilos.
  */
 export const MOBILE_MAX_WIDTH_PX = 768;
+export const TABLET_MAX_WIDTH_PX = 968;
 
-/** Media query de mobile, para uso direto nos arquivos de estilo. */
+/** Media query de mobile (topo, rodapé, menu lateral, cartões). */
 export const mobileMedia = `@media (max-width: ${MOBILE_MAX_WIDTH_PX}px)`;
+
+/** Media query intermediária usada pela landing para empilhar apresentação e login. */
+export const tabletMedia = `@media (max-width: ${TABLET_MAX_WIDTH_PX}px)`;

--- a/FateConnect/Web/src/design-system/tokens/index.ts
+++ b/FateConnect/Web/src/design-system/tokens/index.ts
@@ -2,7 +2,13 @@ export { spacingScale } from './spacing';
 export type { SpacingToken } from './spacing';
 export { radiusScale } from './radius';
 export type { RadiusToken } from './radius';
-export { colorTokens, shadowTokens, iconSizeTokens } from './palette';
+export {
+  colorTokens,
+  colorVariants,
+  darkColorTokens,
+  shadowTokens,
+  iconSizeTokens,
+} from './palette';
 export { fontFamily, typographyTokens } from './typography';
 export { MOBILE_MAX_WIDTH_PX, TABLET_MAX_WIDTH_PX, mobileMedia, tabletMedia } from './breakpoints';
 export type { TypographyToken } from './typography';

--- a/FateConnect/Web/src/design-system/tokens/index.ts
+++ b/FateConnect/Web/src/design-system/tokens/index.ts
@@ -4,5 +4,5 @@ export { radiusScale } from './radius';
 export type { RadiusToken } from './radius';
 export { colorTokens, shadowTokens, iconSizeTokens } from './palette';
 export { fontFamily, typographyTokens } from './typography';
-export { MOBILE_MAX_WIDTH_PX, mobileMedia } from './breakpoints';
+export { MOBILE_MAX_WIDTH_PX, TABLET_MAX_WIDTH_PX, mobileMedia, tabletMedia } from './breakpoints';
 export type { TypographyToken } from './typography';

--- a/FateConnect/Web/src/design-system/tokens/palette.ts
+++ b/FateConnect/Web/src/design-system/tokens/palette.ts
@@ -3,6 +3,13 @@ export const colorTokens = {
   primary: '#43545C',
   accent: '#CF2E2E',
 
+  /**
+   * Vermelho do botão de acesso na landing. **Não é o acento do produto.**
+   * O front atual usa a paleta `warn` do Material sem configurá-la, então herda
+   * o vermelho padrão da biblioteca. Mantido aqui por paridade visual.
+   */
+  inheritedWarn: '#F44336',
+
   surfaceGray: '#F0F2F4',
   surfaceWhite: '#FFFFFF',
   surfaceHover: 'rgba(255, 255, 255, 0.6)',

--- a/FateConnect/Web/src/design-system/tokens/palette.ts
+++ b/FateConnect/Web/src/design-system/tokens/palette.ts
@@ -4,11 +4,12 @@ export const colorTokens = {
   accent: '#CF2E2E',
 
   /**
-   * Vermelho do botão de acesso na landing. **Não é o acento do produto.**
-   * O front atual usa a paleta `warn` do Material sem configurá-la, então herda
-   * o vermelho padrão da biblioteca. Mantido aqui por paridade visual.
+   * Segundo vermelho do produto, usado no botão de acesso — papel de **erro**.
+   * Escurecido em relação ao herdado (`#F44336`) para alcançar 4.5:1 com texto
+   * branco; o tom original fica como `error.light`.
    */
-  inheritedWarn: '#F44336',
+  error: '#E81C0D',
+  errorInherited: '#F44336',
 
   surfaceGray: '#F0F2F4',
   surfaceWhite: '#FFFFFF',
@@ -33,9 +34,51 @@ export const shadowTokens = {
   component: '0 2px 5px rgba(0, 0, 0, 0.08)',
 };
 
-/** Tamanhos de ícone em pixels. */
+/**
+ * Tamanhos de ícone em pixels.
+ *
+ * `sm` e `lg` acompanham a **largura renderizada** dos ícones do produto, não a
+ * altura: os glifos da biblioteca original são mais largos que altos (20x16 e
+ * 40x32), enquanto os nossos são quadrados. Igualar pela largura mantém a massa
+ * visual equivalente.
+ */
 export const iconSizeTokens = {
-  sm: 16,
+  sm: 20,
   md: 24,
-  lg: 32,
+  lg: 40,
+};
+
+/**
+ * Variantes de cada cor de marca, seguindo a mesma regra do tema atual do
+ * produto: `light` é a base clareada 25% e `dark` é a base escurecida 20%.
+ */
+export const colorVariants = {
+  primaryLight: '#68828F',
+  primaryDark: '#36434A',
+  secondaryLight: '#DC6161',
+  secondaryDark: '#A62525',
+  errorLight: '#F77268',
+  /** Escurecido até alcançar 4.5:1 com texto branco — ver `contrast.test.ts`. */
+  errorDark: '#E81C0D',
+};
+
+/**
+ * Tokens do tema escuro, conforme o sistema de cor do Material Design:
+ * superfície `#121212`, cores de marca dessaturadas para alcançar contraste, e
+ * "on colors" brancos por nível de ênfase (alta 87%, média 60%, desabilitado 38%).
+ */
+export const darkColorTokens = {
+  primary: '#68828E',
+  secondary: '#D84E4E',
+  error: '#F44336',
+
+  surface: '#121212',
+  /** Superfície elevada: sobreposição branca de 5%, como o M2 prescreve para 1dp. */
+  surfaceElevated: '#1E1E1E',
+
+  onSurfaceHigh: 'rgba(255, 255, 255, 0.87)',
+  onSurfaceMedium: 'rgba(255, 255, 255, 0.60)',
+  onSurfaceDisabled: 'rgba(255, 255, 255, 0.38)',
+  divider: 'rgba(255, 255, 255, 0.12)',
+  hover: 'rgba(255, 255, 255, 0.08)',
 };

--- a/FateConnect/Web/src/design-system/ui.ts
+++ b/FateConnect/Web/src/design-system/ui.ts
@@ -5,6 +5,7 @@
  * envolver, substituir ou restringir um componente sem varrer o app inteiro.
  */
 export { default as AppBar } from '@mui/material/AppBar';
+export { default as Box } from '@mui/material/Box';
 export { default as Button } from '@mui/material/Button';
 export { default as Drawer } from '@mui/material/Drawer';
 export { default as InputAdornment } from '@mui/material/InputAdornment';
@@ -12,6 +13,7 @@ export { default as IconButton } from '@mui/material/IconButton';
 export { default as List } from '@mui/material/List';
 export { default as ListItemButton } from '@mui/material/ListItemButton';
 export { default as ListItemText } from '@mui/material/ListItemText';
+export { default as Stack } from '@mui/material/Stack';
 export { default as TextField } from '@mui/material/TextField';
 export { default as Toolbar } from '@mui/material/Toolbar';
 export { default as Typography } from '@mui/material/Typography';
@@ -19,9 +21,12 @@ export { default as Typography } from '@mui/material/Typography';
 export type { ButtonProps } from '@mui/material/Button';
 export type { TypographyProps } from '@mui/material/Typography';
 export type { SvgIconComponent } from '@mui/icons-material';
+export type { BoxProps } from '@mui/material/Box';
 
 export { default as DirectionsCarIcon } from '@mui/icons-material/DirectionsCar';
+export { default as DarkModeIcon } from '@mui/icons-material/DarkMode';
 export { default as EmailIcon } from '@mui/icons-material/Email';
+export { default as LightModeIcon } from '@mui/icons-material/LightMode';
 export { default as GroupsIcon } from '@mui/icons-material/Groups';
 export { default as LocationOnIcon } from '@mui/icons-material/LocationOn';
 export { default as MenuIcon } from '@mui/icons-material/Menu';

--- a/FateConnect/Web/src/design-system/ui.ts
+++ b/FateConnect/Web/src/design-system/ui.ts
@@ -7,17 +7,26 @@
 export { default as AppBar } from '@mui/material/AppBar';
 export { default as Button } from '@mui/material/Button';
 export { default as Drawer } from '@mui/material/Drawer';
+export { default as InputAdornment } from '@mui/material/InputAdornment';
 export { default as IconButton } from '@mui/material/IconButton';
 export { default as List } from '@mui/material/List';
 export { default as ListItemButton } from '@mui/material/ListItemButton';
 export { default as ListItemText } from '@mui/material/ListItemText';
+export { default as TextField } from '@mui/material/TextField';
 export { default as Toolbar } from '@mui/material/Toolbar';
 export { default as Typography } from '@mui/material/Typography';
 
 export type { ButtonProps } from '@mui/material/Button';
 export type { TypographyProps } from '@mui/material/Typography';
+export type { SvgIconComponent } from '@mui/icons-material';
 
+export { default as DirectionsCarIcon } from '@mui/icons-material/DirectionsCar';
 export { default as EmailIcon } from '@mui/icons-material/Email';
+export { default as GroupsIcon } from '@mui/icons-material/Groups';
 export { default as LocationOnIcon } from '@mui/icons-material/LocationOn';
 export { default as MenuIcon } from '@mui/icons-material/Menu';
 export { default as PhoneIcon } from '@mui/icons-material/Phone';
+export { default as SearchIcon } from '@mui/icons-material/Search';
+export { default as SecurityIcon } from '@mui/icons-material/Security';
+export { default as VisibilityIcon } from '@mui/icons-material/Visibility';
+export { default as VisibilityOffIcon } from '@mui/icons-material/VisibilityOff';

--- a/FateConnect/Web/src/layouts/GuestLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/index.tsx
@@ -7,7 +7,7 @@ import { APP_CONTACT, FOOTER_COPYRIGHT_LINES, FOOTER_TITLE } from '@app/constant
 import { LANDING_LINKS } from '@app/constants/navigation';
 import { useLandingAnchor } from '@app/hooks/useLandingAnchor';
 import { LandingSection, RoutePath } from '@app/routes/paths';
-import { Footer, Header, NavigationDrawer, Typography } from '@design-system';
+import { Footer, Header, NavigationDrawer, ThemeToggleButton, Typography } from '@design-system';
 import * as S from '../shell.styles';
 
 const MENU_BUTTON_LABEL = 'Abrir menu';
@@ -39,6 +39,7 @@ export function GuestLayout() {
     <S.ShellRoot>
       <Header
         logo={logo}
+        actions={<ThemeToggleButton />}
         menuButtonLabel={MENU_BUTTON_LABEL}
         onMenuClick={handleMenuClick}
         navigation={LANDING_LINKS.map(({ section, label, highlighted }) => (
@@ -63,7 +64,7 @@ export function GuestLayout() {
         ))}
       </NavigationDrawer>
 
-      <S.ShellContent>
+      <S.ShellContent component="main">
         <Outlet />
       </S.ShellContent>
 

--- a/FateConnect/Web/src/layouts/GuestLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/index.tsx
@@ -8,7 +8,7 @@ import { LANDING_LINKS } from '@app/constants/navigation';
 import { useLandingAnchor } from '@app/hooks/useLandingAnchor';
 import { LandingSection, RoutePath } from '@app/routes/paths';
 import { Footer, Header, NavigationDrawer, Typography } from '@design-system';
-import { ShellContent, ShellRoot } from '../shell.styles';
+import * as S from '../shell.styles';
 
 const MENU_BUTTON_LABEL = 'Abrir menu';
 
@@ -36,7 +36,7 @@ export function GuestLayout() {
   );
 
   return (
-    <ShellRoot>
+    <S.ShellRoot>
       <Header
         logo={logo}
         menuButtonLabel={MENU_BUTTON_LABEL}
@@ -63,9 +63,9 @@ export function GuestLayout() {
         ))}
       </NavigationDrawer>
 
-      <ShellContent>
+      <S.ShellContent>
         <Outlet />
-      </ShellContent>
+      </S.ShellContent>
 
       <Footer
         anchorId={LandingSection.CONTACT}
@@ -73,6 +73,6 @@ export function GuestLayout() {
         contact={APP_CONTACT}
         copyrightLines={FOOTER_COPYRIGHT_LINES}
       />
-    </ShellRoot>
+    </S.ShellRoot>
   );
 }

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -11,6 +11,7 @@ import {
   ListItemButton,
   ListItemText,
   NavigationDrawer,
+  ThemeToggleButton,
   Typography,
 } from '@design-system';
 import * as S from '../shell.styles';
@@ -36,6 +37,7 @@ export function MainLayout() {
     <S.ShellRoot>
       <Header
         logo={logo}
+        actions={<ThemeToggleButton />}
         menuButtonLabel={MENU_BUTTON_LABEL}
         onMenuClick={handleMenuClick}
         navigation={APP_LINKS.map(({ path, label }) => (
@@ -53,7 +55,7 @@ export function MainLayout() {
         ))}
       </NavigationDrawer>
 
-      <S.ShellContent>
+      <S.ShellContent component="main">
         <Outlet />
       </S.ShellContent>
 

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -13,7 +13,7 @@ import {
   NavigationDrawer,
   Typography,
 } from '@design-system';
-import { ShellContent, ShellRoot } from '../shell.styles';
+import * as S from '../shell.styles';
 
 const MENU_BUTTON_LABEL = 'Abrir menu';
 
@@ -33,7 +33,7 @@ export function MainLayout() {
   );
 
   return (
-    <ShellRoot>
+    <S.ShellRoot>
       <Header
         logo={logo}
         menuButtonLabel={MENU_BUTTON_LABEL}
@@ -53,9 +53,9 @@ export function MainLayout() {
         ))}
       </NavigationDrawer>
 
-      <ShellContent>
+      <S.ShellContent>
         <Outlet />
-      </ShellContent>
+      </S.ShellContent>
 
       <Footer
         anchorId={LandingSection.CONTACT}
@@ -63,6 +63,6 @@ export function MainLayout() {
         contact={APP_CONTACT}
         copyrightLines={FOOTER_COPYRIGHT_LINES}
       />
-    </ShellRoot>
+    </S.ShellRoot>
   );
 }

--- a/FateConnect/Web/src/layouts/shell.styles.ts
+++ b/FateConnect/Web/src/layouts/shell.styles.ts
@@ -1,18 +1,17 @@
-import { HEADER_HEIGHT_PX, styled } from '@design-system';
+import { HEADER_HEIGHT_PX, Stack, styled } from '@design-system';
+import type { PolymorphicProps } from '@design-system';
 
 /**
  * Casca comum às duas rotas. O topo é fixo, então o conteúdo reserva a altura
  * dele — mesmo comportamento do produto.
  */
-export const ShellRoot = styled('div')({
+export const ShellRoot = styled(Stack)<PolymorphicProps>({
   minHeight: '100vh',
   paddingTop: `${HEADER_HEIGHT_PX}px`,
-  display: 'flex',
   flexDirection: 'column',
 });
 
-export const ShellContent = styled('main')({
-  display: 'flex',
+export const ShellContent = styled(Stack)<PolymorphicProps>({
   flex: 1,
   flexDirection: 'column',
 });

--- a/FateConnect/Web/src/pages/Home/Home.test.tsx
+++ b/FateConnect/Web/src/pages/Home/Home.test.tsx
@@ -1,0 +1,66 @@
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { LandingSection, RoutePath } from '@app/routes/paths';
+import { render, screen, within } from '@app/test/testing-library';
+import { Home } from '.';
+import {
+  DESCRIPTION_HIGHLIGHTS,
+  DESCRIPTION_TITLE,
+} from './components/LandingDescription/constants';
+import { HOW_IT_WORKS_STEPS, HOW_IT_WORKS_TITLE } from './components/LandingHowItWorks/constants';
+import { SERVICE_CARDS, SERVICES_TITLE } from './components/LandingServices/constants';
+
+function renderHome() {
+  const router = createMemoryRouter([{ path: RoutePath.LANDING, element: <Home /> }], {
+    initialEntries: [RoutePath.LANDING],
+  });
+  render(<RouterProvider router={router} />);
+}
+
+describe('Home', () => {
+  it('should render the presentation with its highlights', () => {
+    renderHome();
+
+    expect(screen.getByRole('heading', { name: DESCRIPTION_TITLE })).toBeInTheDocument();
+
+    // Alguns rótulos de destaque repetem o título de um card de serviço.
+    const destaques = within(screen.getByRole('list', { name: 'Destaques do FateConnect' }));
+    DESCRIPTION_HIGHLIGHTS.forEach(({ label }) => {
+      expect(destaques.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  it('should render every service card', () => {
+    renderHome();
+
+    expect(screen.getByRole('heading', { name: SERVICES_TITLE })).toBeInTheDocument();
+    SERVICE_CARDS.forEach(({ title }) => {
+      expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
+    });
+  });
+
+  it('should render the how it works steps in order', () => {
+    renderHome();
+
+    expect(screen.getByRole('heading', { name: HOW_IT_WORKS_TITLE })).toBeInTheDocument();
+    HOW_IT_WORKS_STEPS.forEach(({ number, title }) => {
+      expect(screen.getByText(String(number))).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
+    });
+  });
+
+  it('should expose the anchors targeted by the header navigation', () => {
+    renderHome();
+
+    [LandingSection.SERVICES, LandingSection.HOW_IT_WORKS, LandingSection.LOGIN].forEach((id) => {
+      expect(document.getElementById(id)).toBeInTheDocument();
+    });
+  });
+
+  it('should render the login card', () => {
+    renderHome();
+
+    expect(screen.getByRole('heading', { name: 'Acesse sua conta' })).toBeInTheDocument();
+  });
+});

--- a/FateConnect/Web/src/pages/Home/components/LandingDescription/constants.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingDescription/constants.ts
@@ -1,0 +1,21 @@
+import {
+  DirectionsCarIcon,
+  GroupsIcon,
+  SearchIcon,
+  SecurityIcon,
+  type SvgIconComponent,
+} from '@design-system';
+
+export type DescriptionHighlight = { label: string; Icon: SvgIconComponent };
+
+export const DESCRIPTION_HIGHLIGHTS: DescriptionHighlight[] = [
+  { label: 'Caronas Seguras', Icon: DirectionsCarIcon },
+  { label: 'Achados & Perdidos', Icon: SearchIcon },
+  { label: 'Portal de Denúncias', Icon: SecurityIcon },
+  { label: 'Comunidade Verificada', Icon: GroupsIcon },
+];
+
+export const DESCRIPTION_TITLE = 'Conectando a Comunidade Acadêmica';
+
+export const DESCRIPTION_LEAD =
+  'Facilite sua vida na Fatec Sorocaba: encontre caronas, recupere pertences, registre denúncias e interaja com outros estudantes com total praticidade e segurança.';

--- a/FateConnect/Web/src/pages/Home/components/LandingDescription/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingDescription/index.tsx
@@ -10,14 +10,14 @@ export function LandingDescription() {
         <Typography variant="h1">{DESCRIPTION_TITLE}</Typography>
       </S.TitleContainer>
 
-      <S.Lead>
+      <S.Lead component="p">
         <Typography variant="subtitle">{DESCRIPTION_LEAD}</Typography>
       </S.Lead>
 
-      <S.HighlightList aria-label="Destaques do FateConnect">
+      <S.HighlightList component="ul" aria-label="Destaques do FateConnect">
         {DESCRIPTION_HIGHLIGHTS.map(({ label, Icon }) => (
-          <S.HighlightItem key={label}>
-            <S.IconDisc aria-hidden="true">
+          <S.HighlightItem component="li" key={label}>
+            <S.IconDisc component="span" aria-hidden="true">
               <Icon />
             </S.IconDisc>
             <Typography variant="subtitleBold">{label}</Typography>

--- a/FateConnect/Web/src/pages/Home/components/LandingDescription/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingDescription/index.tsx
@@ -1,0 +1,29 @@
+import { Typography } from '@design-system';
+
+import { DESCRIPTION_HIGHLIGHTS, DESCRIPTION_LEAD, DESCRIPTION_TITLE } from './constants';
+import * as S from './styles';
+
+export function LandingDescription() {
+  return (
+    <S.DescriptionRoot>
+      <S.TitleContainer>
+        <Typography variant="h1">{DESCRIPTION_TITLE}</Typography>
+      </S.TitleContainer>
+
+      <S.Lead>
+        <Typography variant="subtitle">{DESCRIPTION_LEAD}</Typography>
+      </S.Lead>
+
+      <S.HighlightList aria-label="Destaques do FateConnect">
+        {DESCRIPTION_HIGHLIGHTS.map(({ label, Icon }) => (
+          <S.HighlightItem key={label}>
+            <S.IconDisc aria-hidden="true">
+              <Icon />
+            </S.IconDisc>
+            <Typography variant="subtitleBold">{label}</Typography>
+          </S.HighlightItem>
+        ))}
+      </S.HighlightList>
+    </S.DescriptionRoot>
+  );
+}

--- a/FateConnect/Web/src/pages/Home/components/LandingDescription/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingDescription/styles.ts
@@ -1,11 +1,11 @@
-import { colorTokens, iconSizeTokens, mobileMedia, styled } from '@design-system';
+import { Box, Stack, iconSizeTokens, mobileMedia, styled } from '@design-system';
+import type { PolymorphicProps } from '@design-system';
 
 const MAX_WIDTH_PX = 600;
 const TITLE_MAX_WIDTH_PX = 500;
 const HIGHLIGHT_MAX_WIDTH_PX = 120;
 
-export const DescriptionRoot = styled('div')({
-  display: 'flex',
+export const DescriptionRoot = styled(Stack)<PolymorphicProps>({
   flex: 1,
   flexDirection: 'column',
   alignItems: 'center',
@@ -13,43 +13,43 @@ export const DescriptionRoot = styled('div')({
   maxWidth: `${MAX_WIDTH_PX}px`,
 });
 
-export const TitleContainer = styled('div')({
-  display: 'flex',
+export const TitleContainer = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
   maxWidth: `${TITLE_MAX_WIDTH_PX}px`,
   justifyContent: 'center',
-  color: colorTokens.primary,
+  color: theme.palette.text.primary,
   textAlign: 'center',
-});
+}));
 
-export const Lead = styled('p')({
-  color: colorTokens.textMuted,
+export const Lead = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.secondary,
   textAlign: 'center',
-});
+}));
 
-export const HighlightList = styled('ul')({
+export const HighlightList = styled(Stack)<PolymorphicProps>({
   listStyle: 'none',
-  display: 'flex',
+  flexDirection: 'row',
   gap: '1rem',
 
   [mobileMedia]: { display: 'none' },
 });
 
-export const HighlightItem = styled('li')({
-  display: 'flex',
+export const HighlightItem = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
   alignItems: 'center',
   gap: '12px',
   maxWidth: `${HIGHLIGHT_MAX_WIDTH_PX}px`,
-  color: colorTokens.primary,
+  color: theme.palette.text.primary,
   textAlign: 'center',
 
   '& svg': {
     fontSize: `${iconSizeTokens.sm}px`,
-    color: colorTokens.accent,
+    color: theme.palette.secondary.main,
   },
-});
+}));
 
-export const IconDisc = styled('span')({
-  display: 'flex',
+export const IconDisc = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'center',
 });

--- a/FateConnect/Web/src/pages/Home/components/LandingDescription/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingDescription/styles.ts
@@ -1,0 +1,55 @@
+import { colorTokens, iconSizeTokens, mobileMedia, styled } from '@design-system';
+
+const MAX_WIDTH_PX = 600;
+const TITLE_MAX_WIDTH_PX = 500;
+const HIGHLIGHT_MAX_WIDTH_PX = 120;
+
+export const DescriptionRoot = styled('div')({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '24px',
+  maxWidth: `${MAX_WIDTH_PX}px`,
+});
+
+export const TitleContainer = styled('div')({
+  display: 'flex',
+  maxWidth: `${TITLE_MAX_WIDTH_PX}px`,
+  justifyContent: 'center',
+  color: colorTokens.primary,
+  textAlign: 'center',
+});
+
+export const Lead = styled('p')({
+  color: colorTokens.textMuted,
+  textAlign: 'center',
+});
+
+export const HighlightList = styled('ul')({
+  listStyle: 'none',
+  display: 'flex',
+  gap: '1rem',
+
+  [mobileMedia]: { display: 'none' },
+});
+
+export const HighlightItem = styled('li')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '12px',
+  maxWidth: `${HIGHLIGHT_MAX_WIDTH_PX}px`,
+  color: colorTokens.primary,
+  textAlign: 'center',
+
+  '& svg': {
+    fontSize: `${iconSizeTokens.sm}px`,
+    color: colorTokens.accent,
+  },
+});
+
+export const IconDisc = styled('span')({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});

--- a/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/constants.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/constants.ts
@@ -1,0 +1,18 @@
+export type HowItWorksStep = { number: number; title: string; description: string };
+
+export const HOW_IT_WORKS_TITLE = 'Como Funciona';
+
+export const HOW_IT_WORKS_STEPS: HowItWorksStep[] = [
+  {
+    number: 1,
+    title: 'Cadastre-se',
+    description:
+      'Crie sua conta com o e-mail institucional da Fatec Sorocaba para fazer parte da comunidade verificada do FateConnect.',
+  },
+  {
+    number: 2,
+    title: 'Explore',
+    description:
+      'Busque caronas, publique em achados e perdidos e use os demais serviços pensados para o dia a dia no campus.',
+  },
+];

--- a/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/index.tsx
@@ -1,0 +1,35 @@
+import { Typography } from '@design-system';
+
+import { LandingSection } from '@app/routes/paths';
+import { HOW_IT_WORKS_STEPS, HOW_IT_WORKS_TITLE } from './constants';
+import * as S from './styles';
+
+const HEADING_ID = 'como-funciona-heading';
+
+export function LandingHowItWorks() {
+  return (
+    <S.HowSection id={LandingSection.HOW_IT_WORKS} aria-labelledby={HEADING_ID}>
+      <S.SectionTitle>
+        <Typography variant="h1" id={HEADING_ID}>
+          {HOW_IT_WORKS_TITLE}
+        </Typography>
+      </S.SectionTitle>
+
+      <S.StepsGrid>
+        {HOW_IT_WORKS_STEPS.map(({ number, title, description }) => (
+          <S.StepCard key={number}>
+            <S.StepBadge aria-hidden="true">{number}</S.StepBadge>
+            <S.StepBody>
+              <S.StepTitle>
+                <Typography variant="h2">{title}</Typography>
+              </S.StepTitle>
+              <S.StepDescription>
+                <Typography variant="subtitle">{description}</Typography>
+              </S.StepDescription>
+            </S.StepBody>
+          </S.StepCard>
+        ))}
+      </S.StepsGrid>
+    </S.HowSection>
+  );
+}

--- a/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/index.tsx
@@ -8,7 +8,7 @@ const HEADING_ID = 'como-funciona-heading';
 
 export function LandingHowItWorks() {
   return (
-    <S.HowSection id={LandingSection.HOW_IT_WORKS} aria-labelledby={HEADING_ID}>
+    <S.HowSection component="section" id={LandingSection.HOW_IT_WORKS} aria-labelledby={HEADING_ID}>
       <S.SectionTitle>
         <Typography variant="h1" id={HEADING_ID}>
           {HOW_IT_WORKS_TITLE}
@@ -17,8 +17,10 @@ export function LandingHowItWorks() {
 
       <S.StepsGrid>
         {HOW_IT_WORKS_STEPS.map(({ number, title, description }) => (
-          <S.StepCard key={number}>
-            <S.StepBadge aria-hidden="true">{number}</S.StepBadge>
+          <S.StepCard component="article" key={number}>
+            <S.StepBadge component="span" aria-hidden="true">
+              {number}
+            </S.StepBadge>
             <S.StepBody>
               <S.StepTitle>
                 <Typography variant="h2">{title}</Typography>

--- a/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/styles.ts
@@ -1,72 +1,67 @@
-import {
-  colorTokens,
-  mobileMedia,
-  radius,
-  radiusScale,
-  shadowTokens,
-  styled,
-} from '@design-system';
+import { Box, Stack, mobileMedia, radius, radiusScale, shadowTokens, styled } from '@design-system';
+import type { PolymorphicProps } from '@design-system';
 
-export const HowSection = styled('section')({
-  display: 'flex',
+export const HowSection = styled(Stack)<PolymorphicProps>({
   flexDirection: 'column',
   alignItems: 'center',
   padding: '3rem 7vw',
 });
 
-export const SectionTitle = styled('div')({
-  display: 'flex',
+export const SectionTitle = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
   textAlign: 'center',
   marginBottom: '2rem',
-  color: colorTokens.primary,
-});
+  color: theme.palette.text.primary,
+}));
 
-export const StepsGrid = styled('div')({
-  display: 'flex',
+export const StepsGrid = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
   gap: '2rem',
 
   [mobileMedia]: { flexDirection: 'column' },
 });
 
-export const StepCard = styled('article')({
+export const StepCard = styled(Stack)<PolymorphicProps>(({ theme }) => ({
   position: 'relative',
-  display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   padding: '2rem 1.5rem 1.75rem',
-  background: colorTokens.surfaceWhite,
+  background: theme.palette.background.paper,
   borderRadius: radius(radiusScale.component),
   boxShadow: shadowTokens.component,
   textAlign: 'center',
-});
+}));
 
-export const StepBadge = styled('span')({
+export const StepBadge = styled(Stack)<PolymorphicProps>(({ theme }) => ({
   position: 'absolute',
   top: '-1.25rem',
   left: '50%',
   transform: 'translateX(-50%)',
-  display: 'flex',
+  flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'center',
   width: '2.5rem',
   height: '2.5rem',
   borderRadius: '50%',
-  backgroundColor: colorTokens.accent,
-  color: colorTokens.surfaceWhite,
+  backgroundColor: theme.palette.secondary.main,
+  color: theme.palette.common.white,
   fontWeight: 700,
   fontSize: '1.125rem',
   lineHeight: 1,
 
   [mobileMedia]: { left: '2rem' },
-});
+}));
 
-export const StepBody = styled('div')({
-  display: 'flex',
+export const StepBody = styled(Stack)<PolymorphicProps>({
   flexDirection: 'column',
   gap: '0.75rem',
   marginTop: '0.5rem',
 });
 
-export const StepTitle = styled('div')({ color: colorTokens.primary });
+export const StepTitle = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.primary,
+}));
 
-export const StepDescription = styled('div')({ color: colorTokens.textMuted });
+export const StepDescription = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.secondary,
+}));

--- a/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/styles.ts
@@ -1,0 +1,72 @@
+import {
+  colorTokens,
+  mobileMedia,
+  radius,
+  radiusScale,
+  shadowTokens,
+  styled,
+} from '@design-system';
+
+export const HowSection = styled('section')({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '3rem 7vw',
+});
+
+export const SectionTitle = styled('div')({
+  display: 'flex',
+  textAlign: 'center',
+  marginBottom: '2rem',
+  color: colorTokens.primary,
+});
+
+export const StepsGrid = styled('div')({
+  display: 'flex',
+  gap: '2rem',
+
+  [mobileMedia]: { flexDirection: 'column' },
+});
+
+export const StepCard = styled('article')({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '2rem 1.5rem 1.75rem',
+  background: colorTokens.surfaceWhite,
+  borderRadius: radius(radiusScale.component),
+  boxShadow: shadowTokens.component,
+  textAlign: 'center',
+});
+
+export const StepBadge = styled('span')({
+  position: 'absolute',
+  top: '-1.25rem',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '2.5rem',
+  height: '2.5rem',
+  borderRadius: '50%',
+  backgroundColor: colorTokens.accent,
+  color: colorTokens.surfaceWhite,
+  fontWeight: 700,
+  fontSize: '1.125rem',
+  lineHeight: 1,
+
+  [mobileMedia]: { left: '2rem' },
+});
+
+export const StepBody = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  marginTop: '0.5rem',
+});
+
+export const StepTitle = styled('div')({ color: colorTokens.primary });
+
+export const StepDescription = styled('div')({ color: colorTokens.textMuted });

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
@@ -30,8 +30,8 @@ function renderCard(initialPath: string = RoutePath.LANDING) {
 }
 
 async function preencher(email: string, senha: string) {
-  await userEvent.type(screen.getByLabelText('E-mail'), email);
-  await userEvent.type(screen.getByLabelText('Senha'), senha);
+  await userEvent.type(screen.getByLabelText(/E-mail/), email);
+  await userEvent.type(screen.getByLabelText(/Senha/), senha);
 }
 
 describe('LandingLoginCard', () => {
@@ -55,13 +55,24 @@ describe('LandingLoginCard', () => {
 
   it('should toggle the password visibility', async () => {
     renderCard();
-    const campoSenha = screen.getByLabelText('Senha');
+    const campoSenha = screen.getByLabelText(/Senha/);
 
     expect(campoSenha).toHaveAttribute('type', 'password');
 
     await userEvent.click(screen.getByRole('button', { name: PASSWORD_TOGGLE_LABEL }));
 
     expect(campoSenha).toHaveAttribute('type', 'text');
+  });
+
+  it('should show an icon that reflects whether the password is visible', async () => {
+    renderCard();
+
+    // Senha oculta: olho cortado. O ícone mostra o estado, não a ação.
+    expect(screen.getByTestId('VisibilityOffIcon')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: PASSWORD_TOGGLE_LABEL }));
+
+    expect(screen.getByTestId('VisibilityIcon')).toBeInTheDocument();
   });
 
   it('should greet the user and go to the menu after a successful login', async () => {
@@ -117,6 +128,6 @@ describe('LandingLoginCard', () => {
   it('should focus the email field when the page is opened at the login anchor', async () => {
     renderCard(`${RoutePath.LANDING}#${LandingSection.LOGIN}`);
 
-    expect(screen.getByLabelText('E-mail')).toHaveFocus();
+    expect(screen.getByLabelText(/E-mail/)).toHaveFocus();
   });
 });

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
@@ -1,0 +1,122 @@
+import { http, HttpResponse } from 'msw';
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
+import { LandingSection, RoutePath } from '@app/routes/paths';
+import { render, screen, userEvent } from '@app/test/testing-library';
+import { LandingLoginCard } from '.';
+import {
+  LOGIN_ERROR_MESSAGES,
+  PASSWORD_TOGGLE_LABEL,
+  SUBMIT_LABEL,
+  SUBMIT_LOADING_LABEL,
+} from './constants';
+import { LOGIN_MESSAGES } from './schema';
+
+const LOGIN_URL = 'https://api.fateconnect.test/auth/login';
+
+function renderCard(initialPath: string = RoutePath.LANDING) {
+  const router = createMemoryRouter(
+    [
+      { path: RoutePath.LANDING, element: <LandingLoginCard /> },
+      { path: RoutePath.MENU, element: <div>menu</div> },
+    ],
+    { initialEntries: [initialPath] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+async function preencher(email: string, senha: string) {
+  await userEvent.type(screen.getByLabelText('E-mail'), email);
+  await userEvent.type(screen.getByLabelText('Senha'), senha);
+}
+
+describe('LandingLoginCard', () => {
+  it('should show the required messages when submitting an empty form', async () => {
+    renderCard();
+
+    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+
+    expect(await screen.findByText(LOGIN_MESSAGES.emailRequired)).toBeInTheDocument();
+    expect(screen.getByText(LOGIN_MESSAGES.passwordRequired)).toBeInTheDocument();
+  });
+
+  it('should reject a malformed email', async () => {
+    renderCard();
+    await preencher('nao-e-email', 'segredo123');
+
+    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+
+    expect(await screen.findByText(LOGIN_MESSAGES.emailInvalid)).toBeInTheDocument();
+  });
+
+  it('should toggle the password visibility', async () => {
+    renderCard();
+    const campoSenha = screen.getByLabelText('Senha');
+
+    expect(campoSenha).toHaveAttribute('type', 'password');
+
+    await userEvent.click(screen.getByRole('button', { name: PASSWORD_TOGGLE_LABEL }));
+
+    expect(campoSenha).toHaveAttribute('type', 'text');
+  });
+
+  it('should greet the user and go to the menu after a successful login', async () => {
+    server.use(
+      http.post(LOGIN_URL, () =>
+        HttpResponse.json({ token: 'abc', nomeCompleto: 'Fulano de Tal' }),
+      ),
+    );
+    const router = renderCard();
+    await preencher('aluno@fatec.sp.gov.br', 'segredo123');
+
+    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+
+    expect(await screen.findByText('Bem-vindo(a), Fulano de Tal!')).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(RoutePath.MENU);
+  });
+
+  it('should report invalid credentials when the api answers unauthorized', async () => {
+    server.use(http.post(LOGIN_URL, () => new HttpResponse(null, { status: 401 })));
+    renderCard();
+    await preencher('aluno@fatec.sp.gov.br', 'segredo-errado');
+
+    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+
+    expect(await screen.findByText(LOGIN_ERROR_MESSAGES.invalidCredentials)).toBeInTheDocument();
+  });
+
+  it('should report a generic failure for other api errors', async () => {
+    server.use(http.post(LOGIN_URL, () => new HttpResponse(null, { status: 500 })));
+    renderCard();
+    await preencher('aluno@fatec.sp.gov.br', 'segredo123');
+
+    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+
+    expect(await screen.findByText(LOGIN_ERROR_MESSAGES.generic)).toBeInTheDocument();
+  });
+
+  it('should show the loading label while the request is in flight', async () => {
+    server.use(
+      http.post(LOGIN_URL, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return HttpResponse.json({ token: 'abc', nomeCompleto: 'Fulano' });
+      }),
+    );
+    renderCard();
+    await preencher('aluno@fatec.sp.gov.br', 'segredo123');
+
+    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+
+    expect(await screen.findByRole('button', { name: SUBMIT_LOADING_LABEL })).toBeDisabled();
+  });
+
+  it('should focus the email field when the page is opened at the login anchor', async () => {
+    renderCard(`${RoutePath.LANDING}#${LandingSection.LOGIN}`);
+
+    expect(screen.getByLabelText('E-mail')).toHaveFocus();
+  });
+});

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/constants.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/constants.ts
@@ -1,0 +1,15 @@
+export const LOGIN_CARD_TITLE = 'Acesse sua conta';
+export const EMAIL_LABEL = 'E-mail';
+export const PASSWORD_LABEL = 'Senha';
+export const SUBMIT_LABEL = 'Entrar';
+export const SUBMIT_LOADING_LABEL = 'Entrando...';
+export const PASSWORD_TOGGLE_LABEL = 'Mostrar ou ocultar senha';
+export const SIGNUP_PROMPT = 'Não tem conta?';
+export const SIGNUP_LINK_LABEL = 'Cadastre-se';
+
+export const LOGIN_ERROR_MESSAGES = {
+  invalidCredentials: 'E-mail ou senha inválidos.',
+  generic: 'Erro ao realizar login. Tente novamente.',
+};
+
+export const welcomeMessage = (fullName: string): string => `Bem-vindo(a), ${fullName}!`;

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -83,14 +83,14 @@ export function LandingLoginCard() {
   const { ref: emailFieldRef, ...emailField } = register('email');
 
   return (
-    <S.CardRoot aria-labelledby="landing-login-title">
+    <S.CardRoot component="article" aria-labelledby="landing-login-title">
       <S.CardTitle>
         <Typography variant="h2" id="landing-login-title">
           {LOGIN_CARD_TITLE}
         </Typography>
       </S.CardTitle>
 
-      <S.Form onSubmit={onSubmit} noValidate>
+      <S.Form component="form" onSubmit={onSubmit} noValidate>
         <TextField
           {...emailField}
           inputRef={(element: HTMLInputElement | null) => {
@@ -98,6 +98,7 @@ export function LandingLoginCard() {
             emailInputRef.current = element;
           }}
           label={EMAIL_LABEL}
+          required
           type="email"
           autoComplete="username"
           error={Boolean(errors.email)}
@@ -107,6 +108,7 @@ export function LandingLoginCard() {
         <TextField
           {...register('password')}
           label={PASSWORD_LABEL}
+          required
           type={passwordHidden ? 'password' : 'text'}
           autoComplete={passwordHidden ? 'current-password' : 'off'}
           error={Boolean(errors.password)}
@@ -121,7 +123,8 @@ export function LandingLoginCard() {
                     aria-pressed={!passwordHidden}
                     onClick={handleTogglePassword}
                   >
-                    {passwordHidden ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                    {/* O ícone mostra o estado atual: olho aberto = senha visível. */}
+                    {passwordHidden ? <VisibilityOffIcon /> : <VisibilityIcon />}
                   </IconButton>
                 </InputAdornment>
               ),
@@ -130,13 +133,13 @@ export function LandingLoginCard() {
         />
 
         <S.SubmitRow>
-          <Button type="submit" variant="contained" color="secondary" disabled={isPending}>
+          <Button type="submit" variant="contained" color="error" disabled={isPending}>
             {isPending ? SUBMIT_LOADING_LABEL : SUBMIT_LABEL}
           </Button>
         </S.SubmitRow>
       </S.Form>
 
-      <S.SignupRow>
+      <S.SignupRow component="p">
         <Typography variant="caption">{SIGNUP_PROMPT}</Typography>
         <RouterLink to={RoutePath.SIGNUP}>
           <Typography variant="captionBold">{SIGNUP_LINK_LABEL}</Typography>

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -1,0 +1,147 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Link as RouterLink, useLocation, useNavigate } from 'react-router';
+
+import { useNotification } from '@app/hooks/useNotification';
+import { LandingSection, RoutePath } from '@app/routes/paths';
+import { login } from '@app/services/auth/authService';
+import type { ApiError } from '@app/services/httpClient';
+import {
+  Button,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Typography,
+  VisibilityIcon,
+  VisibilityOffIcon,
+} from '@design-system';
+
+import {
+  EMAIL_LABEL,
+  LOGIN_CARD_TITLE,
+  LOGIN_ERROR_MESSAGES,
+  PASSWORD_LABEL,
+  PASSWORD_TOGGLE_LABEL,
+  SIGNUP_LINK_LABEL,
+  SIGNUP_PROMPT,
+  SUBMIT_LABEL,
+  SUBMIT_LOADING_LABEL,
+  welcomeMessage,
+} from './constants';
+import { loginSchema, type LoginFormValues } from './schema';
+import * as S from './styles';
+
+const UNAUTHORIZED = 401;
+
+export function LandingLoginCard() {
+  const navigate = useNavigate();
+  const { hash } = useLocation();
+  const { notifySuccess, notifyError } = useNotification();
+  const emailInputRef = useRef<HTMLInputElement>(null);
+  const [passwordHidden, setPasswordHidden] = useState(true);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: '', password: '' },
+  });
+
+  // Chegando na landing pela âncora de login, o campo de e-mail recebe o foco.
+  useEffect(() => {
+    if (hash !== `#${LandingSection.LOGIN}`) return;
+
+    emailInputRef.current?.focus();
+  }, [hash]);
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: login,
+    onSuccess: (response) => {
+      notifySuccess(welcomeMessage(response.nomeCompleto));
+      navigate(RoutePath.MENU);
+    },
+    onError: (error: ApiError) => {
+      if (error.status === UNAUTHORIZED) {
+        notifyError(LOGIN_ERROR_MESSAGES.invalidCredentials);
+        return;
+      }
+
+      notifyError(LOGIN_ERROR_MESSAGES.generic);
+    },
+  });
+
+  const handleTogglePassword = useCallback(() => setPasswordHidden((hidden) => !hidden), []);
+
+  const onSubmit = handleSubmit(({ email, password }) => {
+    mutate({ emailFatec: email, senha: password });
+  });
+
+  const { ref: emailFieldRef, ...emailField } = register('email');
+
+  return (
+    <S.CardRoot aria-labelledby="landing-login-title">
+      <S.CardTitle>
+        <Typography variant="h2" id="landing-login-title">
+          {LOGIN_CARD_TITLE}
+        </Typography>
+      </S.CardTitle>
+
+      <S.Form onSubmit={onSubmit} noValidate>
+        <TextField
+          {...emailField}
+          inputRef={(element: HTMLInputElement | null) => {
+            emailFieldRef(element);
+            emailInputRef.current = element;
+          }}
+          label={EMAIL_LABEL}
+          type="email"
+          autoComplete="username"
+          error={Boolean(errors.email)}
+          helperText={errors.email?.message}
+        />
+
+        <TextField
+          {...register('password')}
+          label={PASSWORD_LABEL}
+          type={passwordHidden ? 'password' : 'text'}
+          autoComplete={passwordHidden ? 'current-password' : 'off'}
+          error={Boolean(errors.password)}
+          helperText={errors.password?.message}
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    type="button"
+                    aria-label={PASSWORD_TOGGLE_LABEL}
+                    aria-pressed={!passwordHidden}
+                    onClick={handleTogglePassword}
+                  >
+                    {passwordHidden ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+
+        <S.SubmitRow>
+          <Button type="submit" variant="contained" color="secondary" disabled={isPending}>
+            {isPending ? SUBMIT_LOADING_LABEL : SUBMIT_LABEL}
+          </Button>
+        </S.SubmitRow>
+      </S.Form>
+
+      <S.SignupRow>
+        <Typography variant="caption">{SIGNUP_PROMPT}</Typography>
+        <RouterLink to={RoutePath.SIGNUP}>
+          <Typography variant="captionBold">{SIGNUP_LINK_LABEL}</Typography>
+        </RouterLink>
+      </S.SignupRow>
+    </S.CardRoot>
+  );
+}

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/schema.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+/** Mensagens iguais às do produto. */
+export const LOGIN_MESSAGES = {
+  emailRequired: 'Informe o e-mail',
+  emailInvalid: 'E-mail inválido',
+  passwordRequired: 'Informe a senha',
+};
+
+export const loginSchema = z.object({
+  email: z.string().min(1, LOGIN_MESSAGES.emailRequired).email(LOGIN_MESSAGES.emailInvalid),
+  password: z.string().min(1, LOGIN_MESSAGES.passwordRequired),
+});
+
+export type LoginFormValues = z.infer<typeof loginSchema>;

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/styles.ts
@@ -1,26 +1,17 @@
-import {
-  colorTokens,
-  darken,
-  radius,
-  radiusScale,
-  shadowTokens,
-  styled,
-  tabletMedia,
-} from '@design-system';
+import { Box, Stack, radius, radiusScale, shadowTokens, styled, tabletMedia } from '@design-system';
+import type { FormHTMLAttributes } from 'react';
+
+import type { PolymorphicProps } from '@design-system';
 
 const CARD_WIDTH_PX = 360;
 const SUBMIT_HEIGHT_PX = 40;
 
-/** Mesma proporção que o MUI usa para derivar o estado de hover. */
-const HOVER_DARKEN_RATIO = 0.2;
-
-export const CardRoot = styled('article')({
-  display: 'flex',
+export const CardRoot = styled(Stack)<PolymorphicProps>(({ theme }) => ({
   flexDirection: 'column',
   gap: '1.25rem',
   padding: '1.75rem',
   width: `${CARD_WIDTH_PX}px`,
-  background: colorTokens.surfaceWhite,
+  background: theme.palette.background.paper,
   borderRadius: radius(radiusScale.component),
   boxShadow: shadowTokens.component,
 
@@ -28,50 +19,47 @@ export const CardRoot = styled('article')({
     justifySelf: 'center',
     maxWidth: '24rem',
   },
-});
+}));
 
-export const CardTitle = styled('div')({
-  color: colorTokens.primary,
+export const CardTitle = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.primary,
   textAlign: 'center',
-});
+}));
 
-export const Form = styled('form')({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1rem',
+export const Form = styled(Stack)<PolymorphicProps & FormHTMLAttributes<HTMLFormElement>>(
+  ({ theme }) => ({
+    flexDirection: 'column',
+    gap: '1rem',
 
-  '& svg': { color: colorTokens.textMuted },
-});
+    '& svg': { color: theme.palette.text.secondary },
+  }),
+);
 
-export const SubmitRow = styled('div')({
+export const SubmitRow = styled(Box)<PolymorphicProps>({
   marginTop: '0.5rem',
 
   '& .MuiButton-root': {
     width: '100%',
     height: `${SUBMIT_HEIGHT_PX}px`,
     borderRadius: radius(radiusScale.component),
-    backgroundColor: colorTokens.inheritedWarn,
-  },
-  '& .MuiButton-root:hover': {
-    backgroundColor: darken(colorTokens.inheritedWarn, HOVER_DARKEN_RATIO),
   },
 });
 
-export const SignupRow = styled('p')({
-  display: 'flex',
+export const SignupRow = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
   flexWrap: 'wrap',
   alignItems: 'baseline',
   gap: '0.35rem',
   justifyContent: 'center',
   textAlign: 'center',
-  color: colorTokens.textMuted,
+  color: theme.palette.text.secondary,
 
   '& a': {
-    color: colorTokens.accent,
+    color: theme.palette.secondary.main,
     textDecoration: 'none',
   },
   '& a:hover': {
     textDecoration: 'underline',
-    textDecorationColor: colorTokens.accent,
+    textDecorationColor: theme.palette.secondary.main,
   },
-});
+}));

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/styles.ts
@@ -1,0 +1,77 @@
+import {
+  colorTokens,
+  darken,
+  radius,
+  radiusScale,
+  shadowTokens,
+  styled,
+  tabletMedia,
+} from '@design-system';
+
+const CARD_WIDTH_PX = 360;
+const SUBMIT_HEIGHT_PX = 40;
+
+/** Mesma proporção que o MUI usa para derivar o estado de hover. */
+const HOVER_DARKEN_RATIO = 0.2;
+
+export const CardRoot = styled('article')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.25rem',
+  padding: '1.75rem',
+  width: `${CARD_WIDTH_PX}px`,
+  background: colorTokens.surfaceWhite,
+  borderRadius: radius(radiusScale.component),
+  boxShadow: shadowTokens.component,
+
+  [tabletMedia]: {
+    justifySelf: 'center',
+    maxWidth: '24rem',
+  },
+});
+
+export const CardTitle = styled('div')({
+  color: colorTokens.primary,
+  textAlign: 'center',
+});
+
+export const Form = styled('form')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+
+  '& svg': { color: colorTokens.textMuted },
+});
+
+export const SubmitRow = styled('div')({
+  marginTop: '0.5rem',
+
+  '& .MuiButton-root': {
+    width: '100%',
+    height: `${SUBMIT_HEIGHT_PX}px`,
+    borderRadius: radius(radiusScale.component),
+    backgroundColor: colorTokens.inheritedWarn,
+  },
+  '& .MuiButton-root:hover': {
+    backgroundColor: darken(colorTokens.inheritedWarn, HOVER_DARKEN_RATIO),
+  },
+});
+
+export const SignupRow = styled('p')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'baseline',
+  gap: '0.35rem',
+  justifyContent: 'center',
+  textAlign: 'center',
+  color: colorTokens.textMuted,
+
+  '& a': {
+    color: colorTokens.accent,
+    textDecoration: 'none',
+  },
+  '& a:hover': {
+    textDecoration: 'underline',
+    textDecorationColor: colorTokens.accent,
+  },
+});

--- a/FateConnect/Web/src/pages/Home/components/LandingServices/constants.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingServices/constants.ts
@@ -1,0 +1,38 @@
+import {
+  DirectionsCarIcon,
+  GroupsIcon,
+  SearchIcon,
+  SecurityIcon,
+  type SvgIconComponent,
+} from '@design-system';
+
+export type ServiceCard = { title: string; description: string; Icon: SvgIconComponent };
+
+export const SERVICES_TITLE = 'Nossos Serviços';
+
+export const SERVICE_CARDS: ServiceCard[] = [
+  {
+    title: 'Caronas Universitárias',
+    description:
+      'Encontre ou ofereça caronas para outros estudantes da Fatec. Economize dinheiro e faça novos amigos no caminho.',
+    Icon: DirectionsCarIcon,
+  },
+  {
+    title: 'Achados & Perdidos',
+    description:
+      'Perdeu algo no campus? Encontre seu objeto de volta de maneira fácil e rápida com a nossa plataforma!',
+    Icon: SearchIcon,
+  },
+  {
+    title: 'Comunidade Verificada',
+    description:
+      'Todos os usuários são verificados através do e-mail institucional, garantindo que você interaja apenas com membros da comunidade acadêmica.',
+    Icon: GroupsIcon,
+  },
+  {
+    title: 'Portal de Denúncias',
+    description:
+      'Relate situações inadequadas, assédio, bullying ou qualquer comportamento impróprio de forma anônima e segura. Sua denúncia será tratada com total confidencialidade.',
+    Icon: SecurityIcon,
+  },
+];

--- a/FateConnect/Web/src/pages/Home/components/LandingServices/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingServices/index.tsx
@@ -8,7 +8,11 @@ const HEADING_ID = 'servicos-heading';
 
 export function LandingServices() {
   return (
-    <S.ServicesSection id={LandingSection.SERVICES} aria-labelledby={HEADING_ID}>
+    <S.ServicesSection
+      component="section"
+      id={LandingSection.SERVICES}
+      aria-labelledby={HEADING_ID}
+    >
       <S.SectionTitle>
         <Typography variant="h1" id={HEADING_ID}>
           {SERVICES_TITLE}
@@ -17,7 +21,7 @@ export function LandingServices() {
 
       <S.CardsGrid>
         {SERVICE_CARDS.map(({ title, description, Icon }) => (
-          <S.ServiceCardRoot key={title}>
+          <S.ServiceCardRoot component="article" key={title}>
             <S.IconContainer aria-hidden="true">
               <Icon />
             </S.IconContainer>

--- a/FateConnect/Web/src/pages/Home/components/LandingServices/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingServices/index.tsx
@@ -1,0 +1,35 @@
+import { Typography } from '@design-system';
+
+import { LandingSection } from '@app/routes/paths';
+import { SERVICE_CARDS, SERVICES_TITLE } from './constants';
+import * as S from './styles';
+
+const HEADING_ID = 'servicos-heading';
+
+export function LandingServices() {
+  return (
+    <S.ServicesSection id={LandingSection.SERVICES} aria-labelledby={HEADING_ID}>
+      <S.SectionTitle>
+        <Typography variant="h1" id={HEADING_ID}>
+          {SERVICES_TITLE}
+        </Typography>
+      </S.SectionTitle>
+
+      <S.CardsGrid>
+        {SERVICE_CARDS.map(({ title, description, Icon }) => (
+          <S.ServiceCardRoot key={title}>
+            <S.IconContainer aria-hidden="true">
+              <Icon />
+            </S.IconContainer>
+            <S.CardTitle>
+              <Typography variant="h2">{title}</Typography>
+            </S.CardTitle>
+            <S.CardBody>
+              <Typography variant="subtitle">{description}</Typography>
+            </S.CardBody>
+          </S.ServiceCardRoot>
+        ))}
+      </S.CardsGrid>
+    </S.ServicesSection>
+  );
+}

--- a/FateConnect/Web/src/pages/Home/components/LandingServices/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingServices/styles.ts
@@ -1,5 +1,6 @@
 import {
-  colorTokens,
+  Box,
+  Stack,
   iconSizeTokens,
   mobileMedia,
   radius,
@@ -7,30 +8,30 @@ import {
   shadowTokens,
   styled,
 } from '@design-system';
+import type { PolymorphicProps } from '@design-system';
 
 const CARD_MIN_WIDTH_PX = 500;
 const ICON_DISC_SIZE_PX = 70;
 
-export const ServicesSection = styled('section')({
+export const ServicesSection = styled(Box)<PolymorphicProps>({
   padding: '5vh 7vw 7vh',
 });
 
-export const SectionTitle = styled('div')({
+export const SectionTitle = styled(Box)<PolymorphicProps>(({ theme }) => ({
   display: 'block',
   textAlign: 'center',
   marginBottom: '2rem',
-  color: colorTokens.primary,
-});
+  color: theme.palette.text.primary,
+}));
 
-export const CardsGrid = styled('div')({
-  display: 'flex',
+export const CardsGrid = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
   justifyContent: 'center',
   flexWrap: 'wrap',
   gap: '2rem',
 });
 
-export const ServiceCardRoot = styled('article')({
-  display: 'flex',
+export const ServiceCardRoot = styled(Stack)<PolymorphicProps>(({ theme }) => ({
   flex: 0.5,
   flexDirection: 'column',
   minWidth: `${CARD_MIN_WIDTH_PX}px`,
@@ -38,28 +39,32 @@ export const ServiceCardRoot = styled('article')({
   gap: '1rem',
   padding: '2rem',
   textAlign: 'center',
-  backgroundColor: colorTokens.surfaceGray,
+  backgroundColor: theme.palette.background.default,
   borderRadius: radius(radiusScale.component),
   boxShadow: shadowTokens.component,
 
   [mobileMedia]: { minWidth: '100%' },
-});
+}));
 
-export const IconContainer = styled('div')({
-  display: 'flex',
+export const IconContainer = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
   justifyContent: 'center',
   alignItems: 'center',
   width: `${ICON_DISC_SIZE_PX}px`,
   height: `${ICON_DISC_SIZE_PX}px`,
   borderRadius: '50%',
-  backgroundColor: colorTokens.accent,
+  backgroundColor: theme.palette.secondary.main,
 
   '& svg': {
     fontSize: `${iconSizeTokens.lg}px`,
-    color: colorTokens.surfaceWhite,
+    color: theme.palette.common.white,
   },
-});
+}));
 
-export const CardTitle = styled('div')({ color: colorTokens.primary });
+export const CardTitle = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.primary,
+}));
 
-export const CardBody = styled('div')({ color: colorTokens.textMuted });
+export const CardBody = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.secondary,
+}));

--- a/FateConnect/Web/src/pages/Home/components/LandingServices/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingServices/styles.ts
@@ -1,0 +1,65 @@
+import {
+  colorTokens,
+  iconSizeTokens,
+  mobileMedia,
+  radius,
+  radiusScale,
+  shadowTokens,
+  styled,
+} from '@design-system';
+
+const CARD_MIN_WIDTH_PX = 500;
+const ICON_DISC_SIZE_PX = 70;
+
+export const ServicesSection = styled('section')({
+  padding: '5vh 7vw 7vh',
+});
+
+export const SectionTitle = styled('div')({
+  display: 'block',
+  textAlign: 'center',
+  marginBottom: '2rem',
+  color: colorTokens.primary,
+});
+
+export const CardsGrid = styled('div')({
+  display: 'flex',
+  justifyContent: 'center',
+  flexWrap: 'wrap',
+  gap: '2rem',
+});
+
+export const ServiceCardRoot = styled('article')({
+  display: 'flex',
+  flex: 0.5,
+  flexDirection: 'column',
+  minWidth: `${CARD_MIN_WIDTH_PX}px`,
+  alignItems: 'center',
+  gap: '1rem',
+  padding: '2rem',
+  textAlign: 'center',
+  backgroundColor: colorTokens.surfaceGray,
+  borderRadius: radius(radiusScale.component),
+  boxShadow: shadowTokens.component,
+
+  [mobileMedia]: { minWidth: '100%' },
+});
+
+export const IconContainer = styled('div')({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: `${ICON_DISC_SIZE_PX}px`,
+  height: `${ICON_DISC_SIZE_PX}px`,
+  borderRadius: '50%',
+  backgroundColor: colorTokens.accent,
+
+  '& svg': {
+    fontSize: `${iconSizeTokens.lg}px`,
+    color: colorTokens.surfaceWhite,
+  },
+});
+
+export const CardTitle = styled('div')({ color: colorTokens.primary });
+
+export const CardBody = styled('div')({ color: colorTokens.textMuted });

--- a/FateConnect/Web/src/pages/Home/index.tsx
+++ b/FateConnect/Web/src/pages/Home/index.tsx
@@ -1,6 +1,25 @@
-import { Typography } from '@design-system';
+import { LandingSection } from '@app/routes/paths';
+import { LandingDescription } from './components/LandingDescription';
+import { LandingHowItWorks } from './components/LandingHowItWorks';
+import { LandingLoginCard } from './components/LandingLoginCard';
+import { LandingServices } from './components/LandingServices';
+import * as S from './styles';
 
-/** Placeholder — a tela é migrada na #53. */
 export function Home() {
-  return <Typography variant="h1">Início</Typography>;
+  return (
+    <S.HomeRoot>
+      <S.DescriptionContainer aria-label="Apresentação e acesso">
+        <LandingDescription />
+        <S.LoginAnchor id={LandingSection.LOGIN}>
+          <LandingLoginCard />
+        </S.LoginAnchor>
+      </S.DescriptionContainer>
+
+      <S.ServicesContainer aria-label="Nossos Serviços">
+        <LandingServices />
+      </S.ServicesContainer>
+
+      <LandingHowItWorks />
+    </S.HomeRoot>
+  );
 }

--- a/FateConnect/Web/src/pages/Home/index.tsx
+++ b/FateConnect/Web/src/pages/Home/index.tsx
@@ -8,14 +8,14 @@ import * as S from './styles';
 export function Home() {
   return (
     <S.HomeRoot>
-      <S.DescriptionContainer aria-label="Apresentação e acesso">
+      <S.DescriptionContainer component="section" aria-label="Apresentação e acesso">
         <LandingDescription />
         <S.LoginAnchor id={LandingSection.LOGIN}>
           <LandingLoginCard />
         </S.LoginAnchor>
       </S.DescriptionContainer>
 
-      <S.ServicesContainer aria-label="Nossos Serviços">
+      <S.ServicesContainer component="section" aria-label="Nossos Serviços">
         <LandingServices />
       </S.ServicesContainer>
 

--- a/FateConnect/Web/src/pages/Home/styles.ts
+++ b/FateConnect/Web/src/pages/Home/styles.ts
@@ -1,13 +1,13 @@
-import { colorTokens, styled, tabletMedia } from '@design-system';
+import { Stack, styled, tabletMedia } from '@design-system';
+import type { PolymorphicProps } from '@design-system';
 
-export const HomeRoot = styled('div')({
-  display: 'flex',
+export const HomeRoot = styled(Stack)<PolymorphicProps>({
   flexDirection: 'column',
   width: '100%',
 });
 
-export const DescriptionContainer = styled('section')({
-  display: 'flex',
+export const DescriptionContainer = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'space-around',
   padding: '7vh 7vw',
@@ -16,15 +16,14 @@ export const DescriptionContainer = styled('section')({
   [tabletMedia]: { flexDirection: 'column' },
 });
 
-export const LoginAnchor = styled('div')({
-  display: 'flex',
+export const LoginAnchor = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
 
   [tabletMedia]: { justifyContent: 'center' },
 });
 
-export const ServicesContainer = styled('section')({
-  display: 'flex',
+export const ServicesContainer = styled(Stack)<PolymorphicProps>(({ theme }) => ({
   flexDirection: 'column',
   alignItems: 'center',
-  background: colorTokens.surfaceWhite,
-});
+  background: theme.palette.background.paper,
+}));

--- a/FateConnect/Web/src/pages/Home/styles.ts
+++ b/FateConnect/Web/src/pages/Home/styles.ts
@@ -1,0 +1,30 @@
+import { colorTokens, styled, tabletMedia } from '@design-system';
+
+export const HomeRoot = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+});
+
+export const DescriptionContainer = styled('section')({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-around',
+  padding: '7vh 7vw',
+  gap: '32px',
+
+  [tabletMedia]: { flexDirection: 'column' },
+});
+
+export const LoginAnchor = styled('div')({
+  display: 'flex',
+
+  [tabletMedia]: { justifyContent: 'center' },
+});
+
+export const ServicesContainer = styled('section')({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  background: colorTokens.surfaceWhite,
+});

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -14,7 +14,7 @@ function renderRoute(initialPath: string) {
 
 describe('routeConfig', () => {
   it.each([
-    [RoutePath.LANDING, 'Início'],
+    [RoutePath.LANDING, 'Conectando a Comunidade Acadêmica'],
     [RoutePath.SIGNUP, 'Cadastro'],
     [RoutePath.MENU, 'Menu'],
     [RoutePath.LOST_AND_FOUND, 'Achados e Perdidos'],

--- a/FateConnect/Web/yarn.lock
+++ b/FateConnect/Web/yarn.lock
@@ -428,6 +428,13 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.12.tgz#afefe785949f16ac4cdd1e695935a321572dd56a"
   integrity sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==
 
+"@hookform/resolvers@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-5.9.1.tgz#2010c1b542ce6fa75fa5d8fee5cc911ece009f5c"
+  integrity sha512-7b7vsbraJxKgjVSA1Nur9tLwj539WGJUBLA7QNvXnFoT2pM5Z7G+6rlukk4B2/QrTZy6huRtH6wKeESPKuIr6w==
+  dependencies:
+    "@standard-schema/utils" "^0.3.0"
+
 "@humanfs/core@^0.19.2":
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.2.tgz#a8272ca03b2acf492670222b2320b6c421bfde60"
@@ -771,6 +778,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
 "@tanstack/query-core@5.101.4":
   version "5.101.4"
@@ -3163,6 +3175,11 @@ react-dom@^19.2.8:
   dependencies:
     scheduler "^0.27.0"
 
+react-hook-form@^7.85.0:
+  version "7.85.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.85.0.tgz#45b95cc794f9ed752ffc9121cc6ddcc92e97acf0"
+  integrity sha512-U2MTriFXnclmV4rOE20p2DcRFv5WEg3FIcBFOKcOLFHDVvGIMPvLTkTWefUsonmlaVy23khVDxDWym6uJVGOzw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -4005,7 +4022,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-4.0.2.tgz#bc605eba49ce0fcd598c127fee1c236be3f22918"
   integrity sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==
 
-"zod@^3.25.0 || ^4.0.0":
+"zod@^3.25.0 || ^4.0.0", zod@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Objetivo

Migrar a landing page — apresentação, serviços, como funciona e cartão de login — com **paridade visual verificada por medição**. No caminho, três correções de projeto no design system e um tema escuro.

## Alterações

### Landing (#53)

- **Apresentação:** título, texto de abertura e os quatro destaques, que somem abaixo de 768px como no produto.
- **Serviços:** quatro cartões com disco de ícone, empilhando abaixo de 768px.
- **Como funciona:** dois passos com numerador sobreposto, virando coluna no mobile.
- **Cartão de login:** `react-hook-form` + `zod`, alternância de visibilidade da senha, estados de carregamento e erro, foco automático ao entrar pela âncora `#login`, e navegação para o menu no sucesso.

### Design system

- **Paletas clara e escura** seguindo o sistema de cor do Material Design. As variantes `light`/`dark` usam **a mesma regra do tema atual do produto** (base clareada 25% / escurecida 20%), então o M2 é seguido sem inventar cor.
- **Tema escuro:** superfície `#121212`, superfície elevada `#1E1E1E`, cores de marca dessaturadas até alcançarem contraste e *on colors* por ênfase (87% / 60% / 38%).
- **`chromeSurface` / `onChromeSurface`:** topo, rodapé e menu lateral usam a cor de marca no claro e superfície elevada no escuro, numa decisão centralizada.
- **Seletor de tema** fixo à direita do topo.
- **Cor sai da paleta, não do token.** Os 41 usos diretos de token viraram `theme.palette.*`; token direto só em `theme/`, que constrói a paleta.
- **`Stack` para flex, `Box` no resto** — nenhuma tag HTML crua nos estilos. Semântica preservada pela prop `component`.

### Correções de projeto

- **Suavização de fonte:** o `CssBaseline` do MUI aplica `antialiased`, que afina todo texto. O produto usa o padrão do navegador — sem isso, cada peso parecia um grau menor.
- **Reset global:** margem e recuo zerados em todo elemento, como no produto.
- **Contraste:** duas combinações herdadas ficavam abaixo de AA. Corrigidas — o acento passou a usar branco puro (4,42 → 5,14:1) e o vermelho de erro foi escurecido (3,68 → 4,56:1), com o tom original preservado como `error.light`.

### Lint

Cinco importações passaram a ser **bloqueadas por regra**, não por convenção: `@mui/*` fora do design system, caminho interno de `@design-system`, `@emotion/*`, tokens de cor fora do tema, e `@testing-library/react` fora dos testes. Cada uma foi verificada contra um arquivo de violação proposital.

## Paridade medida

`getComputedStyle` dos elementos equivalentes nos dois apps, em 1440px e 700px:

| Métrica | Referência | Migrado |
| ------- | ---------- | ------- |
| Apresentação — padding / gap | `63px 100.8px` / `32px` | idêntico |
| Título — tamanho / peso / cor | `32px` / `700` / `rgb(67,84,92)` | idêntico |
| Destaques — gap / largura do item | `16px` / `120px` | idêntico |
| Ícones — destaque / cartão | `20x16` / `40x32` | `20x20` / `40x40` (ver desvios) |
| Cartão de login — largura / padding / gap / raio | `360px` / `28px` / `20px` / `10px` | idêntico |
| Botão de acesso — largura / altura / raio | `304px` / `40px` / `10px` | idêntico |
| Serviços — padding / cartão / disco | `45px 100.8px 63px` / `500px` / `70px` | idêntico |
| Como funciona — padding / numerador | `48px 100.8px` / `40px`, topo `-20px` | idêntico |
| Topo — altura / padding / sombra | `64px` / `0 100.8px` / componente | idêntico |
| Navegação — item / destaque | `16px/500` / `16px/400` | idêntico |
| Rodapé — fundo / direção / divisor | marca / `row` / vertical | idêntico |
| Menu lateral — largura / fundo / item | `300px` / marca / `48px` | idêntico |
| Mobile 700px — todos os pontos de quebra | coluna, destaques ocultos, divisor horizontal | idêntico |

## Desvios conscientes

Três diferenças **decididas**, não escapadas:

1. **Ícones.** Os glifos da biblioteca original são mais largos que altos (`20x16`, `40x32`); os do MUI são quadrados. Os tokens acompanham a **largura**, que é a dimensão que dá a massa visual — a altura fica maior que a da referência.
2. **Ícone reflete estado, não ação.** Olho aberto quando a senha está visível; lua quando o tema escuro está ativo. A referência faz o oposto. O rótulo acessível continua descrevendo a ação do clique.
3. **Seletor de tema e tema escuro** não existem na referência.

## Issue

- #53

Closes #53

## Evidências

| Gate | Resultado |
| ---- | --------- |
| `yarn typecheck` | exit 0 |
| `yarn lint` | exit 0 |
| `yarn test:ci` | 21 arquivos, **87 testes**, exit 0 |
| `yarn build` | exit 0 |
| Cobertura | 99,5% statements · 83,33% branches · 99,71% lines |

O contraste é verificado por teste em **todos** os pares de conteúdo e fundo, nos dois temas, com o mínimo AA (4,5:1) — cor nova sem o par correspondente reprova a suíte.
