### PR TITLE
feat(55): add the rides module with filter card and confirm dialog

### DIFF
--- a/FateConnect/Web/eslint.config.js
+++ b/FateConnect/Web/eslint.config.js
@@ -51,8 +51,10 @@ export default tseslint.config(
                 'Importe pelo barrel: `@design-system`. Se o componente ainda não é exportado, adicione-o ao barrel.',
             },
             {
-              group: ['@design-system/*'],
-              message: 'Importe do barrel `@design-system`, nunca de um caminho interno dele.',
+              // `@design-system/icons` é o segundo barrel público; o resto continua interno.
+              group: ['@design-system/*', '!@design-system/icons'],
+              message:
+                'Importe do barrel `@design-system` (ou `@design-system/icons`), nunca de um caminho interno dele.',
             },
             {
               group: ['@emotion/*'],

--- a/FateConnect/Web/src/components/DrawerSectionItem/index.tsx
+++ b/FateConnect/Web/src/components/DrawerSectionItem/index.tsx
@@ -4,11 +4,11 @@ import { ListItemButton, ListItemText } from '@design-system';
 
 import type { LandingSectionEnum } from '@app/routes/paths';
 
-type DrawerSectionItemProps = {
+type DrawerSectionItemProps = Readonly<{
   section: LandingSectionEnum;
   label: string;
   onSelect: (section: LandingSectionEnum) => void;
-};
+}>;
 
 /** Item do menu lateral que rola até uma seção da landing. */
 export function DrawerSectionItem({ section, label, onSelect }: DrawerSectionItemProps) {

--- a/FateConnect/Web/src/components/DrawerSectionItem/index.tsx
+++ b/FateConnect/Web/src/components/DrawerSectionItem/index.tsx
@@ -2,12 +2,12 @@ import { useCallback } from 'react';
 
 import { ListItemButton, ListItemText } from '@design-system';
 
-import type { LandingSection } from '@app/routes/paths';
+import type { LandingSectionEnum } from '@app/routes/paths';
 
 type DrawerSectionItemProps = {
-  section: LandingSection;
+  section: LandingSectionEnum;
   label: string;
-  onSelect: (section: LandingSection) => void;
+  onSelect: (section: LandingSectionEnum) => void;
 };
 
 /** Item do menu lateral que rola até uma seção da landing. */

--- a/FateConnect/Web/src/components/LandingNavButton/index.tsx
+++ b/FateConnect/Web/src/components/LandingNavButton/index.tsx
@@ -3,12 +3,12 @@ import { useCallback } from 'react';
 import type { LandingSectionEnum } from '@app/routes/paths';
 import { Button } from '@design-system';
 
-type LandingNavButtonProps = {
+type LandingNavButtonProps = Readonly<{
   section: LandingSectionEnum;
   label: string;
   highlighted: boolean;
   onSelect: (section: LandingSectionEnum) => void;
-};
+}>;
 
 /** Botão de seção da landing. Existe para não criar callback anônimo no JSX do header. */
 export function LandingNavButton({ section, label, highlighted, onSelect }: LandingNavButtonProps) {

--- a/FateConnect/Web/src/components/LandingNavButton/index.tsx
+++ b/FateConnect/Web/src/components/LandingNavButton/index.tsx
@@ -1,13 +1,13 @@
 import { useCallback } from 'react';
 
-import type { LandingSection } from '@app/routes/paths';
+import type { LandingSectionEnum } from '@app/routes/paths';
 import { Button } from '@design-system';
 
 type LandingNavButtonProps = {
-  section: LandingSection;
+  section: LandingSectionEnum;
   label: string;
   highlighted: boolean;
-  onSelect: (section: LandingSection) => void;
+  onSelect: (section: LandingSectionEnum) => void;
 };
 
 /** Botão de seção da landing. Existe para não criar callback anônimo no JSX do header. */

--- a/FateConnect/Web/src/constants/navigation.ts
+++ b/FateConnect/Web/src/constants/navigation.ts
@@ -11,9 +11,11 @@ export const LANDING_LINKS: LandingLink[] = [
   { section: LandingSection.LOGIN, label: 'Entrar', highlighted: true },
 ];
 
-/** Navegação da área logada. */
+/**
+ * Navegação da área logada. Sem "Entre em Contato": a tela de contato existe
+ * como âncora na landing, não como rota de quem já entrou.
+ */
 export const APP_LINKS: AppLink[] = [
   { path: RoutePath.LOST_AND_FOUND, label: 'Achados & Perdidos' },
   { path: RoutePath.RIDES, label: 'Caronas' },
-  { path: RoutePath.CONTACT, label: 'Entre em Contato' },
 ];

--- a/FateConnect/Web/src/constants/navigation.ts
+++ b/FateConnect/Web/src/constants/navigation.ts
@@ -1,14 +1,14 @@
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 
-export type LandingLink = { section: LandingSection; label: string; highlighted: boolean };
-export type AppLink = { path: RoutePath; label: string };
+export type LandingLink = { section: LandingSectionEnum; label: string; highlighted: boolean };
+export type AppLink = { path: RoutePathEnum; label: string };
 
 /** Navegação da landing: rola até a seção correspondente. */
 export const LANDING_LINKS: LandingLink[] = [
-  { section: LandingSection.SERVICES, label: 'Serviços', highlighted: false },
-  { section: LandingSection.HOW_IT_WORKS, label: 'Como Funciona', highlighted: false },
-  { section: LandingSection.CONTACT, label: 'Entre em Contato', highlighted: false },
-  { section: LandingSection.LOGIN, label: 'Entrar', highlighted: true },
+  { section: LandingSectionEnum.SERVICES, label: 'Serviços', highlighted: false },
+  { section: LandingSectionEnum.HOW_IT_WORKS, label: 'Como Funciona', highlighted: false },
+  { section: LandingSectionEnum.CONTACT, label: 'Entre em Contato', highlighted: false },
+  { section: LandingSectionEnum.LOGIN, label: 'Entrar', highlighted: true },
 ];
 
 /**
@@ -16,6 +16,6 @@ export const LANDING_LINKS: LandingLink[] = [
  * como âncora na landing, não como rota de quem já entrou.
  */
 export const APP_LINKS: AppLink[] = [
-  { path: RoutePath.LOST_AND_FOUND, label: 'Achados & Perdidos' },
-  { path: RoutePath.RIDES, label: 'Caronas' },
+  { path: RoutePathEnum.LOST_AND_FOUND, label: 'Achados & Perdidos' },
+  { path: RoutePathEnum.RIDES, label: 'Caronas' },
 ];

--- a/FateConnect/Web/src/design-system/ThemeProvider/index.tsx
+++ b/FateConnect/Web/src/design-system/ThemeProvider/index.tsx
@@ -6,11 +6,11 @@ import { GlobalStyles } from '../GlobalStyles';
 import { createAppTheme, type ThemeMode } from '../theme';
 import { ThemeModeContext } from './context/ThemeModeContext';
 
-type ThemeProviderProps = {
+type ThemeProviderProps = Readonly<{
   children: ReactNode;
   /** Modo inicial; o usuário alterna a partir daí. */
   defaultMode?: ThemeMode;
-};
+}>;
 
 /** Único ponto onde o tema é criado e injetado na árvore. */
 export function ThemeProvider({ children, defaultMode = 'light' }: ThemeProviderProps) {

--- a/FateConnect/Web/src/design-system/components/ConfirmDialog/DialogMessage/index.tsx
+++ b/FateConnect/Web/src/design-system/components/ConfirmDialog/DialogMessage/index.tsx
@@ -1,0 +1,29 @@
+import Typography from '@mui/material/Typography';
+import type { ReactNode } from 'react';
+
+export type DialogMessageProps = Readonly<{
+  /** Trecho em destaque no meio da frase — o nome do que será removido. */
+  emphasis?: string;
+  prefix?: string;
+  suffix?: string;
+  /** Mensagem inteira, quando não há trecho em destaque. */
+  children?: ReactNode;
+}>;
+
+/**
+ * Corpo da confirmação. Com `emphasis`, a frase é montada em três partes para
+ * o nome do item aparecer em destaque no meio dela.
+ */
+export function DialogMessage({ emphasis, prefix, suffix, children }: DialogMessageProps) {
+  if (emphasis) {
+    return (
+      <Typography variant="subtitle">
+        {prefix}
+        <strong>{emphasis}</strong>
+        {suffix}
+      </Typography>
+    );
+  }
+
+  return <Typography variant="subtitle">{children}</Typography>;
+}

--- a/FateConnect/Web/src/design-system/components/ConfirmDialog/index.tsx
+++ b/FateConnect/Web/src/design-system/components/ConfirmDialog/index.tsx
@@ -1,0 +1,63 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import Typography from '@mui/material/Typography';
+import type { ReactNode } from 'react';
+
+import { DialogMessage } from './DialogMessage';
+import * as S from './styles';
+
+const DEFAULT_TITLE = 'Confirmar ação';
+const DEFAULT_CONFIRM = 'Confirmar';
+const DEFAULT_CANCEL = 'Cancelar';
+const TITLE_ID = 'confirm-dialog-title';
+
+export type ConfirmDialogProps = Readonly<{
+  open: boolean;
+  onCancel: VoidFunction;
+  onConfirm: VoidFunction;
+  /** Corpo da confirmação — normalmente um `ConfirmDialog.Message`. */
+  children: ReactNode;
+  title?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}>;
+
+/**
+ * Confirmação de ação destrutiva. Prop-driven: quem abre decide os textos e o
+ * que acontece — o diálogo não conhece o domínio.
+ */
+function ConfirmDialog({
+  open,
+  onCancel,
+  onConfirm,
+  children,
+  title = DEFAULT_TITLE,
+  confirmLabel = DEFAULT_CONFIRM,
+  cancelLabel = DEFAULT_CANCEL,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onClose={onCancel} aria-labelledby={TITLE_ID}>
+      <S.DialogRoot>
+        <S.Content>
+          <Typography variant="h2" id={TITLE_ID}>
+            {title}
+          </Typography>
+          {children}
+        </S.Content>
+
+        <S.Actions>
+          <Button type="button" variant="contained" color="primary" onClick={onCancel}>
+            {cancelLabel}
+          </Button>
+          <Button type="button" variant="contained" color="secondary" onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </S.Actions>
+      </S.DialogRoot>
+    </Dialog>
+  );
+}
+
+ConfirmDialog.Message = DialogMessage;
+
+export { ConfirmDialog };

--- a/FateConnect/Web/src/design-system/components/ConfirmDialog/styles.ts
+++ b/FateConnect/Web/src/design-system/components/ConfirmDialog/styles.ts
@@ -1,0 +1,50 @@
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import Stack from '@mui/material/Stack';
+
+import { styled } from '../../styled';
+import type { PolymorphicProps } from '../../styled';
+import { spacing } from '../../theme/helpers/spacing';
+import { radius } from '../../theme/helpers/radius';
+import { mobileMedia, radiusScale, spacingScale } from '../../tokens';
+
+const { xs, xl } = spacingScale;
+
+const ACTION_MIN_WIDTH_PX = 120;
+const ACTION_MIN_WIDTH_MOBILE_PX = 100;
+const CONTENT_MAX_WIDTH_PX = 400;
+const ACTION_LETTER_SPACING = '0.4px';
+
+export const DialogRoot = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: spacing(xl),
+  textAlign: 'center',
+});
+
+export const Content = styled(DialogContent)({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: spacing(xl),
+  maxWidth: `${CONTENT_MAX_WIDTH_PX}px`,
+});
+
+export const Actions = styled(DialogActions)({
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: spacing(xs),
+
+  '& .MuiButton-root': {
+    minWidth: `${ACTION_MIN_WIDTH_PX}px`,
+    borderRadius: radius(radiusScale.component),
+    letterSpacing: ACTION_LETTER_SPACING,
+  },
+
+  [mobileMedia]: {
+    '& .MuiButton-root': { minWidth: `${ACTION_MIN_WIDTH_MOBILE_PX}px` },
+  },
+});

--- a/FateConnect/Web/src/design-system/components/Footer/index.tsx
+++ b/FateConnect/Web/src/design-system/components/Footer/index.tsx
@@ -5,13 +5,13 @@ import Typography from '@mui/material/Typography';
 
 import * as S from './styles';
 
-type FooterProps = {
+type FooterProps = Readonly<{
   /** Id da âncora usada pela navegação da aplicação. */
   anchorId: string;
   title: string;
   contact: { email: string; phone: string; address: string };
   copyrightLines: string[];
-};
+}>;
 
 export function Footer({ anchorId, title, contact, copyrightLines }: FooterProps) {
   return (

--- a/FateConnect/Web/src/design-system/components/Header/index.tsx
+++ b/FateConnect/Web/src/design-system/components/Header/index.tsx
@@ -5,7 +5,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 
 import * as S from './styles';
 
-type HeaderProps = {
+type HeaderProps = Readonly<{
   /** Marca à esquerda. A aplicação decide para onde ela navega. */
   logo: ReactNode;
   /** Navegação exibida acima do breakpoint mobile. */
@@ -14,7 +14,7 @@ type HeaderProps = {
   actions?: ReactNode;
   onMenuClick: VoidFunction;
   menuButtonLabel: string;
-};
+}>;
 
 /**
  * Cromo do topo: barra fixa, faixa de navegação responsiva e botão de menu.

--- a/FateConnect/Web/src/design-system/components/NavigationDrawer/index.tsx
+++ b/FateConnect/Web/src/design-system/components/NavigationDrawer/index.tsx
@@ -2,12 +2,12 @@ import type { ReactNode } from 'react';
 
 import * as S from './styles';
 
-type NavigationDrawerProps = {
+type NavigationDrawerProps = Readonly<{
   open: boolean;
   onClose: VoidFunction;
   header: ReactNode;
   children: ReactNode;
-};
+}>;
 
 /** Menu lateral. Quem usa monta o cabeçalho e os itens. */
 export function NavigationDrawer({ open, onClose, header, children }: NavigationDrawerProps) {

--- a/FateConnect/Web/src/design-system/components/StatusTag/index.tsx
+++ b/FateConnect/Web/src/design-system/components/StatusTag/index.tsx
@@ -1,0 +1,18 @@
+import Typography from '@mui/material/Typography';
+import type { ReactNode } from 'react';
+
+import * as S from './styles';
+import type { StatusTagTone } from './types';
+
+export type StatusTagProps = { tone?: StatusTagTone; children: ReactNode };
+
+/** Etiqueta de estado — fundo suave com o texto na cor correspondente. */
+export function StatusTag({ tone = 'neutral', children }: StatusTagProps) {
+  return (
+    <S.TagRoot component="span" tone={tone}>
+      <Typography variant="caption" color="inherit">
+        {children}
+      </Typography>
+    </S.TagRoot>
+  );
+}

--- a/FateConnect/Web/src/design-system/components/StatusTag/index.tsx
+++ b/FateConnect/Web/src/design-system/components/StatusTag/index.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import * as S from './styles';
 import type { StatusTagTone } from './types';
 
-export type StatusTagProps = { tone?: StatusTagTone; children: ReactNode };
+export type StatusTagProps = Readonly<{ tone?: StatusTagTone; children: ReactNode }>;
 
 /** Etiqueta de estado — fundo suave com o texto na cor correspondente. */
 export function StatusTag({ tone = 'neutral', children }: StatusTagProps) {

--- a/FateConnect/Web/src/design-system/components/StatusTag/styles.ts
+++ b/FateConnect/Web/src/design-system/components/StatusTag/styles.ts
@@ -1,0 +1,32 @@
+import Box from '@mui/material/Box';
+
+import { styled } from '../../styled';
+import type { PolymorphicProps } from '../../styled';
+import { spacing } from '../../theme/helpers/spacing';
+import { spacingScale } from '../../tokens';
+import type { StatusTagTone } from './types';
+
+const { xxs, sm } = spacingScale;
+
+const TAG_RADIUS_PX = 12;
+
+export const TagRoot = styled(Box)<PolymorphicProps & { tone: StatusTagTone }>(({
+  theme,
+  tone,
+}) => {
+  const tones: Record<StatusTagTone, { background: string; color: string }> = {
+    success: { background: theme.palette.success.light, color: theme.palette.success.main },
+    warning: { background: theme.palette.warning.light, color: theme.palette.warning.main },
+    neutral: { background: 'transparent', color: 'inherit' },
+  };
+
+  return {
+    // Elemento em linha: a caixa acompanha a altura do texto. A entrelinha
+    // neutra evita que ela cresça quando o pai é um contêiner flex.
+    display: 'inline',
+    lineHeight: 1,
+    padding: spacing(xxs, sm),
+    borderRadius: `${TAG_RADIUS_PX}px`,
+    ...tones[tone],
+  };
+});

--- a/FateConnect/Web/src/design-system/components/StatusTag/types.ts
+++ b/FateConnect/Web/src/design-system/components/StatusTag/types.ts
@@ -1,0 +1,2 @@
+/** Tom da etiqueta. A cor de cada tom vem da paleta, nos dois temas. */
+export type StatusTagTone = 'neutral' | 'success' | 'warning';

--- a/FateConnect/Web/src/design-system/components/ThemeToggleButton/index.tsx
+++ b/FateConnect/Web/src/design-system/components/ThemeToggleButton/index.tsx
@@ -1,7 +1,7 @@
 import IconButton from '@mui/material/IconButton';
 
 import { useThemeMode } from '../../ThemeProvider/context/ThemeModeContext';
-import { DarkModeIcon, LightModeIcon } from '../../ui';
+import { DarkModeIcon, LightModeIcon } from '../../icons';
 
 const LABEL_PARA_ESCURO = 'Ativar tema escuro';
 const LABEL_PARA_CLARO = 'Ativar tema claro';

--- a/FateConnect/Web/src/design-system/icons.ts
+++ b/FateConnect/Web/src/design-system/icons.ts
@@ -1,0 +1,30 @@
+/**
+ * Ícones expostos pelo design system, separados dos componentes.
+ *
+ * A aplicação importa daqui — `import { AddIcon } from '@design-system/icons'` —,
+ * nunca de `@mui/icons-material`: trocar a biblioteca de ícones fica sendo uma
+ * mudança neste arquivo, não uma varredura pelo app.
+ */
+export { default as AccessTimeIcon } from '@mui/icons-material/AccessTime';
+export { default as AddIcon } from '@mui/icons-material/Add';
+export { default as ArrowBackIcon } from '@mui/icons-material/ArrowBack';
+export { default as CalendarTodayIcon } from '@mui/icons-material/CalendarToday';
+export { default as DarkModeIcon } from '@mui/icons-material/DarkMode';
+export { default as DeleteIcon } from '@mui/icons-material/Delete';
+export { default as DirectionsCarIcon } from '@mui/icons-material/DirectionsCar';
+export { default as EditIcon } from '@mui/icons-material/Edit';
+export { default as EmailIcon } from '@mui/icons-material/Email';
+export { default as FilterAltIcon } from '@mui/icons-material/FilterAlt';
+export { default as GroupsIcon } from '@mui/icons-material/Groups';
+export { default as InfoIcon } from '@mui/icons-material/Info';
+export { default as LightModeIcon } from '@mui/icons-material/LightMode';
+export { default as LocationOnIcon } from '@mui/icons-material/LocationOn';
+export { default as MenuIcon } from '@mui/icons-material/Menu';
+export { default as PhoneIcon } from '@mui/icons-material/Phone';
+export { default as ScheduleIcon } from '@mui/icons-material/Schedule';
+export { default as SearchIcon } from '@mui/icons-material/Search';
+export { default as SecurityIcon } from '@mui/icons-material/Security';
+export { default as VisibilityIcon } from '@mui/icons-material/Visibility';
+export { default as VisibilityOffIcon } from '@mui/icons-material/VisibilityOff';
+
+export type { SvgIconComponent } from '@mui/icons-material';

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -1,8 +1,10 @@
 /**
- * Ponto de entrada público do design system.
+ * Ponto de entrada público do design system — componentes, estilo e os tokens
+ * que a aplicação de fato consome. Os ícones têm o seu próprio barrel, em
+ * `@design-system/icons`.
  *
- * A aplicação importa **apenas daqui** (`@ds`), nunca de um caminho interno —
- * é o que mantém barato extrair esta camada para um pacote no futuro.
+ * Aqui só entra o que pode ser usado direto na aplicação: o que é matéria-prima
+ * do tema — paleta, tipografia, fábrica do tema — fica interno de propósito.
  */
 export * from './ui';
 export { styled, css, keyframes, darken, lighten, alpha } from './styled';
@@ -24,20 +26,14 @@ export { DateLocalizationProvider } from './DateLocalizationProvider';
 export { useThemeMode } from './ThemeProvider/context/ThemeModeContext';
 export { ThemeToggleButton } from './components/ThemeToggleButton';
 export { GlobalStyles } from './GlobalStyles';
-export { createAppTheme, spacing, radius, components } from './theme';
+export { spacing, radius } from './theme';
 export {
   spacingScale,
   radiusScale,
   shadowTokens,
   iconSizeTokens,
-  fontFamily,
-  typographyTokens,
-  MOBILE_MAX_WIDTH_PX,
-  TABLET_MAX_WIDTH_PX,
-  COMPACT_MAX_WIDTH_PX,
   compactMedia,
   mobileMedia,
   tabletMedia,
   desktopMedia,
 } from './tokens';
-export type { SpacingToken, RadiusToken, TypographyToken } from './tokens';

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -12,6 +12,12 @@ export { Header } from './components/Header';
 export { HEADER_HEIGHT_PX } from './components/Header/styles';
 export { Footer } from './components/Footer';
 export { NavigationDrawer } from './components/NavigationDrawer';
+export { ConfirmDialog } from './components/ConfirmDialog';
+export { StatusTag } from './components/StatusTag';
+export type { StatusTagProps } from './components/StatusTag';
+export type { StatusTagTone } from './components/StatusTag/types';
+export type { ConfirmDialogProps } from './components/ConfirmDialog';
+export type { DialogMessageProps } from './components/ConfirmDialog/DialogMessage';
 
 export { ThemeProvider } from './ThemeProvider';
 export { DateLocalizationProvider } from './DateLocalizationProvider';
@@ -22,13 +28,14 @@ export { createAppTheme, spacing, radius, components } from './theme';
 export {
   spacingScale,
   radiusScale,
-  colorTokens,
   shadowTokens,
   iconSizeTokens,
   fontFamily,
   typographyTokens,
   MOBILE_MAX_WIDTH_PX,
   TABLET_MAX_WIDTH_PX,
+  COMPACT_MAX_WIDTH_PX,
+  compactMedia,
   mobileMedia,
   tabletMedia,
   desktopMedia,

--- a/FateConnect/Web/src/design-system/styled.ts
+++ b/FateConnect/Web/src/design-system/styled.ts
@@ -20,5 +20,9 @@ import type { ElementType } from 'react';
  * O `styled` do Emotion não preserva a assinatura polimórfica do `Box`, então a
  * prop `component` some da tipagem. Declarar este genérico devolve a prop:
  * `styled(Box)<PolymorphicProps>({ ... })`.
+ *
+ * Quando o elemento alvo tem props próprias — um `NavLink` com `to`, por
+ * exemplo —, declare-as no parâmetro:
+ * `styled(Box)<PolymorphicProps<Pick<NavLinkProps, 'to'>>>({ ... })`.
  */
-export type PolymorphicProps = { component?: ElementType };
+export type PolymorphicProps<TargetProps = unknown> = { component?: ElementType } & TargetProps;

--- a/FateConnect/Web/src/design-system/theme/contrast.test.ts
+++ b/FateConnect/Web/src/design-system/theme/contrast.test.ts
@@ -41,6 +41,8 @@ describe('light theme contrast', () => {
     ['content on the secondary colour', palette.secondary.contrastText, palette.secondary.main],
     ['content on the error colour', palette.error.contrastText, palette.error.main],
     ['content on the app chrome', onChromeSurface(lightTheme), chromeSurface(lightTheme)],
+    ['a success tag', palette.success.main, palette.success.light],
+    ['a warning tag', palette.warning.main, palette.warning.light],
   ])('should meet AA for %s', (_, foreground, background) => {
     expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
   });
@@ -57,6 +59,8 @@ describe('dark theme contrast', () => {
     ['the secondary colour on the background', palette.secondary.main, palette.background.default],
     ['the error colour on the background', palette.error.main, palette.background.default],
     ['content on the app chrome', onChromeSurface(darkTheme), chromeSurface(darkTheme)],
+    ['a success tag', palette.success.main, palette.success.light],
+    ['a warning tag', palette.warning.main, palette.warning.light],
   ])('should meet AA for %s', (_, foreground, background) => {
     expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
   });

--- a/FateConnect/Web/src/design-system/theme/palettes.ts
+++ b/FateConnect/Web/src/design-system/theme/palettes.ts
@@ -30,6 +30,7 @@ export const lightPalette: PaletteOptions = {
     dark: colorVariants.errorDark,
     contrastText: colorTokens.surfaceWhite,
   },
+  // `light` é o fundo da etiqueta de estado e `main` o texto sobre ele.
   success: { main: colorTokens.successText, light: colorTokens.successBackground },
   warning: { main: colorTokens.warningText, light: colorTokens.warningBackground },
   background: { default: colorTokens.surfaceGray, paper: colorTokens.surfaceWhite },
@@ -56,8 +57,10 @@ export const darkPalette: PaletteOptions = {
     main: darkColorTokens.error,
     contrastText: darkColorTokens.surface,
   },
-  success: { main: colorTokens.successBackground },
-  warning: { main: colorTokens.warningBackground },
+  // `light` é o fundo da etiqueta e `main` o texto sobre ele — mesmo contrato
+  // do tema claro, com o par invertido para continuar legível no escuro.
+  success: { light: darkColorTokens.successTagBackground, main: darkColorTokens.successTagText },
+  warning: { light: darkColorTokens.warningTagBackground, main: darkColorTokens.warningTagText },
   background: {
     default: darkColorTokens.surface,
     paper: darkColorTokens.surfaceElevated,

--- a/FateConnect/Web/src/design-system/tokens/breakpoints.ts
+++ b/FateConnect/Web/src/design-system/tokens/breakpoints.ts
@@ -2,8 +2,12 @@
  * Larguras máximas dos breakpoints do produto. Não coincidem com os do MUI
  * (`md` = 900px), por isso são declaradas aqui e usadas direto nos estilos.
  */
+export const COMPACT_MAX_WIDTH_PX = 600;
 export const MOBILE_MAX_WIDTH_PX = 768;
 export const TABLET_MAX_WIDTH_PX = 968;
+
+/** Consulta mais estreita, usada pelo cartão de carona ao empilhar a etiqueta. */
+export const compactMedia = `@media (max-width: ${COMPACT_MAX_WIDTH_PX}px)`;
 
 /** Media query de mobile (topo, rodapé, menu lateral, cartões). */
 export const mobileMedia = `@media (max-width: ${MOBILE_MAX_WIDTH_PX}px)`;

--- a/FateConnect/Web/src/design-system/tokens/index.ts
+++ b/FateConnect/Web/src/design-system/tokens/index.ts
@@ -11,6 +11,8 @@ export {
 } from './palette';
 export { fontFamily, typographyTokens } from './typography';
 export {
+  COMPACT_MAX_WIDTH_PX,
+  compactMedia,
   MOBILE_MAX_WIDTH_PX,
   TABLET_MAX_WIDTH_PX,
   mobileMedia,

--- a/FateConnect/Web/src/design-system/tokens/palette.ts
+++ b/FateConnect/Web/src/design-system/tokens/palette.ts
@@ -81,6 +81,16 @@ export const darkColorTokens = {
   /** Superfície elevada: sobreposição branca de 5%, como o M2 prescreve para 1dp. */
   surfaceElevated: '#1E1E1E',
 
+  /**
+   * Etiquetas de estado. No tema claro elas são fundo claro com texto escuro;
+   * no escuro isso se inverte, senão o texto some no próprio fundo. Os fundos
+   * são a cor de estado a 16% já achatada sobre a superfície elevada.
+   */
+  successTagBackground: '#3B3F3C',
+  successTagText: '#A5D6A7',
+  warningTagBackground: '#424038',
+  warningTagText: '#FFE082',
+
   onSurfaceHigh: 'rgba(255, 255, 255, 0.87)',
   onSurfaceMedium: 'rgba(255, 255, 255, 0.60)',
   onSurfaceDisabled: 'rgba(255, 255, 255, 0.38)',

--- a/FateConnect/Web/src/design-system/ui.ts
+++ b/FateConnect/Web/src/design-system/ui.ts
@@ -4,15 +4,21 @@
  * A aplicação importa daqui, nunca de `@mui/material` — é o que permite
  * envolver, substituir ou restringir um componente sem varrer o app inteiro.
  */
+export { default as Accordion } from '@mui/material/Accordion';
+export { default as AccordionDetails } from '@mui/material/AccordionDetails';
+export { default as AccordionSummary } from '@mui/material/AccordionSummary';
 export { default as AppBar } from '@mui/material/AppBar';
 export { default as Box } from '@mui/material/Box';
 export { default as Button } from '@mui/material/Button';
 export { default as Checkbox } from '@mui/material/Checkbox';
 export { default as CircularProgress } from '@mui/material/CircularProgress';
+export { default as Dialog } from '@mui/material/Dialog';
+export { default as DialogActions } from '@mui/material/DialogActions';
+export { default as DialogContent } from '@mui/material/DialogContent';
 export { default as Drawer } from '@mui/material/Drawer';
 export { default as FormControlLabel } from '@mui/material/FormControlLabel';
-export { default as InputAdornment } from '@mui/material/InputAdornment';
 export { default as IconButton } from '@mui/material/IconButton';
+export { default as InputAdornment } from '@mui/material/InputAdornment';
 export { default as List } from '@mui/material/List';
 export { default as ListItemButton } from '@mui/material/ListItemButton';
 export { default as ListItemText } from '@mui/material/ListItemText';
@@ -21,26 +27,36 @@ export { default as Popover } from '@mui/material/Popover';
 export { default as Stack } from '@mui/material/Stack';
 export { default as TextField } from '@mui/material/TextField';
 export { default as Toolbar } from '@mui/material/Toolbar';
+export { default as Tooltip } from '@mui/material/Tooltip';
 export { default as Typography } from '@mui/material/Typography';
 
+export type { BoxProps } from '@mui/material/Box';
 export type { ButtonProps } from '@mui/material/Button';
 export type { TypographyProps } from '@mui/material/Typography';
 export type { SvgIconComponent } from '@mui/icons-material';
-export type { BoxProps } from '@mui/material/Box';
 
+export { default as AccessTimeIcon } from '@mui/icons-material/AccessTime';
+export { default as AddIcon } from '@mui/icons-material/Add';
+export { default as ArrowBackIcon } from '@mui/icons-material/ArrowBack';
 export { default as CalendarTodayIcon } from '@mui/icons-material/CalendarToday';
-export { default as DirectionsCarIcon } from '@mui/icons-material/DirectionsCar';
 export { default as DarkModeIcon } from '@mui/icons-material/DarkMode';
+export { default as DeleteIcon } from '@mui/icons-material/Delete';
+export { default as DirectionsCarIcon } from '@mui/icons-material/DirectionsCar';
+export { default as EditIcon } from '@mui/icons-material/Edit';
 export { default as EmailIcon } from '@mui/icons-material/Email';
-export { default as LightModeIcon } from '@mui/icons-material/LightMode';
+export { default as FilterAltIcon } from '@mui/icons-material/FilterAlt';
 export { default as GroupsIcon } from '@mui/icons-material/Groups';
+export { default as InfoIcon } from '@mui/icons-material/Info';
+export { default as LightModeIcon } from '@mui/icons-material/LightMode';
 export { default as LocationOnIcon } from '@mui/icons-material/LocationOn';
 export { default as MenuIcon } from '@mui/icons-material/Menu';
 export { default as PhoneIcon } from '@mui/icons-material/Phone';
+export { default as ScheduleIcon } from '@mui/icons-material/Schedule';
 export { default as SearchIcon } from '@mui/icons-material/Search';
 export { default as SecurityIcon } from '@mui/icons-material/Security';
 export { default as VisibilityIcon } from '@mui/icons-material/Visibility';
 export { default as VisibilityOffIcon } from '@mui/icons-material/VisibilityOff';
 
-/** Calendário do seletor de data. O locale vem do `DateLocalizationProvider`. */
+/** Componentes de data. O locale vem do `DateLocalizationProvider`. */
 export { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+export { DatePicker } from '@mui/x-date-pickers/DatePicker';

--- a/FateConnect/Web/src/design-system/ui.ts
+++ b/FateConnect/Web/src/design-system/ui.ts
@@ -33,29 +33,6 @@ export { default as Typography } from '@mui/material/Typography';
 export type { BoxProps } from '@mui/material/Box';
 export type { ButtonProps } from '@mui/material/Button';
 export type { TypographyProps } from '@mui/material/Typography';
-export type { SvgIconComponent } from '@mui/icons-material';
-
-export { default as AccessTimeIcon } from '@mui/icons-material/AccessTime';
-export { default as AddIcon } from '@mui/icons-material/Add';
-export { default as ArrowBackIcon } from '@mui/icons-material/ArrowBack';
-export { default as CalendarTodayIcon } from '@mui/icons-material/CalendarToday';
-export { default as DarkModeIcon } from '@mui/icons-material/DarkMode';
-export { default as DeleteIcon } from '@mui/icons-material/Delete';
-export { default as DirectionsCarIcon } from '@mui/icons-material/DirectionsCar';
-export { default as EditIcon } from '@mui/icons-material/Edit';
-export { default as EmailIcon } from '@mui/icons-material/Email';
-export { default as FilterAltIcon } from '@mui/icons-material/FilterAlt';
-export { default as GroupsIcon } from '@mui/icons-material/Groups';
-export { default as InfoIcon } from '@mui/icons-material/Info';
-export { default as LightModeIcon } from '@mui/icons-material/LightMode';
-export { default as LocationOnIcon } from '@mui/icons-material/LocationOn';
-export { default as MenuIcon } from '@mui/icons-material/Menu';
-export { default as PhoneIcon } from '@mui/icons-material/Phone';
-export { default as ScheduleIcon } from '@mui/icons-material/Schedule';
-export { default as SearchIcon } from '@mui/icons-material/Search';
-export { default as SecurityIcon } from '@mui/icons-material/Security';
-export { default as VisibilityIcon } from '@mui/icons-material/Visibility';
-export { default as VisibilityOffIcon } from '@mui/icons-material/VisibilityOff';
 
 /** Componentes de data. O locale vem do `DateLocalizationProvider`. */
 export { DateCalendar } from '@mui/x-date-pickers/DateCalendar';

--- a/FateConnect/Web/src/hooks/useHashScroll.test.tsx
+++ b/FateConnect/Web/src/hooks/useHashScroll.test.tsx
@@ -1,7 +1,7 @@
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { render } from '@app/test/testing-library';
 import { useHashScroll } from './useHashScroll';
 
@@ -12,9 +12,10 @@ function ScreenWithHash() {
 }
 
 function renderAt(initialPath: string) {
-  const router = createMemoryRouter([{ path: RoutePath.LANDING, element: <ScreenWithHash /> }], {
-    initialEntries: [initialPath],
-  });
+  const router = createMemoryRouter(
+    [{ path: RoutePathEnum.LANDING, element: <ScreenWithHash /> }],
+    { initialEntries: [initialPath] },
+  );
   render(<RouterProvider router={router} />);
 }
 
@@ -26,10 +27,10 @@ describe('useHashScroll', () => {
   it('should scroll to the section when the URL carries a fragment', () => {
     const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView');
     const section = document.createElement('section');
-    section.id = LandingSection.LOGIN;
+    section.id = LandingSectionEnum.LOGIN;
     document.body.appendChild(section);
 
-    renderAt(`${RoutePath.LANDING}#${LandingSection.LOGIN}`);
+    renderAt(`${RoutePathEnum.LANDING}#${LandingSectionEnum.LOGIN}`);
 
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
 
@@ -39,7 +40,7 @@ describe('useHashScroll', () => {
   it('should not scroll when the URL has no fragment', () => {
     const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView');
 
-    renderAt(RoutePath.LANDING);
+    renderAt(RoutePathEnum.LANDING);
 
     expect(scrollIntoView).not.toHaveBeenCalled();
   });

--- a/FateConnect/Web/src/hooks/useLandingAnchor.test.tsx
+++ b/FateConnect/Web/src/hooks/useLandingAnchor.test.tsx
@@ -1,7 +1,7 @@
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent } from '@app/test/testing-library';
 import { useLandingAnchor } from './useLandingAnchor';
 
@@ -9,7 +9,7 @@ function SectionButton() {
   const goToSection = useLandingAnchor();
 
   return (
-    <button type="button" onClick={() => goToSection(LandingSection.SERVICES)}>
+    <button type="button" onClick={() => goToSection(LandingSectionEnum.SERVICES)}>
       Serviços
     </button>
   );
@@ -18,8 +18,8 @@ function SectionButton() {
 function renderAt(initialPath: string) {
   const router = createMemoryRouter(
     [
-      { path: RoutePath.LANDING, element: <SectionButton /> },
-      { path: RoutePath.CONTACT, element: <SectionButton /> },
+      { path: RoutePathEnum.LANDING, element: <SectionButton /> },
+      { path: RoutePathEnum.CONTACT, element: <SectionButton /> },
     ],
     { initialEntries: [initialPath] },
   );
@@ -34,21 +34,21 @@ describe('useLandingAnchor', () => {
   });
 
   it('should navigate to the landing page with the fragment when on another route', async () => {
-    const router = renderAt(RoutePath.CONTACT);
+    const router = renderAt(RoutePathEnum.CONTACT);
 
     await userEvent.click(screen.getByRole('button', { name: 'Serviços' }));
 
-    expect(router.state.location.pathname).toBe(RoutePath.LANDING);
-    expect(router.state.location.hash).toBe(`#${LandingSection.SERVICES}`);
+    expect(router.state.location.pathname).toBe(RoutePathEnum.LANDING);
+    expect(router.state.location.hash).toBe(`#${LandingSectionEnum.SERVICES}`);
   });
 
   it('should scroll to the section without navigating when already on the landing page', async () => {
     const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView');
     const section = document.createElement('section');
-    section.id = LandingSection.SERVICES;
+    section.id = LandingSectionEnum.SERVICES;
     document.body.appendChild(section);
 
-    const router = renderAt(RoutePath.LANDING);
+    const router = renderAt(RoutePathEnum.LANDING);
     await userEvent.click(screen.getByRole('button', { name: 'Serviços' }));
 
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });

--- a/FateConnect/Web/src/hooks/useLandingAnchor.ts
+++ b/FateConnect/Web/src/hooks/useLandingAnchor.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
-import { RoutePath } from '@app/routes/paths';
+import { RoutePathEnum } from '@app/routes/paths';
 import { scrollToSection } from '@app/utils/scrollToSection';
 
 /**
@@ -18,8 +18,8 @@ export function useLandingAnchor(): (sectionId: string) => void {
 
   return useCallback(
     (sectionId: string) => {
-      if (pathname !== RoutePath.LANDING) {
-        navigate(`${RoutePath.LANDING}#${sectionId}`);
+      if (pathname !== RoutePathEnum.LANDING) {
+        navigate(`${RoutePathEnum.LANDING}#${sectionId}`);
         return;
       }
 

--- a/FateConnect/Web/src/layouts/GuestLayout/GuestLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/GuestLayout.test.tsx
@@ -1,7 +1,7 @@
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent, within } from '@app/test/testing-library';
 import { GuestLayout } from '.';
 
@@ -10,10 +10,10 @@ function renderLayout() {
     [
       {
         element: <GuestLayout />,
-        children: [{ path: RoutePath.LANDING, element: <div>landing</div> }],
+        children: [{ path: RoutePathEnum.LANDING, element: <div>landing</div> }],
       },
     ],
-    { initialEntries: [RoutePath.LANDING] },
+    { initialEntries: [RoutePathEnum.LANDING] },
   );
   render(<RouterProvider router={router} />);
 
@@ -50,7 +50,7 @@ describe('GuestLayout', () => {
     await userEvent.click(within(drawer).getByRole('button', { name: 'Serviços' }));
 
     expect(router.state.location.hash).toBe('');
-    expect(document.getElementById(LandingSection.SERVICES)).not.toBeInTheDocument();
+    expect(document.getElementById(LandingSectionEnum.SERVICES)).not.toBeInTheDocument();
   });
 
   it('should point the logo to the landing page', () => {
@@ -58,7 +58,7 @@ describe('GuestLayout', () => {
 
     expect(screen.getAllByRole('link', { name: 'FateConnect' })[0]).toHaveAttribute(
       'href',
-      RoutePath.LANDING,
+      RoutePathEnum.LANDING,
     );
   });
 

--- a/FateConnect/Web/src/layouts/GuestLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/index.tsx
@@ -6,7 +6,7 @@ import { LandingNavButton } from '@app/components/LandingNavButton';
 import { APP_CONTACT, FOOTER_COPYRIGHT_LINES, FOOTER_TITLE } from '@app/constants/appContact';
 import { LANDING_LINKS } from '@app/constants/navigation';
 import { useLandingAnchor } from '@app/hooks/useLandingAnchor';
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { Footer, Header, NavigationDrawer, ThemeToggleButton, Typography } from '@design-system';
 import * as S from '../shell.styles';
 
@@ -20,7 +20,7 @@ export function GuestLayout() {
   const handleMenuClick = useCallback(() => setDrawerOpen(true), []);
   const handleDrawerClose = useCallback(() => setDrawerOpen(false), []);
   const handleSectionSelect = useCallback(
-    (section: LandingSection) => {
+    (section: LandingSectionEnum) => {
       setDrawerOpen(false);
       goToSection(section);
     },
@@ -28,7 +28,7 @@ export function GuestLayout() {
   );
 
   const logo = (
-    <RouterLink to={RoutePath.LANDING} aria-label="FateConnect">
+    <RouterLink to={RoutePathEnum.LANDING} aria-label="FateConnect">
       <Typography variant="logo" color="inherit">
         FateConnect
       </Typography>
@@ -69,7 +69,7 @@ export function GuestLayout() {
       </S.ShellContent>
 
       <Footer
-        anchorId={LandingSection.CONTACT}
+        anchorId={LandingSectionEnum.CONTACT}
         title={FOOTER_TITLE}
         contact={APP_CONTACT}
         copyrightLines={FOOTER_COPYRIGHT_LINES}

--- a/FateConnect/Web/src/layouts/GuestLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/index.tsx
@@ -3,7 +3,7 @@ import { Link as RouterLink, Outlet } from 'react-router';
 
 import { DrawerSectionItem } from '@app/components/DrawerSectionItem';
 import { LandingNavButton } from '@app/components/LandingNavButton';
-import { APP_CONTACT, FOOTER_COPYRIGHT_LINES, FOOTER_TITLE } from '@app/constants/appContact';
+import * as C from '@app/constants/appContact';
 import { LANDING_LINKS } from '@app/constants/navigation';
 import { useLandingAnchor } from '@app/hooks/useLandingAnchor';
 import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
@@ -70,9 +70,9 @@ export function GuestLayout() {
 
       <Footer
         anchorId={LandingSectionEnum.CONTACT}
-        title={FOOTER_TITLE}
-        contact={APP_CONTACT}
-        copyrightLines={FOOTER_COPYRIGHT_LINES}
+        title={C.FOOTER_TITLE}
+        contact={C.APP_CONTACT}
+        copyrightLines={C.FOOTER_COPYRIGHT_LINES}
       />
     </S.ShellRoot>
   );

--- a/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
@@ -1,7 +1,7 @@
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
-import { RoutePath } from '@app/routes/paths';
+import { RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent, within } from '@app/test/testing-library';
 import { MainLayout } from '.';
 
@@ -11,12 +11,12 @@ function renderLayout() {
       {
         element: <MainLayout />,
         children: [
-          { path: RoutePath.MENU, element: <div>menu</div> },
-          { path: RoutePath.RIDES, element: <div>caronas</div> },
+          { path: RoutePathEnum.MENU, element: <div>menu</div> },
+          { path: RoutePathEnum.RIDES, element: <div>caronas</div> },
         ],
       },
     ],
-    { initialEntries: [RoutePath.MENU] },
+    { initialEntries: [RoutePathEnum.MENU] },
   );
   render(<RouterProvider router={router} />);
 
@@ -41,7 +41,7 @@ describe('MainLayout', () => {
     const drawer = screen.getByRole('presentation');
     await userEvent.click(within(drawer).getByRole('link', { name: 'Caronas' }));
 
-    expect(router.state.location.pathname).toBe(RoutePath.RIDES);
+    expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES);
   });
 
   it('should point the logo to the menu', () => {
@@ -49,7 +49,7 @@ describe('MainLayout', () => {
 
     expect(screen.getAllByRole('link', { name: 'FateConnect' })[0]).toHaveAttribute(
       'href',
-      RoutePath.MENU,
+      RoutePathEnum.MENU,
     );
   });
 });

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -3,7 +3,7 @@ import { Link as RouterLink, Outlet } from 'react-router';
 
 import { APP_CONTACT, FOOTER_COPYRIGHT_LINES, FOOTER_TITLE } from '@app/constants/appContact';
 import { APP_LINKS } from '@app/constants/navigation';
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import {
   Button,
   Footer,
@@ -26,7 +26,7 @@ export function MainLayout() {
   const handleDrawerClose = useCallback(() => setDrawerOpen(false), []);
 
   const logo = (
-    <RouterLink to={RoutePath.MENU} aria-label="FateConnect">
+    <RouterLink to={RoutePathEnum.MENU} aria-label="FateConnect">
       <Typography variant="logo" color="inherit">
         FateConnect
       </Typography>
@@ -60,7 +60,7 @@ export function MainLayout() {
       </S.ShellContent>
 
       <Footer
-        anchorId={LandingSection.CONTACT}
+        anchorId={LandingSectionEnum.CONTACT}
         title={FOOTER_TITLE}
         contact={APP_CONTACT}
         copyrightLines={FOOTER_COPYRIGHT_LINES}

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { Link as RouterLink, Outlet } from 'react-router';
 
-import { APP_CONTACT, FOOTER_COPYRIGHT_LINES, FOOTER_TITLE } from '@app/constants/appContact';
+import * as C from '@app/constants/appContact';
 import { APP_LINKS } from '@app/constants/navigation';
 import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import {
@@ -61,9 +61,9 @@ export function MainLayout() {
 
       <Footer
         anchorId={LandingSectionEnum.CONTACT}
-        title={FOOTER_TITLE}
-        contact={APP_CONTACT}
-        copyrightLines={FOOTER_COPYRIGHT_LINES}
+        title={C.FOOTER_TITLE}
+        contact={C.APP_CONTACT}
+        copyrightLines={C.FOOTER_COPYRIGHT_LINES}
       />
     </S.ShellRoot>
   );

--- a/FateConnect/Web/src/pages/Home/Home.test.tsx
+++ b/FateConnect/Web/src/pages/Home/Home.test.tsx
@@ -1,7 +1,7 @@
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { render, screen, within } from '@app/test/testing-library';
 import { Home } from '.';
 import {
@@ -12,8 +12,8 @@ import { HOW_IT_WORKS_STEPS, HOW_IT_WORKS_TITLE } from './components/LandingHowI
 import { SERVICE_CARDS, SERVICES_TITLE } from './components/LandingServices/constants';
 
 function renderHome() {
-  const router = createMemoryRouter([{ path: RoutePath.LANDING, element: <Home /> }], {
-    initialEntries: [RoutePath.LANDING],
+  const router = createMemoryRouter([{ path: RoutePathEnum.LANDING, element: <Home /> }], {
+    initialEntries: [RoutePathEnum.LANDING],
   });
   render(<RouterProvider router={router} />);
 }
@@ -53,7 +53,11 @@ describe('Home', () => {
   it('should expose the anchors targeted by the header navigation', () => {
     renderHome();
 
-    [LandingSection.SERVICES, LandingSection.HOW_IT_WORKS, LandingSection.LOGIN].forEach((id) => {
+    [
+      LandingSectionEnum.SERVICES,
+      LandingSectionEnum.HOW_IT_WORKS,
+      LandingSectionEnum.LOGIN,
+    ].forEach((id) => {
       expect(document.getElementById(id)).toBeInTheDocument();
     });
   });

--- a/FateConnect/Web/src/pages/Home/components/LandingDescription/constants/index.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingDescription/constants/index.ts
@@ -4,7 +4,7 @@ import {
   SearchIcon,
   SecurityIcon,
   type SvgIconComponent,
-} from '@design-system';
+} from '@design-system/icons';
 
 export type DescriptionHighlight = { label: string; Icon: SvgIconComponent };
 

--- a/FateConnect/Web/src/pages/Home/components/LandingDescription/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingDescription/index.tsx
@@ -1,21 +1,21 @@
 import { Typography } from '@design-system';
 
-import { DESCRIPTION_HIGHLIGHTS, DESCRIPTION_LEAD, DESCRIPTION_TITLE } from './constants';
+import * as C from './constants';
 import * as S from './styles';
 
 export function LandingDescription() {
   return (
     <S.DescriptionRoot>
       <S.TitleContainer>
-        <Typography variant="h1">{DESCRIPTION_TITLE}</Typography>
+        <Typography variant="h1">{C.DESCRIPTION_TITLE}</Typography>
       </S.TitleContainer>
 
       <S.Lead component="p">
-        <Typography variant="subtitle">{DESCRIPTION_LEAD}</Typography>
+        <Typography variant="subtitle">{C.DESCRIPTION_LEAD}</Typography>
       </S.Lead>
 
       <S.HighlightList component="ul" aria-label="Destaques do FateConnect">
-        {DESCRIPTION_HIGHLIGHTS.map(({ label, Icon }) => (
+        {C.DESCRIPTION_HIGHLIGHTS.map(({ label, Icon }) => (
           <S.HighlightItem component="li" key={label}>
             <S.IconDisc component="span" aria-hidden="true">
               <Icon />

--- a/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingHowItWorks/index.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@design-system';
 
-import { LandingSection } from '@app/routes/paths';
+import { LandingSectionEnum } from '@app/routes/paths';
 import { HOW_IT_WORKS_STEPS, HOW_IT_WORKS_TITLE } from './constants';
 import * as S from './styles';
 
@@ -8,7 +8,11 @@ const HEADING_ID = 'como-funciona-heading';
 
 export function LandingHowItWorks() {
   return (
-    <S.HowSection component="section" id={LandingSection.HOW_IT_WORKS} aria-labelledby={HEADING_ID}>
+    <S.HowSection
+      component="section"
+      id={LandingSectionEnum.HOW_IT_WORKS}
+      aria-labelledby={HEADING_ID}
+    >
       <S.SectionTitle>
         <Typography variant="h1" id={HEADING_ID}>
           {HOW_IT_WORKS_TITLE}

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
@@ -3,7 +3,7 @@ import { RouterProvider, createMemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '@app/mocks/server';
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 import { LandingLoginCard } from '.';
 import { LOGIN_ERROR_MESSAGES, PASSWORD_TOGGLE_LABEL, SUBMIT_LABEL } from './constants';
@@ -11,11 +11,11 @@ import { LOGIN_MESSAGES } from './schema';
 
 const LOGIN_URL = 'https://api.fateconnect.test/auth/login';
 
-function renderCard(initialPath: string = RoutePath.LANDING) {
+function renderCard(initialPath: string = RoutePathEnum.LANDING) {
   const router = createMemoryRouter(
     [
-      { path: RoutePath.LANDING, element: <LandingLoginCard /> },
-      { path: RoutePath.MENU, element: <div>menu</div> },
+      { path: RoutePathEnum.LANDING, element: <LandingLoginCard /> },
+      { path: RoutePathEnum.MENU, element: <div>menu</div> },
     ],
     { initialEntries: [initialPath] },
   );
@@ -82,7 +82,7 @@ describe('LandingLoginCard', () => {
     await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
 
     expect(await screen.findByText('Bem-vindo(a), Fulano de Tal!')).toBeInTheDocument();
-    expect(router.state.location.pathname).toBe(RoutePath.MENU);
+    expect(router.state.location.pathname).toBe(RoutePathEnum.MENU);
   });
 
   it('should report invalid credentials when the api answers unauthorized', async () => {
@@ -132,7 +132,7 @@ describe('LandingLoginCard', () => {
   });
 
   it('should focus the email field when the page is opened at the login anchor', async () => {
-    renderCard(`${RoutePath.LANDING}#${LandingSection.LOGIN}`);
+    renderCard(`${RoutePathEnum.LANDING}#${LandingSectionEnum.LOGIN}`);
 
     expect(screen.getByLabelText(/E-mail/)).toHaveFocus();
   });

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
@@ -6,7 +6,7 @@ import { server } from '@app/mocks/server';
 import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 import { LandingLoginCard } from '.';
-import { LOGIN_ERROR_MESSAGES, PASSWORD_TOGGLE_LABEL, SUBMIT_LABEL } from './constants';
+import * as C from './constants';
 import { LOGIN_MESSAGES } from './schema';
 
 const LOGIN_URL = 'https://api.fateconnect.test/auth/login';
@@ -33,7 +33,7 @@ describe('LandingLoginCard', () => {
   it('should show the required messages when submitting an empty form', async () => {
     renderCard();
 
-    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.SUBMIT_LABEL }));
 
     expect(await screen.findByText(LOGIN_MESSAGES.emailRequired)).toBeInTheDocument();
     expect(screen.getByText(LOGIN_MESSAGES.passwordRequired)).toBeInTheDocument();
@@ -43,7 +43,7 @@ describe('LandingLoginCard', () => {
     renderCard();
     await preencher('nao-e-email', 'segredo123');
 
-    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.SUBMIT_LABEL }));
 
     expect(await screen.findByText(LOGIN_MESSAGES.emailInvalid)).toBeInTheDocument();
   });
@@ -54,7 +54,7 @@ describe('LandingLoginCard', () => {
 
     expect(campoSenha).toHaveAttribute('type', 'password');
 
-    await userEvent.click(screen.getByRole('button', { name: PASSWORD_TOGGLE_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.PASSWORD_TOGGLE_LABEL }));
 
     expect(campoSenha).toHaveAttribute('type', 'text');
   });
@@ -65,7 +65,7 @@ describe('LandingLoginCard', () => {
     // Senha oculta: olho cortado. O ícone mostra o estado, não a ação.
     expect(screen.getByTestId('VisibilityOffIcon')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: PASSWORD_TOGGLE_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.PASSWORD_TOGGLE_LABEL }));
 
     expect(screen.getByTestId('VisibilityIcon')).toBeInTheDocument();
   });
@@ -79,7 +79,7 @@ describe('LandingLoginCard', () => {
     const router = renderCard();
     await preencher('aluno@fatec.sp.gov.br', 'segredo123');
 
-    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.SUBMIT_LABEL }));
 
     expect(await screen.findByText('Bem-vindo(a), Fulano de Tal!')).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(RoutePathEnum.MENU);
@@ -90,9 +90,9 @@ describe('LandingLoginCard', () => {
     renderCard();
     await preencher('aluno@fatec.sp.gov.br', 'segredo-errado');
 
-    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.SUBMIT_LABEL }));
 
-    expect(await screen.findByText(LOGIN_ERROR_MESSAGES.invalidCredentials)).toBeInTheDocument();
+    expect(await screen.findByText(C.LOGIN_ERROR_MESSAGES.invalidCredentials)).toBeInTheDocument();
   });
 
   it('should report a generic failure for other api errors', async () => {
@@ -100,9 +100,9 @@ describe('LandingLoginCard', () => {
     renderCard();
     await preencher('aluno@fatec.sp.gov.br', 'segredo123');
 
-    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.SUBMIT_LABEL }));
 
-    expect(await screen.findByText(LOGIN_ERROR_MESSAGES.generic)).toBeInTheDocument();
+    expect(await screen.findByText(C.LOGIN_ERROR_MESSAGES.generic)).toBeInTheDocument();
   });
 
   it('should show the loading indicator while the request is in flight', async () => {
@@ -122,9 +122,9 @@ describe('LandingLoginCard', () => {
     renderCard();
     await preencher('aluno@fatec.sp.gov.br', 'segredo123');
 
-    await userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.SUBMIT_LABEL }));
 
-    const submitButton = screen.getByRole('button', { name: SUBMIT_LABEL });
+    const submitButton = screen.getByRole('button', { name: C.SUBMIT_LABEL });
     await waitFor(() => expect(submitButton).toBeDisabled());
     expect(within(submitButton).getByRole('progressbar')).toBeInTheDocument();
 

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router';
 
 import { useNotification } from '@app/hooks/useNotification';
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { login } from '@app/services/auth/authService';
 import type { ApiError } from '@app/services/httpClient';
 import { Button, IconButton, InputAdornment, TextField, Typography } from '@design-system';
@@ -45,7 +45,7 @@ export function LandingLoginCard() {
 
   // Chegando na landing pela âncora de login, o campo de e-mail recebe o foco.
   useEffect(() => {
-    if (hash !== `#${LandingSection.LOGIN}`) return;
+    if (hash !== `#${LandingSectionEnum.LOGIN}`) return;
 
     emailInputRef.current?.focus();
   }, [hash]);
@@ -56,7 +56,7 @@ export function LandingLoginCard() {
     meta: { notifiesErrorItself: true },
     onSuccess: (response) => {
       notifySuccess(welcomeMessage(response.nomeCompleto));
-      navigate(RoutePath.MENU);
+      navigate(RoutePathEnum.MENU);
     },
     onError: (error: ApiError) => {
       if (error.status === UNAUTHORIZED) {
@@ -135,7 +135,7 @@ export function LandingLoginCard() {
 
       <S.SignupRow component="p">
         <Typography variant="caption">{SIGNUP_PROMPT}</Typography>
-        <RouterLink to={RoutePath.SIGNUP}>
+        <RouterLink to={RoutePathEnum.SIGNUP}>
           <Typography variant="captionBold">{SIGNUP_LINK_LABEL}</Typography>
         </RouterLink>
       </S.SignupRow>

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -59,6 +59,8 @@ export function LandingLoginCard() {
 
   const { mutate, isPending } = useMutation({
     mutationFn: login,
+    // A mensagem depende do status; o aviso sai daqui, não do tratamento global.
+    meta: { notifiesErrorItself: true },
     onSuccess: (response) => {
       notifySuccess(welcomeMessage(response.nomeCompleto));
       navigate(RoutePath.MENU);

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -8,15 +8,8 @@ import { useNotification } from '@app/hooks/useNotification';
 import { LandingSection, RoutePath } from '@app/routes/paths';
 import { login } from '@app/services/auth/authService';
 import type { ApiError } from '@app/services/httpClient';
-import {
-  Button,
-  IconButton,
-  InputAdornment,
-  TextField,
-  Typography,
-  VisibilityIcon,
-  VisibilityOffIcon,
-} from '@design-system';
+import { Button, IconButton, InputAdornment, TextField, Typography } from '@design-system';
+import { VisibilityIcon, VisibilityOffIcon } from '@design-system/icons';
 
 import {
   EMAIL_LABEL,

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -11,17 +11,7 @@ import type { ApiError } from '@app/services/httpClient';
 import { Button, IconButton, InputAdornment, TextField, Typography } from '@design-system';
 import { VisibilityIcon, VisibilityOffIcon } from '@design-system/icons';
 
-import {
-  EMAIL_LABEL,
-  LOGIN_CARD_TITLE,
-  LOGIN_ERROR_MESSAGES,
-  PASSWORD_LABEL,
-  PASSWORD_TOGGLE_LABEL,
-  SIGNUP_LINK_LABEL,
-  SIGNUP_PROMPT,
-  SUBMIT_LABEL,
-  welcomeMessage,
-} from './constants';
+import * as C from './constants';
 import { loginSchema, type LoginFormValues } from './schema';
 import * as S from './styles';
 
@@ -55,16 +45,16 @@ export function LandingLoginCard() {
     // A mensagem depende do status; o aviso sai daqui, não do tratamento global.
     meta: { notifiesErrorItself: true },
     onSuccess: (response) => {
-      notifySuccess(welcomeMessage(response.nomeCompleto));
+      notifySuccess(C.welcomeMessage(response.nomeCompleto));
       navigate(RoutePathEnum.MENU);
     },
     onError: (error: ApiError) => {
       if (error.status === UNAUTHORIZED) {
-        notifyError(LOGIN_ERROR_MESSAGES.invalidCredentials);
+        notifyError(C.LOGIN_ERROR_MESSAGES.invalidCredentials);
         return;
       }
 
-      notifyError(LOGIN_ERROR_MESSAGES.generic);
+      notifyError(C.LOGIN_ERROR_MESSAGES.generic);
     },
   });
 
@@ -80,7 +70,7 @@ export function LandingLoginCard() {
     <S.CardRoot component="article" aria-labelledby="landing-login-title">
       <S.CardTitle>
         <Typography variant="h2" id="landing-login-title">
-          {LOGIN_CARD_TITLE}
+          {C.LOGIN_CARD_TITLE}
         </Typography>
       </S.CardTitle>
 
@@ -91,7 +81,7 @@ export function LandingLoginCard() {
             emailFieldRef(element);
             emailInputRef.current = element;
           }}
-          label={EMAIL_LABEL}
+          label={C.EMAIL_LABEL}
           required
           type="email"
           autoComplete="username"
@@ -101,7 +91,7 @@ export function LandingLoginCard() {
 
         <TextField
           {...register('password')}
-          label={PASSWORD_LABEL}
+          label={C.PASSWORD_LABEL}
           required
           type={passwordHidden ? 'password' : 'text'}
           autoComplete={passwordHidden ? 'current-password' : 'off'}
@@ -113,7 +103,7 @@ export function LandingLoginCard() {
                 <InputAdornment position="end">
                   <IconButton
                     type="button"
-                    aria-label={PASSWORD_TOGGLE_LABEL}
+                    aria-label={C.PASSWORD_TOGGLE_LABEL}
                     aria-pressed={!passwordHidden}
                     onClick={handleTogglePassword}
                   >
@@ -128,15 +118,15 @@ export function LandingLoginCard() {
 
         <S.SubmitRow>
           <Button type="submit" variant="contained" color="error" loading={isPending}>
-            {SUBMIT_LABEL}
+            {C.SUBMIT_LABEL}
           </Button>
         </S.SubmitRow>
       </S.Form>
 
       <S.SignupRow component="p">
-        <Typography variant="caption">{SIGNUP_PROMPT}</Typography>
+        <Typography variant="caption">{C.SIGNUP_PROMPT}</Typography>
         <RouterLink to={RoutePathEnum.SIGNUP}>
-          <Typography variant="captionBold">{SIGNUP_LINK_LABEL}</Typography>
+          <Typography variant="captionBold">{C.SIGNUP_LINK_LABEL}</Typography>
         </RouterLink>
       </S.SignupRow>
     </S.CardRoot>

--- a/FateConnect/Web/src/pages/Home/components/LandingServices/constants/index.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingServices/constants/index.ts
@@ -4,7 +4,7 @@ import {
   SearchIcon,
   SecurityIcon,
   type SvgIconComponent,
-} from '@design-system';
+} from '@design-system/icons';
 
 export type ServiceCard = { title: string; description: string; Icon: SvgIconComponent };
 

--- a/FateConnect/Web/src/pages/Home/components/LandingServices/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingServices/index.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@design-system';
 
-import { LandingSection } from '@app/routes/paths';
+import { LandingSectionEnum } from '@app/routes/paths';
 import { SERVICE_CARDS, SERVICES_TITLE } from './constants';
 import * as S from './styles';
 
@@ -10,7 +10,7 @@ export function LandingServices() {
   return (
     <S.ServicesSection
       component="section"
-      id={LandingSection.SERVICES}
+      id={LandingSectionEnum.SERVICES}
       aria-labelledby={HEADING_ID}
     >
       <S.SectionTitle>

--- a/FateConnect/Web/src/pages/Home/index.tsx
+++ b/FateConnect/Web/src/pages/Home/index.tsx
@@ -1,4 +1,4 @@
-import { LandingSection } from '@app/routes/paths';
+import { LandingSectionEnum } from '@app/routes/paths';
 import { LandingDescription } from './components/LandingDescription';
 import { LandingHowItWorks } from './components/LandingHowItWorks';
 import { LandingLoginCard } from './components/LandingLoginCard';
@@ -10,7 +10,7 @@ export function Home() {
     <S.HomeRoot>
       <S.DescriptionContainer component="section" aria-label="Apresentação e acesso">
         <LandingDescription />
-        <S.LoginAnchor id={LandingSection.LOGIN}>
+        <S.LoginAnchor id={LandingSectionEnum.LOGIN}>
           <LandingLoginCard />
         </S.LoginAnchor>
       </S.DescriptionContainer>

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -4,14 +4,14 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { server } from '@app/mocks/server';
 import { routeConfig } from '@app/routes/routeConfig';
-import { RoutePath } from '@app/routes/paths';
+import { RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent } from '@app/test/testing-library';
 import { BACK_LABEL, OFFER_TAB_LABEL, RIDES_TITLE, SEARCH_TAB_LABEL } from './constants';
 import { OFFER_TITLE } from './screens/OfferRide/constants';
 
 const RIDES_URL = 'https://rides.fateconnect.test/caronas';
 
-function renderRides(initialPath: string = RoutePath.RIDES_SEARCH) {
+function renderRides(initialPath: string = RoutePathEnum.RIDES_SEARCH) {
   const router = createMemoryRouter(routeConfig, { initialEntries: [initialPath] });
   render(<RouterProvider router={router} />);
 
@@ -27,7 +27,10 @@ describe('Rides', () => {
     renderRides();
 
     expect(screen.getByRole('heading', { name: RIDES_TITLE })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: BACK_LABEL })).toHaveAttribute('href', RoutePath.MENU);
+    expect(screen.getByRole('link', { name: BACK_LABEL })).toHaveAttribute(
+      'href',
+      RoutePathEnum.MENU,
+    );
   });
 
   it('should mark the current tab for assistive technology', () => {
@@ -45,13 +48,13 @@ describe('Rides', () => {
 
     await userEvent.click(screen.getByRole('link', { name: OFFER_TAB_LABEL }));
 
-    expect(router.state.location.pathname).toBe(RoutePath.RIDES_OFFER);
+    expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES_OFFER);
     expect(await screen.findByRole('heading', { name: OFFER_TITLE })).toBeInTheDocument();
   });
 
   it('should send the bare rides path to the search screen', () => {
-    const router = renderRides(RoutePath.RIDES);
+    const router = renderRides(RoutePathEnum.RIDES);
 
-    expect(router.state.location.pathname).toBe(RoutePath.RIDES_SEARCH);
+    expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES_SEARCH);
   });
 });

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -6,7 +6,7 @@ import { server } from '@app/mocks/server';
 import { routeConfig } from '@app/routes/routeConfig';
 import { RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent } from '@app/test/testing-library';
-import { BACK_LABEL, OFFER_TAB_LABEL, RIDES_TITLE, SEARCH_TAB_LABEL } from './constants';
+import * as C from './constants';
 import { OFFER_TITLE } from './screens/OfferRide/constants';
 
 const RIDES_URL = 'https://rides.fateconnect.test/caronas';
@@ -26,8 +26,8 @@ describe('Rides', () => {
   it('should render the title and the way back to the menu', () => {
     renderRides();
 
-    expect(screen.getByRole('heading', { name: RIDES_TITLE })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: BACK_LABEL })).toHaveAttribute(
+    expect(screen.getByRole('heading', { name: C.RIDES_TITLE })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: C.BACK_LABEL })).toHaveAttribute(
       'href',
       RoutePathEnum.MENU,
     );
@@ -36,17 +36,19 @@ describe('Rides', () => {
   it('should mark the current tab for assistive technology', () => {
     renderRides();
 
-    expect(screen.getByRole('link', { name: SEARCH_TAB_LABEL })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: C.SEARCH_TAB_LABEL })).toHaveAttribute(
       'aria-current',
       'page',
     );
-    expect(screen.getByRole('link', { name: OFFER_TAB_LABEL })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: C.OFFER_TAB_LABEL })).not.toHaveAttribute(
+      'aria-current',
+    );
   });
 
   it('should move to the offer screen through the tab', async () => {
     const router = renderRides();
 
-    await userEvent.click(screen.getByRole('link', { name: OFFER_TAB_LABEL }));
+    await userEvent.click(screen.getByRole('link', { name: C.OFFER_TAB_LABEL }));
 
     expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES_OFFER);
     expect(await screen.findByRole('heading', { name: OFFER_TITLE })).toBeInTheDocument();

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -1,0 +1,57 @@
+import { http, HttpResponse } from 'msw';
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
+import { routeConfig } from '@app/routes/routeConfig';
+import { RoutePath } from '@app/routes/paths';
+import { render, screen, userEvent } from '@app/test/testing-library';
+import { BACK_LABEL, OFFER_TAB_LABEL, RIDES_TITLE, SEARCH_TAB_LABEL } from './constants';
+import { OFFER_TITLE } from './screens/OfferRide/constants';
+
+const RIDES_URL = 'https://rides.fateconnect.test/caronas';
+
+function renderRides(initialPath: string = RoutePath.RIDES_SEARCH) {
+  const router = createMemoryRouter(routeConfig, { initialEntries: [initialPath] });
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+describe('Rides', () => {
+  beforeEach(() => {
+    server.use(http.get(RIDES_URL, () => HttpResponse.json([])));
+  });
+
+  it('should render the title and the way back to the menu', () => {
+    renderRides();
+
+    expect(screen.getByRole('heading', { name: RIDES_TITLE })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: BACK_LABEL })).toHaveAttribute('href', RoutePath.MENU);
+  });
+
+  it('should mark the current tab for assistive technology', () => {
+    renderRides();
+
+    expect(screen.getByRole('link', { name: SEARCH_TAB_LABEL })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: OFFER_TAB_LABEL })).not.toHaveAttribute('aria-current');
+  });
+
+  it('should move to the offer screen through the tab', async () => {
+    const router = renderRides();
+
+    await userEvent.click(screen.getByRole('link', { name: OFFER_TAB_LABEL }));
+
+    expect(router.state.location.pathname).toBe(RoutePath.RIDES_OFFER);
+    expect(await screen.findByRole('heading', { name: OFFER_TITLE })).toBeInTheDocument();
+  });
+
+  it('should send the bare rides path to the search screen', () => {
+    const router = renderRides(RoutePath.RIDES);
+
+    expect(router.state.location.pathname).toBe(RoutePath.RIDES_SEARCH);
+  });
+});

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
@@ -1,0 +1,119 @@
+import { format, parseISO } from 'date-fns';
+import { useCallback, useState } from 'react';
+
+import type { Ride } from '@app/services/rides/types';
+import {
+  AccessTimeIcon,
+  CalendarTodayIcon,
+  ConfirmDialog,
+  DeleteIcon,
+  EditIcon,
+  GroupsIcon,
+  IconButton,
+  StatusTag,
+  Typography,
+} from '@design-system';
+
+import { DELETE_DIALOG, RIDE_CARD_LABELS, seatsLabel } from '../../constants';
+import { rideTypeDisplayLabel, rideTypeTone } from '../../helpers/rideType';
+import * as S from './styles';
+
+const DATE_FORMAT = 'dd/MM/yyyy';
+/** A API devolve `HH:mm:ss`; o cartão mostra só horas e minutos. */
+const TIME_LENGTH = 5;
+
+type RideCardProps = Readonly<{
+  ride: Ride;
+  onEdit: (ride: Ride) => void;
+  onDelete: (ride: Ride) => void;
+}>;
+
+export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const handleEdit = useCallback(() => onEdit(ride), [onEdit, ride]);
+  const handleAskDelete = useCallback(() => setConfirmingDelete(true), []);
+  const handleCancelDelete = useCallback(() => setConfirmingDelete(false), []);
+  const handleConfirmDelete = useCallback(() => {
+    setConfirmingDelete(false);
+    onDelete(ride);
+  }, [onDelete, ride]);
+
+  const typeLabel = rideTypeDisplayLabel(ride.tipoCarona);
+  const tone = rideTypeTone(ride.tipoCarona);
+
+  return (
+    <S.CardRoot component="article">
+      <S.HeaderRow>
+        <Typography variant="subtitleBold">{ride.destino}</Typography>
+
+        <S.HeaderActions>
+          <S.WideOnlyTag>
+            <StatusTag tone={tone}>{typeLabel}</StatusTag>
+          </S.WideOnlyTag>
+
+          <S.ActionButtons>
+            <IconButton type="button" aria-label={RIDE_CARD_LABELS.edit} onClick={handleEdit}>
+              <EditIcon />
+            </IconButton>
+            <IconButton
+              type="button"
+              aria-label={RIDE_CARD_LABELS.delete}
+              onClick={handleAskDelete}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </S.ActionButtons>
+        </S.HeaderActions>
+      </S.HeaderRow>
+
+      <S.InfoRow>
+        <S.InfoItem>
+          <CalendarTodayIcon />
+          <Typography variant="caption" color="inherit">
+            {format(parseISO(ride.dataPartida), DATE_FORMAT)}
+          </Typography>
+        </S.InfoItem>
+
+        <S.InfoItem>
+          <AccessTimeIcon />
+          <Typography variant="caption" color="inherit">
+            {ride.horaPartida.slice(0, TIME_LENGTH)}
+          </Typography>
+        </S.InfoItem>
+
+        <S.InfoItem>
+          <GroupsIcon />
+          <Typography variant="caption" color="inherit">
+            {seatsLabel(ride.qtdVagas)}
+          </Typography>
+        </S.InfoItem>
+      </S.InfoRow>
+
+      <S.Description>
+        <Typography variant="subtitle" color="inherit">
+          {ride.descricao}
+        </Typography>
+      </S.Description>
+
+      <S.CompactOnlyTag>
+        <StatusTag tone={tone}>{typeLabel}</StatusTag>
+      </S.CompactOnlyTag>
+
+      <ConfirmDialog
+        open={confirmingDelete}
+        onCancel={handleCancelDelete}
+        onConfirm={handleConfirmDelete}
+        title={DELETE_DIALOG.title}
+        confirmLabel={DELETE_DIALOG.confirmLabel}
+        cancelLabel={DELETE_DIALOG.cancelLabel}
+      >
+        <ConfirmDialog.Message
+          prefix={DELETE_DIALOG.messagePrefix}
+          emphasis={ride.destino}
+          suffix={DELETE_DIALOG.messageSuffix}
+        />
+      </ConfirmDialog>
+    </S.CardRoot>
+  );
+}

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
@@ -2,17 +2,14 @@ import { format, parseISO } from 'date-fns';
 import { useCallback, useState } from 'react';
 
 import type { Ride } from '@app/services/rides/types';
+import { ConfirmDialog, IconButton, StatusTag, Typography } from '@design-system';
 import {
   AccessTimeIcon,
   CalendarTodayIcon,
-  ConfirmDialog,
   DeleteIcon,
   EditIcon,
   GroupsIcon,
-  IconButton,
-  StatusTag,
-  Typography,
-} from '@design-system';
+} from '@design-system/icons';
 
 import { DELETE_DIALOG, RIDE_CARD_LABELS, seatsLabel } from '../../constants';
 import { rideTypeDisplayLabel, rideTypeTone } from '../../helpers/rideType';

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
@@ -11,7 +11,7 @@ import {
   GroupsIcon,
 } from '@design-system/icons';
 
-import { DELETE_DIALOG, RIDE_CARD_LABELS, seatsLabel } from '../../constants';
+import * as C from '../../constants';
 import { rideTypeDisplayLabel, rideTypeTone } from '../../helpers/rideType';
 import * as S from './styles';
 
@@ -50,12 +50,12 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
           </S.WideOnlyTag>
 
           <S.ActionButtons>
-            <IconButton type="button" aria-label={RIDE_CARD_LABELS.edit} onClick={handleEdit}>
+            <IconButton type="button" aria-label={C.RIDE_CARD_LABELS.edit} onClick={handleEdit}>
               <EditIcon />
             </IconButton>
             <IconButton
               type="button"
-              aria-label={RIDE_CARD_LABELS.delete}
+              aria-label={C.RIDE_CARD_LABELS.delete}
               onClick={handleAskDelete}
             >
               <DeleteIcon />
@@ -82,7 +82,7 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
         <S.InfoItem>
           <GroupsIcon />
           <Typography variant="caption" color="inherit">
-            {seatsLabel(ride.qtdVagas)}
+            {C.seatsLabel(ride.qtdVagas)}
           </Typography>
         </S.InfoItem>
       </S.InfoRow>
@@ -101,14 +101,14 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
         open={confirmingDelete}
         onCancel={handleCancelDelete}
         onConfirm={handleConfirmDelete}
-        title={DELETE_DIALOG.title}
-        confirmLabel={DELETE_DIALOG.confirmLabel}
-        cancelLabel={DELETE_DIALOG.cancelLabel}
+        title={C.DELETE_DIALOG.title}
+        confirmLabel={C.DELETE_DIALOG.confirmLabel}
+        cancelLabel={C.DELETE_DIALOG.cancelLabel}
       >
         <ConfirmDialog.Message
-          prefix={DELETE_DIALOG.messagePrefix}
+          prefix={C.DELETE_DIALOG.messagePrefix}
           emphasis={ride.destino}
-          suffix={DELETE_DIALOG.messageSuffix}
+          suffix={C.DELETE_DIALOG.messageSuffix}
         />
       </ConfirmDialog>
     </S.CardRoot>

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/styles.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/styles.ts
@@ -1,0 +1,100 @@
+import {
+  Box,
+  compactMedia,
+  iconSizeTokens,
+  radius,
+  radiusScale,
+  shadowTokens,
+  spacing,
+  spacingScale,
+  Stack,
+  styled,
+} from '@design-system';
+import type { PolymorphicProps } from '@design-system';
+
+const { xxs, sm, md } = spacingScale;
+
+/** Espaço entre as informações da carona, em unidade de viewport como no produto. */
+const INFO_ROW_GAP = '5vw';
+const ACTION_BUTTON_SIZE_PX = 32;
+/** O glifo da biblioteca de origem ocupa 70% do botão. */
+const ACTION_ICON_SCALE = 0.7;
+
+export const CardRoot = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'column',
+  width: '100%',
+  marginBottom: spacing(md),
+  padding: spacing(md),
+  borderRadius: radius(radiusScale.component),
+  boxShadow: shadowTokens.component,
+  background: theme.palette.background.paper,
+  color: theme.palette.text.primary,
+}));
+
+export const HeaderRow = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: spacing(sm),
+});
+
+export const HeaderActions = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing(sm),
+});
+
+export const InfoRow = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
+  gap: INFO_ROW_GAP,
+  marginBottom: spacing(sm),
+  color: theme.palette.text.secondary,
+}));
+
+export const InfoItem = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing(xxs),
+
+  '& svg': {
+    color: theme.palette.secondary.main,
+    fontSize: `${iconSizeTokens.sm}px`,
+  },
+}));
+
+export const Description = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  marginBottom: spacing(sm),
+}));
+
+export const ActionButtons = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
+
+  '& .MuiIconButton-root': {
+    width: `${ACTION_BUTTON_SIZE_PX}px`,
+    height: `${ACTION_BUTTON_SIZE_PX}px`,
+    padding: spacing(xxs),
+    color: theme.palette.text.primary,
+  },
+  '& .MuiIconButton-root svg': {
+    transform: `scale(${ACTION_ICON_SCALE})`,
+    transformOrigin: 'center',
+  },
+}));
+
+/** A etiqueta acompanha o cabeçalho no desktop e desce para o rodapé no estreito. */
+export const WideOnlyTag = styled(Box)<PolymorphicProps>({
+  display: 'block',
+
+  [compactMedia]: { display: 'none' },
+});
+
+export const CompactOnlyTag = styled(Box)<PolymorphicProps>({
+  display: 'none',
+
+  [compactMedia]: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    padding: spacing(sm, 0),
+  },
+});

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/constants/index.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/constants/index.ts
@@ -1,0 +1,29 @@
+import { RideType } from '@app/services/rides/types';
+
+export const FILTER_PANEL_TITLE = 'Filtros';
+export const FILTER_SUBMIT_LABEL = 'Filtrar';
+
+export const FILTER_LABELS = {
+  departureDate: 'Data',
+  departureTime: 'Hora',
+  destination: 'Destino',
+  rideType: 'Tipo',
+};
+
+export const FILTER_PLACEHOLDERS = { destination: 'Digite o destino', rideType: 'Selecione' };
+
+export const TIME_PICKER_LABEL = 'Abrir seletor de horário';
+
+export const RIDE_TYPE_HELP =
+  'Filtrar por tipo de carona: Filantrópica, com caronas totalmente gratuitas, ou Igualitária, em que os participantes dividem os custos.';
+
+/** `ALL` é sentinela do formulário: não vai para a requisição. */
+export enum RideTypeFilter {
+  ALL = '',
+}
+
+export const RIDE_TYPE_OPTIONS: readonly { value: string; label: string }[] = [
+  { value: RideTypeFilter.ALL, label: 'Todas' },
+  { value: RideType.PHILANTHROPIC, label: 'Filantrópica' },
+  { value: RideType.EGALITARIAN, label: 'Igualitária' },
+];

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/constants/index.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/constants/index.ts
@@ -1,4 +1,4 @@
-import { RideType } from '@app/services/rides/types';
+import { RideTypeEnum } from '@app/services/rides/types';
 
 export const FILTER_PANEL_TITLE = 'Filtros';
 export const FILTER_SUBMIT_LABEL = 'Filtrar';
@@ -18,12 +18,12 @@ export const RIDE_TYPE_HELP =
   'Filtrar por tipo de carona: Filantrópica, com caronas totalmente gratuitas, ou Igualitária, em que os participantes dividem os custos.';
 
 /** `ALL` é sentinela do formulário: não vai para a requisição. */
-export enum RideTypeFilter {
+export enum RideTypeFilterEnum {
   ALL = '',
 }
 
 export const RIDE_TYPE_OPTIONS: readonly { value: string; label: string }[] = [
-  { value: RideTypeFilter.ALL, label: 'Todas' },
-  { value: RideType.PHILANTHROPIC, label: 'Filantrópica' },
-  { value: RideType.EGALITARIAN, label: 'Igualitária' },
+  { value: RideTypeFilterEnum.ALL, label: 'Todas' },
+  { value: RideTypeEnum.PHILANTHROPIC, label: 'Filantrópica' },
+  { value: RideTypeEnum.EGALITARIAN, label: 'Igualitária' },
 ];

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/helpers/toApiDate.test.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/helpers/toApiDate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { toApiDate } from './toApiDate';
+
+describe('toApiDate', () => {
+  it('should pad the day and the month to two digits', () => {
+    expect(toApiDate(new Date(2026, 4, 7))).toBe('2026-05-07');
+  });
+
+  it('should keep the local day, without shifting by timezone', () => {
+    expect(toApiDate(new Date(2026, 0, 1))).toBe('2026-01-01');
+    expect(toApiDate(new Date(2026, 11, 31))).toBe('2026-12-31');
+  });
+});

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/helpers/toApiDate.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/helpers/toApiDate.ts
@@ -1,0 +1,8 @@
+import { format } from 'date-fns';
+
+/** A API espera a data em `aaaa-mm-dd`, no fuso local. */
+const API_DATE_FORMAT = 'yyyy-MM-dd';
+
+export function toApiDate(date: Date): string {
+  return format(date, API_DATE_FORMAT);
+}

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
@@ -14,16 +14,7 @@ import {
 } from '@design-system';
 import { FilterAltIcon, InfoIcon, ScheduleIcon, SearchIcon } from '@design-system/icons';
 
-import {
-  FILTER_LABELS,
-  FILTER_PANEL_TITLE,
-  FILTER_PLACEHOLDERS,
-  FILTER_SUBMIT_LABEL,
-  RIDE_TYPE_HELP,
-  RIDE_TYPE_OPTIONS,
-  RideTypeFilterEnum,
-  TIME_PICKER_LABEL,
-} from './constants';
+import * as C from './constants';
 import { toApiDate } from './helpers/toApiDate';
 import * as S from './styles';
 
@@ -33,7 +24,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
   const [departureDate, setDepartureDate] = useState<Date | null>(null);
   const [departureTime, setDepartureTime] = useState('');
   const [destination, setDestination] = useState('');
-  const [rideType, setRideType] = useState<string>(RideTypeFilterEnum.ALL);
+  const [rideType, setRideType] = useState<string>(C.RideTypeFilterEnum.ALL);
   const timeInputRef = useRef<HTMLInputElement>(null);
 
   const handleOpenTimePicker = useCallback(() => timeInputRef.current?.showPicker(), []);
@@ -71,7 +62,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
       <S.FilterHeader>
         <FilterAltIcon />
         <Typography variant="subtitleBold" color="inherit">
-          {FILTER_PANEL_TITLE}
+          {C.FILTER_PANEL_TITLE}
         </Typography>
       </S.FilterHeader>
 
@@ -83,7 +74,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
                 label={
                   <S.FieldLabel component="span">
                     <Typography variant="subtitleBold" color="inherit">
-                      {FILTER_LABELS.departureDate}
+                      {C.FILTER_LABELS.departureDate}
                     </Typography>
                   </S.FieldLabel>
                 }
@@ -98,7 +89,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
                 label={
                   <S.FieldLabel component="span">
                     <Typography variant="subtitleBold" color="inherit">
-                      {FILTER_LABELS.departureTime}
+                      {C.FILTER_LABELS.departureTime}
                     </Typography>
                   </S.FieldLabel>
                 }
@@ -114,7 +105,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
                       <InputAdornment position="end">
                         <IconButton
                           type="button"
-                          aria-label={TIME_PICKER_LABEL}
+                          aria-label={C.TIME_PICKER_LABEL}
                           onClick={handleOpenTimePicker}
                         >
                           <ScheduleIcon />
@@ -131,12 +122,12 @@ export function RideFilter({ onApply }: RideFilterProps) {
                 label={
                   <S.FieldLabel component="span">
                     <Typography variant="subtitleBold" color="inherit">
-                      {FILTER_LABELS.destination}
+                      {C.FILTER_LABELS.destination}
                     </Typography>
                   </S.FieldLabel>
                 }
                 fullWidth
-                placeholder={FILTER_PLACEHOLDERS.destination}
+                placeholder={C.FILTER_PLACEHOLDERS.destination}
                 value={destination}
                 onChange={handleDestinationChange}
               />
@@ -148,9 +139,9 @@ export function RideFilter({ onApply }: RideFilterProps) {
                 label={
                   <S.FieldLabel component="span">
                     <Typography variant="subtitleBold" color="inherit">
-                      {FILTER_LABELS.rideType}
+                      {C.FILTER_LABELS.rideType}
                     </Typography>
-                    <Tooltip title={RIDE_TYPE_HELP}>
+                    <Tooltip title={C.RIDE_TYPE_HELP}>
                       <InfoIcon fontSize="small" />
                     </Tooltip>
                   </S.FieldLabel>
@@ -160,7 +151,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
                 onChange={handleRideTypeChange}
                 slotProps={{ select: { displayEmpty: true }, inputLabel: { shrink: true } }}
               >
-                {RIDE_TYPE_OPTIONS.map(({ value, label }) => (
+                {C.RIDE_TYPE_OPTIONS.map(({ value, label }) => (
                   <MenuItem key={label} value={value}>
                     {label}
                   </MenuItem>
@@ -172,7 +163,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
               <Button type="submit" variant="contained" color="error" fullWidth>
                 <SearchIcon fontSize="small" />
                 <Typography variant="subtitleBold" color="inherit">
-                  {FILTER_SUBMIT_LABEL}
+                  {C.FILTER_SUBMIT_LABEL}
                 </Typography>
               </Button>
             </S.SubmitCell>

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useRef, useState } from 'react';
+import type { ChangeEvent, SubmitEvent } from 'react';
+
+import type { RideFilter as RideFilterValues, RideType } from '@app/services/rides/types';
+import {
+  Button,
+  DatePicker,
+  FilterAltIcon,
+  IconButton,
+  InfoIcon,
+  InputAdornment,
+  MenuItem,
+  ScheduleIcon,
+  SearchIcon,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@design-system';
+
+import {
+  FILTER_LABELS,
+  FILTER_PANEL_TITLE,
+  FILTER_PLACEHOLDERS,
+  FILTER_SUBMIT_LABEL,
+  RIDE_TYPE_HELP,
+  RIDE_TYPE_OPTIONS,
+  RideTypeFilter,
+  TIME_PICKER_LABEL,
+} from './constants';
+import { toApiDate } from './helpers/toApiDate';
+import * as S from './styles';
+
+type RideFilterProps = Readonly<{ onApply: (filters: RideFilterValues) => void }>;
+
+export function RideFilter({ onApply }: RideFilterProps) {
+  const [departureDate, setDepartureDate] = useState<Date | null>(null);
+  const [departureTime, setDepartureTime] = useState('');
+  const [destination, setDestination] = useState('');
+  const [rideType, setRideType] = useState<string>(RideTypeFilter.ALL);
+  const timeInputRef = useRef<HTMLInputElement>(null);
+
+  const handleOpenTimePicker = useCallback(() => timeInputRef.current?.showPicker(), []);
+  const handleTimeChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => setDepartureTime(event.target.value),
+    [],
+  );
+  const handleDestinationChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => setDestination(event.target.value),
+    [],
+  );
+  const handleRideTypeChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => setRideType(event.target.value),
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    (event: SubmitEvent<HTMLElement>) => {
+      event.preventDefault();
+
+      const filters: RideFilterValues = {};
+
+      if (departureDate) filters.departureDate = toApiDate(departureDate);
+      if (departureTime) filters.departureTime = departureTime;
+      if (destination.trim()) filters.destination = destination.trim();
+      if (rideType) filters.rideType = rideType as RideType;
+
+      onApply(filters);
+    },
+    [departureDate, departureTime, destination, rideType, onApply],
+  );
+
+  return (
+    <S.FilterPanel defaultExpanded disableGutters>
+      <S.FilterHeader>
+        <FilterAltIcon />
+        <Typography variant="subtitleBold" color="inherit">
+          {FILTER_PANEL_TITLE}
+        </Typography>
+      </S.FilterHeader>
+
+      <S.FilterBody>
+        <S.FilterForm component="form" onSubmit={handleSubmit}>
+          <S.FieldsRow>
+            <S.FieldCell>
+              <DatePicker
+                label={
+                  <S.FieldLabel component="span">
+                    <Typography variant="subtitleBold" color="inherit">
+                      {FILTER_LABELS.departureDate}
+                    </Typography>
+                  </S.FieldLabel>
+                }
+                value={departureDate}
+                onChange={setDepartureDate}
+                slotProps={{ textField: { fullWidth: true } }}
+              />
+            </S.FieldCell>
+
+            <S.FieldCell>
+              <TextField
+                label={
+                  <S.FieldLabel component="span">
+                    <Typography variant="subtitleBold" color="inherit">
+                      {FILTER_LABELS.departureTime}
+                    </Typography>
+                  </S.FieldLabel>
+                }
+                type="time"
+                fullWidth
+                value={departureTime}
+                onChange={handleTimeChange}
+                inputRef={timeInputRef}
+                slotProps={{
+                  inputLabel: { shrink: true },
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          type="button"
+                          aria-label={TIME_PICKER_LABEL}
+                          onClick={handleOpenTimePicker}
+                        >
+                          <ScheduleIcon />
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
+            </S.FieldCell>
+
+            <S.FieldCell>
+              <TextField
+                label={
+                  <S.FieldLabel component="span">
+                    <Typography variant="subtitleBold" color="inherit">
+                      {FILTER_LABELS.destination}
+                    </Typography>
+                  </S.FieldLabel>
+                }
+                fullWidth
+                placeholder={FILTER_PLACEHOLDERS.destination}
+                value={destination}
+                onChange={handleDestinationChange}
+              />
+            </S.FieldCell>
+
+            <S.FieldCell>
+              <TextField
+                select
+                label={
+                  <S.FieldLabel component="span">
+                    <Typography variant="subtitleBold" color="inherit">
+                      {FILTER_LABELS.rideType}
+                    </Typography>
+                    <Tooltip title={RIDE_TYPE_HELP}>
+                      <InfoIcon fontSize="small" />
+                    </Tooltip>
+                  </S.FieldLabel>
+                }
+                fullWidth
+                value={rideType}
+                onChange={handleRideTypeChange}
+                slotProps={{ select: { displayEmpty: true }, inputLabel: { shrink: true } }}
+              >
+                {RIDE_TYPE_OPTIONS.map(({ value, label }) => (
+                  <MenuItem key={label} value={value}>
+                    {label}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </S.FieldCell>
+
+            <S.SubmitCell>
+              <Button type="submit" variant="contained" color="error" fullWidth>
+                <SearchIcon fontSize="small" />
+                <Typography variant="subtitleBold" color="inherit">
+                  {FILTER_SUBMIT_LABEL}
+                </Typography>
+              </Button>
+            </S.SubmitCell>
+          </S.FieldsRow>
+        </S.FilterForm>
+      </S.FilterBody>
+    </S.FilterPanel>
+  );
+}

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
@@ -5,17 +5,14 @@ import type { RideFilter as RideFilterValues, RideType } from '@app/services/rid
 import {
   Button,
   DatePicker,
-  FilterAltIcon,
   IconButton,
-  InfoIcon,
   InputAdornment,
   MenuItem,
-  ScheduleIcon,
-  SearchIcon,
   TextField,
   Tooltip,
   Typography,
 } from '@design-system';
+import { FilterAltIcon, InfoIcon, ScheduleIcon, SearchIcon } from '@design-system/icons';
 
 import {
   FILTER_LABELS,

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import type { ChangeEvent, SubmitEvent } from 'react';
 
-import type { RideFilter as RideFilterValues, RideType } from '@app/services/rides/types';
+import type { RideFilter as RideFilterValues, RideTypeEnum } from '@app/services/rides/types';
 import {
   Button,
   DatePicker,
@@ -21,7 +21,7 @@ import {
   FILTER_SUBMIT_LABEL,
   RIDE_TYPE_HELP,
   RIDE_TYPE_OPTIONS,
-  RideTypeFilter,
+  RideTypeFilterEnum,
   TIME_PICKER_LABEL,
 } from './constants';
 import { toApiDate } from './helpers/toApiDate';
@@ -33,7 +33,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
   const [departureDate, setDepartureDate] = useState<Date | null>(null);
   const [departureTime, setDepartureTime] = useState('');
   const [destination, setDestination] = useState('');
-  const [rideType, setRideType] = useState<string>(RideTypeFilter.ALL);
+  const [rideType, setRideType] = useState<string>(RideTypeFilterEnum.ALL);
   const timeInputRef = useRef<HTMLInputElement>(null);
 
   const handleOpenTimePicker = useCallback(() => timeInputRef.current?.showPicker(), []);
@@ -59,7 +59,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
       if (departureDate) filters.departureDate = toApiDate(departureDate);
       if (departureTime) filters.departureTime = departureTime;
       if (destination.trim()) filters.destination = destination.trim();
-      if (rideType) filters.rideType = rideType as RideType;
+      if (rideType) filters.rideType = rideType as RideTypeEnum;
 
       onApply(filters);
     },

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/styles.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/styles.ts
@@ -1,0 +1,105 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  desktopMedia,
+  radius,
+  radiusScale,
+  shadowTokens,
+  spacing,
+  spacingScale,
+  Stack,
+  styled,
+} from '@design-system';
+import type { PolymorphicProps } from '@design-system';
+import type { FormHTMLAttributes } from 'react';
+
+const { none, xxs, xs, md, lg, xl } = spacingScale;
+
+const HEADER_GAP = '3px';
+/** Altura do cabeçalho do painel no produto. */
+const HEADER_HEIGHT_PX = 64;
+const FILTER_BUTTON_HEIGHT_PX = 56;
+const FILTER_BUTTON_LETTER_SPACING = '0.4px';
+const FIELD_BASIS = 'calc(20% - 16px)';
+const FIELD_MIN_WIDTH_PX = 180;
+const INFO_ICON_OPACITY = 0.8;
+
+export const FilterPanel = styled(Accordion)(({ theme }) => ({
+  marginBottom: spacing(md),
+  borderRadius: radius(radiusScale.component),
+  background: theme.palette.background.paper,
+  color: theme.palette.text.primary,
+  border: 'none',
+  boxShadow: shadowTokens.component,
+
+  '&::before': { display: 'none' },
+
+  // Único ponto do produto em que o campo usa o raio de componente: o resto
+  // da aplicação mantém o raio padrão do Material.
+  '& .MuiOutlinedInput-root': { borderRadius: radius(radiusScale.component) },
+}));
+
+export const FilterHeader = styled(AccordionSummary)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  minHeight: `${HEADER_HEIGHT_PX}px`,
+  padding: spacing(none, lg),
+
+  '&.Mui-expanded': { minHeight: `${HEADER_HEIGHT_PX}px` },
+
+  '& .MuiAccordionSummary-content': {
+    display: 'flex',
+    alignItems: 'center',
+    gap: HEADER_GAP,
+  },
+  '& .MuiAccordionSummary-content svg': { color: theme.palette.text.primary },
+}));
+
+export const FilterBody = styled(AccordionDetails)({
+  padding: spacing(none, lg, xl),
+});
+
+export const FilterForm = styled(Stack)<PolymorphicProps<FormHTMLAttributes<HTMLFormElement>>>({
+  flexDirection: 'column',
+});
+
+export const FieldsRow = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  alignItems: 'flex-start',
+  gap: spacing(md),
+  marginTop: spacing(md),
+});
+
+export const FieldCell = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  gap: '6px',
+  width: '100%',
+
+  [desktopMedia]: {
+    flex: `1 1 ${FIELD_BASIS}`,
+    minWidth: `${FIELD_MIN_WIDTH_PX}px`,
+  },
+});
+
+/** Rótulo do campo com o ícone de ajuda ao lado. */
+export const FieldLabel = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing(xxs),
+  color: theme.palette.text.primary,
+
+  '& svg': {
+    color: theme.palette.text.primary,
+    opacity: INFO_ICON_OPACITY,
+  },
+}));
+
+export const SubmitCell = styled(FieldCell)({
+  '& .MuiButton-root': {
+    height: `${FILTER_BUTTON_HEIGHT_PX}px`,
+    letterSpacing: FILTER_BUTTON_LETTER_SPACING,
+    borderRadius: radius(radiusScale.component),
+    gap: spacing(xs),
+  },
+});

--- a/FateConnect/Web/src/pages/Rides/constants/index.ts
+++ b/FateConnect/Web/src/pages/Rides/constants/index.ts
@@ -1,0 +1,25 @@
+export const RIDES_TITLE = 'Caronas';
+export const BACK_LABEL = 'Voltar';
+export const SEARCH_TAB_LABEL = 'Buscar Carona';
+export const OFFER_TAB_LABEL = 'Ofertar Carona';
+
+export const EMPTY_LIST_MESSAGE = 'Nenhuma carona encontrada.';
+
+export const RIDE_LIST_MESSAGES = {
+  loadFailed: 'Erro ao carregar caronas. Tente novamente.',
+  deleteSucceeded: 'Carona excluída com sucesso.',
+  deleteFailed: 'Erro ao excluir a carona. Tente novamente.',
+  editSoon: 'Edição de carona em breve.',
+};
+
+export const DELETE_DIALOG = {
+  title: 'Confirmar Exclusão',
+  messagePrefix: 'Tem certeza que deseja excluir a carona para ',
+  messageSuffix: '?',
+  confirmLabel: 'Excluir',
+  cancelLabel: 'Cancelar',
+};
+
+export const RIDE_CARD_LABELS = { edit: 'Editar', delete: 'Excluir' };
+
+export const seatsLabel = (seats: number): string => `${seats} vagas`;

--- a/FateConnect/Web/src/pages/Rides/helpers/rideType.test.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/rideType.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { RideType } from '@app/services/rides/types';
+import { parseRideType, rideTypeDisplayLabel, rideTypeTone } from './rideType';
+
+describe('parseRideType', () => {
+  it.each([
+    ['Filantropica', RideType.PHILANTHROPIC],
+    ['filantropica', RideType.PHILANTHROPIC],
+    ['Igualitaria', RideType.EGALITARIAN],
+    ['igualitaria', RideType.EGALITARIAN],
+  ])('should read %s as a canonical value', (raw, expected) => {
+    expect(parseRideType(raw)).toBe(expected);
+  });
+
+  it.each([[' inválido '], [null], [undefined], ['']])('should return null for %s', (raw) => {
+    expect(parseRideType(raw)).toBeNull();
+  });
+});
+
+describe('rideTypeDisplayLabel', () => {
+  it('should label the known types in pt-BR', () => {
+    expect(rideTypeDisplayLabel('Filantropica')).toBe('Filantrópica');
+    expect(rideTypeDisplayLabel('igualitaria')).toBe('Igualitária');
+  });
+
+  it('should keep an unknown value, falling back to a dash when it is blank', () => {
+    expect(rideTypeDisplayLabel('desconhecido')).toBe('desconhecido');
+    expect(rideTypeDisplayLabel('   ')).toBe('—');
+  });
+});
+
+describe('rideTypeTone', () => {
+  it.each([
+    ['Filantropica', 'success'],
+    ['Igualitaria', 'warning'],
+    ['desconhecido', 'neutral'],
+  ])('should give %s the expected tone', (value, expected) => {
+    expect(rideTypeTone(value)).toBe(expected);
+  });
+});

--- a/FateConnect/Web/src/pages/Rides/helpers/rideType.test.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/rideType.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { RideType } from '@app/services/rides/types';
+import { RideTypeEnum } from '@app/services/rides/types';
 import { parseRideType, rideTypeDisplayLabel, rideTypeTone } from './rideType';
 
 describe('parseRideType', () => {
   it.each([
-    ['Filantropica', RideType.PHILANTHROPIC],
-    ['filantropica', RideType.PHILANTHROPIC],
-    ['Igualitaria', RideType.EGALITARIAN],
-    ['igualitaria', RideType.EGALITARIAN],
+    ['Filantropica', RideTypeEnum.PHILANTHROPIC],
+    ['filantropica', RideTypeEnum.PHILANTHROPIC],
+    ['Igualitaria', RideTypeEnum.EGALITARIAN],
+    ['igualitaria', RideTypeEnum.EGALITARIAN],
   ])('should read %s as a canonical value', (raw, expected) => {
     expect(parseRideType(raw)).toBe(expected);
   });

--- a/FateConnect/Web/src/pages/Rides/helpers/rideType.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/rideType.ts
@@ -1,25 +1,25 @@
-import { RideType } from '@app/services/rides/types';
+import { RideTypeEnum } from '@app/services/rides/types';
 import type { StatusTagTone } from '@design-system';
 
-const LOWERCASE_TO_RIDE_TYPE: Readonly<Record<string, RideType>> = {
-  filantropica: RideType.PHILANTHROPIC,
-  igualitaria: RideType.EGALITARIAN,
+const LOWERCASE_TO_RIDE_TYPE: Readonly<Record<string, RideTypeEnum>> = {
+  filantropica: RideTypeEnum.PHILANTHROPIC,
+  igualitaria: RideTypeEnum.EGALITARIAN,
 };
 
-const RIDE_TYPE_LABEL: Readonly<Record<RideType, string>> = {
-  [RideType.PHILANTHROPIC]: 'Filantrópica',
-  [RideType.EGALITARIAN]: 'Igualitária',
+const RIDE_TYPE_LABEL: Readonly<Record<RideTypeEnum, string>> = {
+  [RideTypeEnum.PHILANTHROPIC]: 'Filantrópica',
+  [RideTypeEnum.EGALITARIAN]: 'Igualitária',
 };
 
-const RIDE_TYPE_TONE: Readonly<Record<RideType, StatusTagTone>> = {
-  [RideType.PHILANTHROPIC]: 'success',
-  [RideType.EGALITARIAN]: 'warning',
+const RIDE_TYPE_TONE: Readonly<Record<RideTypeEnum, StatusTagTone>> = {
+  [RideTypeEnum.PHILANTHROPIC]: 'success',
+  [RideTypeEnum.EGALITARIAN]: 'warning',
 };
 
 const UNKNOWN_LABEL = '—';
 
 /** Interpreta o valor da API (PascalCase) ou de query em minúsculas. */
-export function parseRideType(raw: string | null | undefined): RideType | null {
+export function parseRideType(raw: string | null | undefined): RideTypeEnum | null {
   if (!raw) return null;
 
   return LOWERCASE_TO_RIDE_TYPE[raw.trim().toLowerCase()] ?? null;

--- a/FateConnect/Web/src/pages/Rides/helpers/rideType.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/rideType.ts
@@ -1,0 +1,42 @@
+import { RideType } from '@app/services/rides/types';
+import type { StatusTagTone } from '@design-system';
+
+const LOWERCASE_TO_RIDE_TYPE: Readonly<Record<string, RideType>> = {
+  filantropica: RideType.PHILANTHROPIC,
+  igualitaria: RideType.EGALITARIAN,
+};
+
+const RIDE_TYPE_LABEL: Readonly<Record<RideType, string>> = {
+  [RideType.PHILANTHROPIC]: 'Filantrópica',
+  [RideType.EGALITARIAN]: 'Igualitária',
+};
+
+const RIDE_TYPE_TONE: Readonly<Record<RideType, StatusTagTone>> = {
+  [RideType.PHILANTHROPIC]: 'success',
+  [RideType.EGALITARIAN]: 'warning',
+};
+
+const UNKNOWN_LABEL = '—';
+
+/** Interpreta o valor da API (PascalCase) ou de query em minúsculas. */
+export function parseRideType(raw: string | null | undefined): RideType | null {
+  if (!raw) return null;
+
+  return LOWERCASE_TO_RIDE_TYPE[raw.trim().toLowerCase()] ?? null;
+}
+
+/** Tom da etiqueta do tipo de carona; a cor sai da paleta, nos dois temas. */
+export function rideTypeTone(value: string): StatusTagTone {
+  const rideType = parseRideType(value);
+  if (!rideType) return 'neutral';
+
+  return RIDE_TYPE_TONE[rideType];
+}
+
+/** Rótulo em pt-BR; valor desconhecido cai no próprio texto, ou num travessão. */
+export function rideTypeDisplayLabel(value: string): string {
+  const rideType = parseRideType(value);
+  if (!rideType) return value.trim() || UNKNOWN_LABEL;
+
+  return RIDE_TYPE_LABEL[rideType];
+}

--- a/FateConnect/Web/src/pages/Rides/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/index.tsx
@@ -1,6 +1,43 @@
-import { Outlet } from 'react-router';
+import { NavLink, Outlet } from 'react-router';
 
-/** Casca das telas de carona; as duas telas filhas são migradas na #55. */
+import { RoutePath } from '@app/routes/paths';
+import { AddIcon, ArrowBackIcon, SearchIcon, Typography } from '@design-system';
+
+import { BACK_LABEL, OFFER_TAB_LABEL, RIDES_TITLE, SEARCH_TAB_LABEL } from './constants';
+import * as S from './styles';
+
+/** Casca das caronas: título, volta para o menu e as duas abas de rota. */
 export function Rides() {
-  return <Outlet />;
+  return (
+    <S.RidesRoot>
+      <S.RidesHeader>
+        <S.PageTitle variant="h1">{RIDES_TITLE}</S.PageTitle>
+
+        <S.BackButton component={NavLink} to={RoutePath.MENU}>
+          <ArrowBackIcon fontSize="small" />
+          <Typography variant="subtitleBold" color="inherit">
+            {BACK_LABEL}
+          </Typography>
+        </S.BackButton>
+      </S.RidesHeader>
+
+      <S.TabList component="nav">
+        <S.Tab component={NavLink} to={RoutePath.RIDES_SEARCH} end>
+          <SearchIcon fontSize="small" />
+          <Typography variant="subtitleBold" color="inherit">
+            {SEARCH_TAB_LABEL}
+          </Typography>
+        </S.Tab>
+
+        <S.Tab component={NavLink} to={RoutePath.RIDES_OFFER}>
+          <AddIcon fontSize="small" />
+          <Typography variant="subtitleBold" color="inherit">
+            {OFFER_TAB_LABEL}
+          </Typography>
+        </S.Tab>
+      </S.TabList>
+
+      <Outlet />
+    </S.RidesRoot>
+  );
 }

--- a/FateConnect/Web/src/pages/Rides/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/index.tsx
@@ -4,7 +4,7 @@ import { RoutePathEnum } from '@app/routes/paths';
 import { Typography } from '@design-system';
 import { AddIcon, ArrowBackIcon, SearchIcon } from '@design-system/icons';
 
-import { BACK_LABEL, OFFER_TAB_LABEL, RIDES_TITLE, SEARCH_TAB_LABEL } from './constants';
+import * as C from './constants';
 import * as S from './styles';
 
 /** Casca das caronas: título, volta para o menu e as duas abas de rota. */
@@ -12,12 +12,12 @@ export function Rides() {
   return (
     <S.RidesRoot>
       <S.RidesHeader>
-        <S.PageTitle variant="h1">{RIDES_TITLE}</S.PageTitle>
+        <S.PageTitle variant="h1">{C.RIDES_TITLE}</S.PageTitle>
 
         <S.BackButton component={NavLink} to={RoutePathEnum.MENU}>
           <ArrowBackIcon fontSize="small" />
           <Typography variant="subtitleBold" color="inherit">
-            {BACK_LABEL}
+            {C.BACK_LABEL}
           </Typography>
         </S.BackButton>
       </S.RidesHeader>
@@ -26,14 +26,14 @@ export function Rides() {
         <S.Tab component={NavLink} to={RoutePathEnum.RIDES_SEARCH} end>
           <SearchIcon fontSize="small" />
           <Typography variant="subtitleBold" color="inherit">
-            {SEARCH_TAB_LABEL}
+            {C.SEARCH_TAB_LABEL}
           </Typography>
         </S.Tab>
 
         <S.Tab component={NavLink} to={RoutePathEnum.RIDES_OFFER}>
           <AddIcon fontSize="small" />
           <Typography variant="subtitleBold" color="inherit">
-            {OFFER_TAB_LABEL}
+            {C.OFFER_TAB_LABEL}
           </Typography>
         </S.Tab>
       </S.TabList>

--- a/FateConnect/Web/src/pages/Rides/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/index.tsx
@@ -1,6 +1,6 @@
 import { NavLink, Outlet } from 'react-router';
 
-import { RoutePath } from '@app/routes/paths';
+import { RoutePathEnum } from '@app/routes/paths';
 import { Typography } from '@design-system';
 import { AddIcon, ArrowBackIcon, SearchIcon } from '@design-system/icons';
 
@@ -14,7 +14,7 @@ export function Rides() {
       <S.RidesHeader>
         <S.PageTitle variant="h1">{RIDES_TITLE}</S.PageTitle>
 
-        <S.BackButton component={NavLink} to={RoutePath.MENU}>
+        <S.BackButton component={NavLink} to={RoutePathEnum.MENU}>
           <ArrowBackIcon fontSize="small" />
           <Typography variant="subtitleBold" color="inherit">
             {BACK_LABEL}
@@ -23,14 +23,14 @@ export function Rides() {
       </S.RidesHeader>
 
       <S.TabList component="nav">
-        <S.Tab component={NavLink} to={RoutePath.RIDES_SEARCH} end>
+        <S.Tab component={NavLink} to={RoutePathEnum.RIDES_SEARCH} end>
           <SearchIcon fontSize="small" />
           <Typography variant="subtitleBold" color="inherit">
             {SEARCH_TAB_LABEL}
           </Typography>
         </S.Tab>
 
-        <S.Tab component={NavLink} to={RoutePath.RIDES_OFFER}>
+        <S.Tab component={NavLink} to={RoutePathEnum.RIDES_OFFER}>
           <AddIcon fontSize="small" />
           <Typography variant="subtitleBold" color="inherit">
             {OFFER_TAB_LABEL}

--- a/FateConnect/Web/src/pages/Rides/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/index.tsx
@@ -1,7 +1,8 @@
 import { NavLink, Outlet } from 'react-router';
 
 import { RoutePath } from '@app/routes/paths';
-import { AddIcon, ArrowBackIcon, SearchIcon, Typography } from '@design-system';
+import { Typography } from '@design-system';
+import { AddIcon, ArrowBackIcon, SearchIcon } from '@design-system/icons';
 
 import { BACK_LABEL, OFFER_TAB_LABEL, RIDES_TITLE, SEARCH_TAB_LABEL } from './constants';
 import * as S from './styles';

--- a/FateConnect/Web/src/pages/Rides/screens/OfferRide/constants/index.ts
+++ b/FateConnect/Web/src/pages/Rides/screens/OfferRide/constants/index.ts
@@ -1,0 +1,4 @@
+export const OFFER_TITLE = 'Ofertar Nova Carona';
+export const OFFER_SUBTITLE = 'Compartilhe uma carona com outros estudantes da Fatec Sorocaba';
+export const OFFER_BUTTON_LABEL = 'Ofertar Carona';
+export const OFFER_SOON_MESSAGE = 'Cadastro de nova carona em breve.';

--- a/FateConnect/Web/src/pages/Rides/screens/OfferRide/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/screens/OfferRide/index.tsx
@@ -4,7 +4,7 @@ import { useNotification } from '@app/hooks/useNotification';
 import { Typography } from '@design-system';
 import { AddIcon } from '@design-system/icons';
 
-import { OFFER_BUTTON_LABEL, OFFER_SOON_MESSAGE, OFFER_SUBTITLE, OFFER_TITLE } from './constants';
+import * as C from './constants';
 import * as S from './styles';
 
 /**
@@ -14,18 +14,18 @@ import * as S from './styles';
 export function OfferRide() {
   const { notifyWarning } = useNotification();
 
-  const handleOfferClick = useCallback(() => notifyWarning(OFFER_SOON_MESSAGE), [notifyWarning]);
+  const handleOfferClick = useCallback(() => notifyWarning(C.OFFER_SOON_MESSAGE), [notifyWarning]);
 
   return (
     <S.OfferWrapper>
       <S.OfferCard>
-        <Typography variant="h2">{OFFER_TITLE}</Typography>
-        <Typography variant="subtitle">{OFFER_SUBTITLE}</Typography>
+        <Typography variant="h2">{C.OFFER_TITLE}</Typography>
+        <Typography variant="subtitle">{C.OFFER_SUBTITLE}</Typography>
 
         <S.OfferButton component="button" type="button" onClick={handleOfferClick}>
           <AddIcon fontSize="small" />
           <Typography variant="subtitleBold" color="inherit">
-            {OFFER_BUTTON_LABEL}
+            {C.OFFER_BUTTON_LABEL}
           </Typography>
         </S.OfferButton>
       </S.OfferCard>

--- a/FateConnect/Web/src/pages/Rides/screens/OfferRide/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/screens/OfferRide/index.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
 
 import { useNotification } from '@app/hooks/useNotification';
-import { AddIcon, Typography } from '@design-system';
+import { Typography } from '@design-system';
+import { AddIcon } from '@design-system/icons';
 
 import { OFFER_BUTTON_LABEL, OFFER_SOON_MESSAGE, OFFER_SUBTITLE, OFFER_TITLE } from './constants';
 import * as S from './styles';

--- a/FateConnect/Web/src/pages/Rides/screens/OfferRide/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/screens/OfferRide/index.tsx
@@ -1,6 +1,33 @@
-import { Typography } from '@design-system';
+import { useCallback } from 'react';
 
-/** Placeholder — a tela é migrada na #55. */
+import { useNotification } from '@app/hooks/useNotification';
+import { AddIcon, Typography } from '@design-system';
+
+import { OFFER_BUTTON_LABEL, OFFER_SOON_MESSAGE, OFFER_SUBTITLE, OFFER_TITLE } from './constants';
+import * as S from './styles';
+
+/**
+ * Cartão de chamada para ofertar carona. O formulário em si ainda não existe no
+ * produto — o botão avisa que está por vir, como hoje.
+ */
 export function OfferRide() {
-  return <Typography variant="h1">Ofertar carona</Typography>;
+  const { notifyWarning } = useNotification();
+
+  const handleOfferClick = useCallback(() => notifyWarning(OFFER_SOON_MESSAGE), [notifyWarning]);
+
+  return (
+    <S.OfferWrapper>
+      <S.OfferCard>
+        <Typography variant="h2">{OFFER_TITLE}</Typography>
+        <Typography variant="subtitle">{OFFER_SUBTITLE}</Typography>
+
+        <S.OfferButton component="button" type="button" onClick={handleOfferClick}>
+          <AddIcon fontSize="small" />
+          <Typography variant="subtitleBold" color="inherit">
+            {OFFER_BUTTON_LABEL}
+          </Typography>
+        </S.OfferButton>
+      </S.OfferCard>
+    </S.OfferWrapper>
+  );
 }

--- a/FateConnect/Web/src/pages/Rides/screens/OfferRide/styles.ts
+++ b/FateConnect/Web/src/pages/Rides/screens/OfferRide/styles.ts
@@ -1,0 +1,59 @@
+import {
+  radius,
+  radiusScale,
+  shadowTokens,
+  spacing,
+  spacingScale,
+  Stack,
+  styled,
+} from '@design-system';
+import type { PolymorphicProps } from '@design-system';
+import type { ButtonHTMLAttributes } from 'react';
+
+const { xxs, md, lg, xxl } = spacingScale;
+
+/** 3rem no topo e no rodapé, 1rem nas laterais, como no produto. */
+const CARD_PADDING = spacing(xxl, md);
+/** 1.5rem entre título, texto e botão. */
+const CARD_GAP = spacing(lg);
+const BUTTON_MIN_WIDTH_PX = 200;
+const BUTTON_HOVER_BRIGHTNESS = 0.95;
+
+export const OfferWrapper = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  marginTop: spacing(md),
+  width: '100%',
+});
+
+export const OfferCard = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  background: theme.palette.background.paper,
+  borderRadius: radius(radiusScale.component),
+  padding: CARD_PADDING,
+  textAlign: 'center',
+  boxShadow: shadowTokens.component,
+  color: theme.palette.text.primary,
+  gap: CARD_GAP,
+}));
+
+export const OfferButton = styled(Stack)<PolymorphicProps<ButtonHTMLAttributes<HTMLButtonElement>>>(
+  ({ theme }) => ({
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing(xxs),
+    padding: spacing(md),
+    minWidth: `${BUTTON_MIN_WIDTH_PX}px`,
+    border: 0,
+    borderRadius: radius(radiusScale.component),
+    color: theme.palette.secondary.contrastText,
+    background: theme.palette.secondary.main,
+    boxShadow: shadowTokens.component,
+    cursor: 'pointer',
+
+    '&:hover': { filter: `brightness(${BUTTON_HOVER_BRIGHTNESS})` },
+  }),
+);

--- a/FateConnect/Web/src/pages/Rides/screens/SearchRide/SearchRide.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/screens/SearchRide/SearchRide.test.tsx
@@ -6,13 +6,7 @@ import { RideTypeEnum } from '@app/services/rides/types';
 import type { Ride } from '@app/services/rides/types';
 import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 import { SearchRide } from '.';
-import {
-  DELETE_DIALOG,
-  EMPTY_LIST_MESSAGE,
-  RIDE_CARD_LABELS,
-  RIDE_LIST_MESSAGES,
-  seatsLabel,
-} from '../../constants';
+import * as C from '../../constants';
 import { FILTER_LABELS, FILTER_SUBMIT_LABEL } from '../../components/RideFilter/constants';
 
 const RIDES_URL = 'https://rides.fateconnect.test/caronas';
@@ -47,7 +41,7 @@ describe('SearchRide', () => {
     expect(await screen.findByText(RIDE.destino)).toBeInTheDocument();
     expect(screen.getByText('22/05/2026')).toBeInTheDocument();
     expect(screen.getByText('07:30')).toBeInTheDocument();
-    expect(screen.getByText(seatsLabel(RIDE.qtdVagas))).toBeInTheDocument();
+    expect(screen.getByText(C.seatsLabel(RIDE.qtdVagas))).toBeInTheDocument();
     // A etiqueta existe duas vezes: uma no cabeçalho e outra no rodapé do
     // cartão, alternadas por media query — que o jsdom não avalia.
     expect(screen.getAllByText('Filantrópica')).toHaveLength(2);
@@ -57,7 +51,7 @@ describe('SearchRide', () => {
     listReturning([]);
     render(<SearchRide />);
 
-    expect(await screen.findByText(EMPTY_LIST_MESSAGE)).toBeInTheDocument();
+    expect(await screen.findByText(C.EMPTY_LIST_MESSAGE)).toBeInTheDocument();
   });
 
   it('should report a failure to load the list', async () => {
@@ -66,7 +60,7 @@ describe('SearchRide', () => {
 
     // O cliente tenta a requisição de novo antes de desistir.
     expect(
-      await screen.findByText(RIDE_LIST_MESSAGES.loadFailed, undefined, { timeout: 5000 }),
+      await screen.findByText(C.RIDE_LIST_MESSAGES.loadFailed, undefined, { timeout: 5000 }),
     ).toBeInTheDocument();
   });
 
@@ -74,7 +68,7 @@ describe('SearchRide', () => {
     server.use(http.get(RIDES_URL, () => new HttpResponse(null, { status: 500 })));
     render(<SearchRide />);
 
-    await screen.findByText(RIDE_LIST_MESSAGES.loadFailed, undefined, { timeout: 5000 });
+    await screen.findByText(C.RIDE_LIST_MESSAGES.loadFailed, undefined, { timeout: 5000 });
 
     expect(screen.getAllByRole('alert')).toHaveLength(1);
   });
@@ -85,7 +79,7 @@ describe('SearchRide', () => {
       requestUrl = url;
     });
     render(<SearchRide />);
-    await screen.findByText(EMPTY_LIST_MESSAGE);
+    await screen.findByText(C.EMPTY_LIST_MESSAGE);
 
     await userEvent.type(screen.getByLabelText(FILTER_LABELS.destination), 'Sorocaba');
     await userEvent.click(screen.getByRole('button', { name: FILTER_SUBMIT_LABEL }));
@@ -98,13 +92,13 @@ describe('SearchRide', () => {
     render(<SearchRide />);
     await screen.findByText(RIDE.destino);
 
-    await userEvent.click(screen.getByRole('button', { name: RIDE_CARD_LABELS.delete }));
+    await userEvent.click(screen.getByRole('button', { name: C.RIDE_CARD_LABELS.delete }));
 
     const dialog = within(await screen.findByRole('dialog'));
-    expect(dialog.getByRole('heading', { name: DELETE_DIALOG.title })).toBeInTheDocument();
+    expect(dialog.getByRole('heading', { name: C.DELETE_DIALOG.title })).toBeInTheDocument();
     expect(dialog.getByText(RIDE.destino)).toBeInTheDocument();
 
-    await userEvent.click(dialog.getByRole('button', { name: DELETE_DIALOG.cancelLabel }));
+    await userEvent.click(dialog.getByRole('button', { name: C.DELETE_DIALOG.cancelLabel }));
 
     // O cartão só volta a ser alcançável quando o diálogo termina de fechar.
     expect(within(await screen.findByRole('article')).getByText(RIDE.destino)).toBeInTheDocument();
@@ -123,12 +117,12 @@ describe('SearchRide', () => {
     render(<SearchRide />);
     await screen.findByText(RIDE.destino);
 
-    await userEvent.click(screen.getByRole('button', { name: RIDE_CARD_LABELS.delete }));
+    await userEvent.click(screen.getByRole('button', { name: C.RIDE_CARD_LABELS.delete }));
     const dialog = within(await screen.findByRole('dialog'));
-    await userEvent.click(dialog.getByRole('button', { name: DELETE_DIALOG.confirmLabel }));
+    await userEvent.click(dialog.getByRole('button', { name: C.DELETE_DIALOG.confirmLabel }));
 
-    expect(await screen.findByText(RIDE_LIST_MESSAGES.deleteSucceeded)).toBeInTheDocument();
-    expect(await screen.findByText(EMPTY_LIST_MESSAGE)).toBeInTheDocument();
+    expect(await screen.findByText(C.RIDE_LIST_MESSAGES.deleteSucceeded)).toBeInTheDocument();
+    expect(await screen.findByText(C.EMPTY_LIST_MESSAGE)).toBeInTheDocument();
   });
 
   it('should report a failure to delete', async () => {
@@ -137,11 +131,11 @@ describe('SearchRide', () => {
     render(<SearchRide />);
     await screen.findByText(RIDE.destino);
 
-    await userEvent.click(screen.getByRole('button', { name: RIDE_CARD_LABELS.delete }));
+    await userEvent.click(screen.getByRole('button', { name: C.RIDE_CARD_LABELS.delete }));
     const dialog = within(await screen.findByRole('dialog'));
-    await userEvent.click(dialog.getByRole('button', { name: DELETE_DIALOG.confirmLabel }));
+    await userEvent.click(dialog.getByRole('button', { name: C.DELETE_DIALOG.confirmLabel }));
 
-    expect(await screen.findByText(RIDE_LIST_MESSAGES.deleteFailed)).toBeInTheDocument();
+    expect(await screen.findByText(C.RIDE_LIST_MESSAGES.deleteFailed)).toBeInTheDocument();
   });
 
   it('should announce that editing is not available yet', async () => {
@@ -149,8 +143,8 @@ describe('SearchRide', () => {
     render(<SearchRide />);
     await screen.findByText(RIDE.destino);
 
-    await userEvent.click(screen.getByRole('button', { name: RIDE_CARD_LABELS.edit }));
+    await userEvent.click(screen.getByRole('button', { name: C.RIDE_CARD_LABELS.edit }));
 
-    expect(await screen.findByText(RIDE_LIST_MESSAGES.editSoon)).toBeInTheDocument();
+    expect(await screen.findByText(C.RIDE_LIST_MESSAGES.editSoon)).toBeInTheDocument();
   });
 });

--- a/FateConnect/Web/src/pages/Rides/screens/SearchRide/SearchRide.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/screens/SearchRide/SearchRide.test.tsx
@@ -1,0 +1,156 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
+import { RideType } from '@app/services/rides/types';
+import type { Ride } from '@app/services/rides/types';
+import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
+import { SearchRide } from '.';
+import {
+  DELETE_DIALOG,
+  EMPTY_LIST_MESSAGE,
+  RIDE_CARD_LABELS,
+  RIDE_LIST_MESSAGES,
+  seatsLabel,
+} from '../../constants';
+import { FILTER_LABELS, FILTER_SUBMIT_LABEL } from '../../components/RideFilter/constants';
+
+const RIDES_URL = 'https://rides.fateconnect.test/caronas';
+
+const RIDE: Ride = {
+  id: 7,
+  qtdVagas: 3,
+  destino: 'Fatec Sorocaba',
+  dataPartida: '2026-05-22T00:00:00',
+  horaPartida: '07:30:00',
+  dataCadastro: '2026-05-01T00:00:00',
+  tipoCarona: RideType.PHILANTHROPIC,
+  descricao: 'Saída do centro, com parada no terminal.',
+  ativo: true,
+};
+
+function listReturning(rides: Ride[], onRequest?: (url: URL) => void) {
+  server.use(
+    http.get(RIDES_URL, ({ request }) => {
+      onRequest?.(new URL(request.url));
+
+      return HttpResponse.json(rides);
+    }),
+  );
+}
+
+describe('SearchRide', () => {
+  it('should show the rides the list returns', async () => {
+    listReturning([RIDE]);
+    render(<SearchRide />);
+
+    expect(await screen.findByText(RIDE.destino)).toBeInTheDocument();
+    expect(screen.getByText('22/05/2026')).toBeInTheDocument();
+    expect(screen.getByText('07:30')).toBeInTheDocument();
+    expect(screen.getByText(seatsLabel(RIDE.qtdVagas))).toBeInTheDocument();
+    // A etiqueta existe duas vezes: uma no cabeçalho e outra no rodapé do
+    // cartão, alternadas por media query — que o jsdom não avalia.
+    expect(screen.getAllByText('Filantrópica')).toHaveLength(2);
+  });
+
+  it('should tell the user when no ride matches', async () => {
+    listReturning([]);
+    render(<SearchRide />);
+
+    expect(await screen.findByText(EMPTY_LIST_MESSAGE)).toBeInTheDocument();
+  });
+
+  it('should report a failure to load the list', async () => {
+    server.use(http.get(RIDES_URL, () => new HttpResponse(null, { status: 500 })));
+    render(<SearchRide />);
+
+    // O cliente tenta a requisição de novo antes de desistir.
+    expect(
+      await screen.findByText(RIDE_LIST_MESSAGES.loadFailed, undefined, { timeout: 5000 }),
+    ).toBeInTheDocument();
+  });
+
+  it('should report a load failure only once', async () => {
+    server.use(http.get(RIDES_URL, () => new HttpResponse(null, { status: 500 })));
+    render(<SearchRide />);
+
+    await screen.findByText(RIDE_LIST_MESSAGES.loadFailed, undefined, { timeout: 5000 });
+
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+  });
+
+  it('should build the request from the filters', async () => {
+    let requestUrl: URL | undefined;
+    listReturning([], (url) => {
+      requestUrl = url;
+    });
+    render(<SearchRide />);
+    await screen.findByText(EMPTY_LIST_MESSAGE);
+
+    await userEvent.type(screen.getByLabelText(FILTER_LABELS.destination), 'Sorocaba');
+    await userEvent.click(screen.getByRole('button', { name: FILTER_SUBMIT_LABEL }));
+
+    await waitFor(() => expect(requestUrl?.searchParams.get('Destino')).toBe('Sorocaba'));
+  });
+
+  it('should ask for confirmation before deleting and keep the ride when it is refused', async () => {
+    listReturning([RIDE]);
+    render(<SearchRide />);
+    await screen.findByText(RIDE.destino);
+
+    await userEvent.click(screen.getByRole('button', { name: RIDE_CARD_LABELS.delete }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('heading', { name: DELETE_DIALOG.title })).toBeInTheDocument();
+    expect(dialog.getByText(RIDE.destino)).toBeInTheDocument();
+
+    await userEvent.click(dialog.getByRole('button', { name: DELETE_DIALOG.cancelLabel }));
+
+    // O cartão só volta a ser alcançável quando o diálogo termina de fechar.
+    expect(within(await screen.findByRole('article')).getByText(RIDE.destino)).toBeInTheDocument();
+  });
+
+  it('should delete the ride once the removal is confirmed', async () => {
+    let deleted = false;
+    server.use(
+      http.get(RIDES_URL, () => HttpResponse.json(deleted ? [] : [RIDE])),
+      http.delete(`${RIDES_URL}/:rideId`, () => {
+        deleted = true;
+
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    render(<SearchRide />);
+    await screen.findByText(RIDE.destino);
+
+    await userEvent.click(screen.getByRole('button', { name: RIDE_CARD_LABELS.delete }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await userEvent.click(dialog.getByRole('button', { name: DELETE_DIALOG.confirmLabel }));
+
+    expect(await screen.findByText(RIDE_LIST_MESSAGES.deleteSucceeded)).toBeInTheDocument();
+    expect(await screen.findByText(EMPTY_LIST_MESSAGE)).toBeInTheDocument();
+  });
+
+  it('should report a failure to delete', async () => {
+    listReturning([RIDE]);
+    server.use(http.delete(`${RIDES_URL}/:rideId`, () => new HttpResponse(null, { status: 500 })));
+    render(<SearchRide />);
+    await screen.findByText(RIDE.destino);
+
+    await userEvent.click(screen.getByRole('button', { name: RIDE_CARD_LABELS.delete }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await userEvent.click(dialog.getByRole('button', { name: DELETE_DIALOG.confirmLabel }));
+
+    expect(await screen.findByText(RIDE_LIST_MESSAGES.deleteFailed)).toBeInTheDocument();
+  });
+
+  it('should announce that editing is not available yet', async () => {
+    listReturning([RIDE]);
+    render(<SearchRide />);
+    await screen.findByText(RIDE.destino);
+
+    await userEvent.click(screen.getByRole('button', { name: RIDE_CARD_LABELS.edit }));
+
+    expect(await screen.findByText(RIDE_LIST_MESSAGES.editSoon)).toBeInTheDocument();
+  });
+});

--- a/FateConnect/Web/src/pages/Rides/screens/SearchRide/SearchRide.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/screens/SearchRide/SearchRide.test.tsx
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '@app/mocks/server';
-import { RideType } from '@app/services/rides/types';
+import { RideTypeEnum } from '@app/services/rides/types';
 import type { Ride } from '@app/services/rides/types';
 import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 import { SearchRide } from '.';
@@ -24,7 +24,7 @@ const RIDE: Ride = {
   dataPartida: '2026-05-22T00:00:00',
   horaPartida: '07:30:00',
   dataCadastro: '2026-05-01T00:00:00',
-  tipoCarona: RideType.PHILANTHROPIC,
+  tipoCarona: RideTypeEnum.PHILANTHROPIC,
   descricao: 'Saída do centro, com parada no terminal.',
   ativo: true,
 };

--- a/FateConnect/Web/src/pages/Rides/screens/SearchRide/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/screens/SearchRide/index.tsx
@@ -1,6 +1,65 @@
-import { Typography } from '@design-system';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
 
-/** Placeholder — a tela é migrada na #55. */
+import { useNotification } from '@app/hooks/useNotification';
+import { deleteRide, listRides } from '@app/services/rides/ridesService';
+import type { Ride, RideFilter as RideFilterValues } from '@app/services/rides/types';
+import { CircularProgress, Typography } from '@design-system';
+
+import { RideCard } from '../../components/RideCard';
+import { RideFilter } from '../../components/RideFilter';
+import { EMPTY_LIST_MESSAGE, RIDE_LIST_MESSAGES } from '../../constants';
+import * as S from './styles';
+
+const SPINNER_SIZE_PX = 60;
+const RIDES_QUERY_KEY = 'rides';
+
 export function SearchRide() {
-  return <Typography variant="h1">Buscar carona</Typography>;
+  const queryClient = useQueryClient();
+  const { notifySuccess, notifyWarning } = useNotification();
+  const [filters, setFilters] = useState<RideFilterValues>({});
+
+  const { data: rides = [], isPending } = useQuery({
+    queryKey: [RIDES_QUERY_KEY, filters],
+    queryFn: () => listRides(filters),
+    meta: { errorMessage: RIDE_LIST_MESSAGES.loadFailed },
+  });
+
+  const { mutate: removeRide, isPending: isRemoving } = useMutation({
+    mutationFn: (ride: Ride) => deleteRide(ride.id),
+    onSuccess: async () => {
+      notifySuccess(RIDE_LIST_MESSAGES.deleteSucceeded);
+      await queryClient.invalidateQueries({ queryKey: [RIDES_QUERY_KEY] });
+    },
+    meta: { errorMessage: RIDE_LIST_MESSAGES.deleteFailed },
+  });
+
+  const handleApplyFilters = useCallback((applied: RideFilterValues) => setFilters(applied), []);
+  const handleEdit = useCallback(() => notifyWarning(RIDE_LIST_MESSAGES.editSoon), [notifyWarning]);
+  const handleDelete = useCallback((ride: Ride) => removeRide(ride), [removeRide]);
+
+  const isLoading = isPending || isRemoving;
+
+  return (
+    <>
+      <RideFilter onApply={handleApplyFilters} />
+
+      <S.RideList>
+        {isLoading && (
+          <S.LoadingContainer>
+            <CircularProgress size={SPINNER_SIZE_PX} />
+          </S.LoadingContainer>
+        )}
+
+        {!isLoading && rides.length === 0 && (
+          <Typography variant="subtitle">{EMPTY_LIST_MESSAGE}</Typography>
+        )}
+
+        {!isLoading &&
+          rides.map((ride) => (
+            <RideCard key={ride.id} ride={ride} onEdit={handleEdit} onDelete={handleDelete} />
+          ))}
+      </S.RideList>
+    </>
+  );
 }

--- a/FateConnect/Web/src/pages/Rides/screens/SearchRide/styles.ts
+++ b/FateConnect/Web/src/pages/Rides/screens/SearchRide/styles.ts
@@ -1,0 +1,18 @@
+import { Stack, styled } from '@design-system';
+import type { PolymorphicProps } from '@design-system';
+
+/** Altura reservada enquanto a lista carrega, para o rodapé não pular. */
+const LOADING_MIN_HEIGHT_PX = 300;
+
+export const RideList = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  width: '100%',
+});
+
+export const LoadingContainer = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  minHeight: `${LOADING_MIN_HEIGHT_PX}px`,
+  width: '100%',
+});

--- a/FateConnect/Web/src/pages/Rides/styles.ts
+++ b/FateConnect/Web/src/pages/Rides/styles.ts
@@ -1,0 +1,90 @@
+import {
+  Box,
+  radius,
+  radiusScale,
+  shadowTokens,
+  spacing,
+  spacingScale,
+  Stack,
+  styled,
+  Typography,
+} from '@design-system';
+import type { PolymorphicProps } from '@design-system';
+import type { NavLinkProps } from 'react-router';
+
+type NavProps = PolymorphicProps<Pick<NavLinkProps, 'to' | 'end'>>;
+
+const { xxs, xs, md } = spacingScale;
+
+/** Recuo da página em unidades de viewport, como no produto. */
+const PAGE_PADDING = '3vw 7vw';
+/** 10px na vertical — sem token equivalente entre 8px e 12px. */
+const BACK_BUTTON_VERTICAL_PADDING_PX = 10;
+const BACK_BUTTON_PADDING = spacing(BACK_BUTTON_VERTICAL_PADDING_PX, md);
+const TAB_PADDING = spacing(md, xxs);
+const TAB_GAP = '3px';
+
+export const RidesRoot = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  flex: 1,
+  width: '100%',
+  gap: spacing(md),
+  padding: PAGE_PADDING,
+});
+
+export const RidesHeader = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const PageTitle = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.primary,
+}));
+
+export const BackButton = styled(Stack)<NavProps>(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing(xs),
+  padding: BACK_BUTTON_PADDING,
+  borderRadius: radius(radiusScale.component),
+  overflow: 'hidden',
+  textDecoration: 'none',
+  color: theme.palette.primary.contrastText,
+  background: theme.palette.primary.main,
+  boxShadow: shadowTokens.component,
+}));
+
+export const TabList = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
+  width: '100%',
+  borderRadius: radius(radiusScale.component),
+  marginTop: spacing(md),
+  background: theme.palette.background.paper,
+  boxShadow: shadowTokens.component,
+}));
+
+export const Tab = styled(Box)<NavProps>(({ theme }) => ({
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: TAB_GAP,
+  textDecoration: 'none',
+  color: theme.palette.text.primary,
+  padding: TAB_PADDING,
+
+  '&:first-of-type': {
+    borderTopLeftRadius: radius(radiusScale.component),
+    borderBottomLeftRadius: radius(radiusScale.component),
+  },
+  '&:last-of-type': {
+    borderTopRightRadius: radius(radiusScale.component),
+    borderBottomRightRadius: radius(radiusScale.component),
+  },
+
+  '&[aria-current="page"]': {
+    background: theme.palette.secondary.main,
+    color: theme.palette.secondary.contrastText,
+  },
+}));

--- a/FateConnect/Web/src/pages/Signup/@types/index.ts
+++ b/FateConnect/Web/src/pages/Signup/@types/index.ts
@@ -1,5 +1,5 @@
 /** Gênero como o formulário o carrega: o `select` trabalha com texto. */
-export enum GenderValue {
+export enum GenderValueEnum {
   MALE = '0',
   FEMALE = '1',
   UNDISCLOSED = '2',

--- a/FateConnect/Web/src/pages/Signup/Signup.test.tsx
+++ b/FateConnect/Web/src/pages/Signup/Signup.test.tsx
@@ -6,17 +6,7 @@ import { server } from '@app/mocks/server';
 import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 import { Signup } from '.';
-import {
-  CALENDAR_TOGGLE_LABEL,
-  FIELD_LABELS,
-  LEGAL_SOON_MESSAGES,
-  PASSWORD_TOGGLE_LABEL,
-  SELECT_PLACEHOLDER,
-  SIGNUP_ERROR_MESSAGES,
-  SUBMIT_LABEL,
-  ZIP_LOOKUP_MESSAGES,
-  signupSuccessMessage,
-} from './constants';
+import * as C from './constants';
 import { SIGNUP_MESSAGES } from './schema';
 
 const SIGNUP_URL = 'https://api.fateconnect.test/usuario/cadastro';
@@ -51,7 +41,7 @@ async function fillRequiredFields() {
   await userEvent.type(screen.getByLabelText(/^Senha/), VALID_SIGNUP.password);
   await userEvent.type(screen.getByLabelText(/Telefone/), VALID_SIGNUP.phone);
   await userEvent.type(screen.getByLabelText(/E-mail para contato/), VALID_SIGNUP.contactEmail);
-  await selectOption(FIELD_LABELS.gender, 'Feminino');
+  await selectOption(C.FIELD_LABELS.gender, 'Feminino');
   await userEvent.click(screen.getByRole('checkbox', { name: /Termos de Uso/ }));
 }
 
@@ -68,7 +58,7 @@ function labelOf(field: HTMLElement): HTMLElement | null {
 }
 
 function submit() {
-  return userEvent.click(screen.getByRole('button', { name: SUBMIT_LABEL }));
+  return userEvent.click(screen.getByRole('button', { name: C.SUBMIT_LABEL }));
 }
 
 describe('Signup', () => {
@@ -152,7 +142,7 @@ describe('Signup', () => {
   it('should toggle the password visibility and show the current state in the icon', async () => {
     renderSignup();
     const password = screen.getByLabelText(/^Senha/);
-    const toggle = screen.getByRole('button', { name: PASSWORD_TOGGLE_LABEL });
+    const toggle = screen.getByRole('button', { name: C.PASSWORD_TOGGLE_LABEL });
 
     expect(password).toHaveAttribute('type', 'password');
     expect(toggle).toHaveAttribute('aria-pressed', 'false');
@@ -190,7 +180,7 @@ describe('Signup', () => {
 
     await userEvent.type(screen.getByLabelText(/CEP/), '00000000');
 
-    expect(await screen.findByText(ZIP_LOOKUP_MESSAGES.notFound)).toBeInTheDocument();
+    expect(await screen.findByText(C.ZIP_LOOKUP_MESSAGES.notFound)).toBeInTheDocument();
     expect(screen.getByLabelText(/Cidade/)).toHaveValue('');
   });
 
@@ -203,7 +193,7 @@ describe('Signup', () => {
 
     await userEvent.type(screen.getByLabelText(/CEP/), '01001000');
 
-    expect(await screen.findByText(ZIP_LOOKUP_MESSAGES.failed)).toBeInTheDocument();
+    expect(await screen.findByText(C.ZIP_LOOKUP_MESSAGES.failed)).toBeInTheDocument();
   });
 
   it('should announce that the legal documents are not available yet', async () => {
@@ -211,11 +201,11 @@ describe('Signup', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Termos de Uso' }));
 
-    expect(await screen.findByText(LEGAL_SOON_MESSAGES.terms)).toBeInTheDocument();
+    expect(await screen.findByText(C.LEGAL_SOON_MESSAGES.terms)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Política de Privacidade' }));
 
-    expect(await screen.findByText(LEGAL_SOON_MESSAGES.privacy)).toBeInTheDocument();
+    expect(await screen.findByText(C.LEGAL_SOON_MESSAGES.privacy)).toBeInTheDocument();
   });
 
   it('should not toggle the consent when the legal link is clicked', async () => {
@@ -233,7 +223,7 @@ describe('Signup', () => {
     await userEvent.click(screen.getByRole('combobox', { name: /Gênero/ }));
 
     const options = within(screen.getByRole('listbox')).getAllByRole('option');
-    expect(options[0]).toHaveTextContent(SELECT_PLACEHOLDER);
+    expect(options[0]).toHaveTextContent(C.SELECT_PLACEHOLDER);
   });
 
   it('should create the account and send the user to the login anchor', async () => {
@@ -251,7 +241,7 @@ describe('Signup', () => {
 
     await submit();
 
-    expect(await screen.findByText(signupSuccessMessage('Maria Silva'))).toBeInTheDocument();
+    expect(await screen.findByText(C.signupSuccessMessage('Maria Silva'))).toBeInTheDocument();
     await waitFor(() => expect(router.state.location.pathname).toBe(RoutePathEnum.LANDING));
     expect(router.state.location.hash).toBe(`#${LandingSectionEnum.LOGIN}`);
   });
@@ -281,9 +271,9 @@ describe('Signup', () => {
   });
 
   it.each([
-    [409, SIGNUP_ERROR_MESSAGES.emailTaken],
-    [400, SIGNUP_ERROR_MESSAGES.invalidData],
-    [500, SIGNUP_ERROR_MESSAGES.generic],
+    [409, C.SIGNUP_ERROR_MESSAGES.emailTaken],
+    [400, C.SIGNUP_ERROR_MESSAGES.invalidData],
+    [500, C.SIGNUP_ERROR_MESSAGES.generic],
   ])('should report the failure for status %s', async (status, message) => {
     server.use(http.post(SIGNUP_URL, () => new HttpResponse(null, { status })));
     renderSignup();
@@ -292,7 +282,7 @@ describe('Signup', () => {
     await submit();
 
     expect(await screen.findByText(message)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: SUBMIT_LABEL })).toBeEnabled();
+    expect(screen.getByRole('button', { name: C.SUBMIT_LABEL })).toBeEnabled();
   });
 
   it('should disable the form while the account is being created', async () => {
@@ -314,7 +304,7 @@ describe('Signup', () => {
 
     await submit();
 
-    const submitButton = screen.getByRole('button', { name: SUBMIT_LABEL });
+    const submitButton = screen.getByRole('button', { name: C.SUBMIT_LABEL });
     await waitFor(() => expect(submitButton).toBeDisabled());
     expect(within(submitButton).getByRole('progressbar')).toBeInTheDocument();
     expect(screen.getByLabelText(/Nome completo/)).toBeDisabled();
@@ -327,7 +317,7 @@ describe('Signup', () => {
     const birthDate = screen.getByLabelText(/Data de nascimento/);
     await userEvent.type(birthDate, '22051999');
 
-    await userEvent.click(screen.getByRole('button', { name: CALENDAR_TOGGLE_LABEL }));
+    await userEvent.click(screen.getByRole('button', { name: C.CALENDAR_TOGGLE_LABEL }));
     const calendar = await screen.findByRole('grid');
     await userEvent.click(within(calendar).getByRole('gridcell', { name: '10' }));
 

--- a/FateConnect/Web/src/pages/Signup/Signup.test.tsx
+++ b/FateConnect/Web/src/pages/Signup/Signup.test.tsx
@@ -3,7 +3,7 @@ import { RouterProvider, createMemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '@app/mocks/server';
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 import { Signup } from '.';
 import {
@@ -34,10 +34,10 @@ const VALID_SIGNUP = {
 function renderSignup() {
   const router = createMemoryRouter(
     [
-      { path: RoutePath.SIGNUP, element: <Signup /> },
-      { path: RoutePath.LANDING, element: <div>landing</div> },
+      { path: RoutePathEnum.SIGNUP, element: <Signup /> },
+      { path: RoutePathEnum.LANDING, element: <div>landing</div> },
     ],
-    { initialEntries: [RoutePath.SIGNUP] },
+    { initialEntries: [RoutePathEnum.SIGNUP] },
   );
   render(<RouterProvider router={router} />);
 
@@ -252,8 +252,8 @@ describe('Signup', () => {
     await submit();
 
     expect(await screen.findByText(signupSuccessMessage('Maria Silva'))).toBeInTheDocument();
-    await waitFor(() => expect(router.state.location.pathname).toBe(RoutePath.LANDING));
-    expect(router.state.location.hash).toBe(`#${LandingSection.LOGIN}`);
+    await waitFor(() => expect(router.state.location.pathname).toBe(RoutePathEnum.LANDING));
+    expect(router.state.location.hash).toBe(`#${LandingSectionEnum.LOGIN}`);
   });
 
   it('should send the payload in the contract the backend expects', async () => {

--- a/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
@@ -4,12 +4,7 @@ import { useFormContext } from 'react-hook-form';
 import { IconButton, InputAdornment, TextField } from '@design-system';
 import { VisibilityIcon, VisibilityOffIcon } from '@design-system/icons';
 
-import {
-  FIELD_LABELS,
-  FIELD_PLACEHOLDERS,
-  GENDER_OPTIONS,
-  PASSWORD_TOGGLE_LABEL,
-} from '../../constants';
+import * as C from '../../constants';
 import type { SignupFormValues } from '../../schema';
 import * as S from '../../styles';
 import { BirthDateField } from '../BirthDateField';
@@ -30,7 +25,7 @@ export function AccountSection() {
       <S.FullWidthCell>
         <TextField
           {...register('fullName')}
-          label={FIELD_LABELS.fullName}
+          label={C.FIELD_LABELS.fullName}
           required
           fullWidth
           type="text"
@@ -43,7 +38,7 @@ export function AccountSection() {
       <S.ThirdWidthCell>
         <TextField
           {...register('nickname')}
-          label={FIELD_LABELS.nickname}
+          label={C.FIELD_LABELS.nickname}
           fullWidth
           type="text"
           autoComplete="nickname"
@@ -53,12 +48,12 @@ export function AccountSection() {
       <S.ThirdWidthCell>
         <TextField
           {...register('fatecEmail')}
-          label={FIELD_LABELS.fatecEmail}
+          label={C.FIELD_LABELS.fatecEmail}
           required
           fullWidth
           type="email"
           autoComplete="work email"
-          placeholder={FIELD_PLACEHOLDERS.fatecEmail}
+          placeholder={C.FIELD_PLACEHOLDERS.fatecEmail}
           error={Boolean(errors.fatecEmail)}
           helperText={errors.fatecEmail?.message}
         />
@@ -71,8 +66,8 @@ export function AccountSection() {
       <S.ThirdWidthCell>
         <SelectField
           name="gender"
-          label={FIELD_LABELS.gender}
-          options={GENDER_OPTIONS}
+          label={C.FIELD_LABELS.gender}
+          options={C.GENDER_OPTIONS}
           autoComplete="sex"
           required
         />
@@ -81,7 +76,7 @@ export function AccountSection() {
       <S.ThirdWidthCell>
         <TextField
           {...register('password')}
-          label={FIELD_LABELS.password}
+          label={C.FIELD_LABELS.password}
           required
           fullWidth
           type={passwordHidden ? 'password' : 'text'}
@@ -94,7 +89,7 @@ export function AccountSection() {
                 <InputAdornment position="end">
                   <IconButton
                     type="button"
-                    aria-label={PASSWORD_TOGGLE_LABEL}
+                    aria-label={C.PASSWORD_TOGGLE_LABEL}
                     aria-pressed={!passwordHidden}
                     onClick={handleTogglePassword}
                   >

--- a/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
@@ -1,13 +1,8 @@
 import { useCallback, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import {
-  IconButton,
-  InputAdornment,
-  TextField,
-  VisibilityIcon,
-  VisibilityOffIcon,
-} from '@design-system';
+import { IconButton, InputAdornment, TextField } from '@design-system';
+import { VisibilityIcon, VisibilityOffIcon } from '@design-system/icons';
 
 import {
   FIELD_LABELS,

--- a/FateConnect/Web/src/pages/Signup/components/AddressSection/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/AddressSection/index.tsx
@@ -2,12 +2,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { CircularProgress, InputAdornment, TextField } from '@design-system';
 
-import {
-  BRAZILIAN_STATES,
-  FIELD_LABELS,
-  FIELD_PLACEHOLDERS,
-  ZIP_LOOKUP_LABEL,
-} from '../../constants';
+import * as C from '../../constants';
 import { useAddressAutofill } from '../../hooks/useAddressAutofill';
 import { useFilledLabel } from '../../hooks/useFilledLabel';
 import { SelectField } from '../SelectField';
@@ -32,19 +27,19 @@ export function AddressSection() {
       <S.ThirdWidthCell>
         <TextField
           {...zipCodeField}
-          label={FIELD_LABELS.zipCode}
+          label={C.FIELD_LABELS.zipCode}
           fullWidth
           type="text"
           inputMode="numeric"
           autoComplete="postal-code"
-          placeholder={FIELD_PLACEHOLDERS.zipCode}
+          placeholder={C.FIELD_PLACEHOLDERS.zipCode}
           aria-busy={isLookingUpZipCode}
           slotProps={{
             inputLabel: zipCodeLabel,
             input: {
               endAdornment: isLookingUpZipCode ? (
                 <InputAdornment position="end">
-                  <CircularProgress size={SPINNER_SIZE_PX} aria-label={ZIP_LOOKUP_LABEL} />
+                  <CircularProgress size={SPINNER_SIZE_PX} aria-label={C.ZIP_LOOKUP_LABEL} />
                 </InputAdornment>
               ) : null,
             },
@@ -55,8 +50,8 @@ export function AddressSection() {
       <S.ThirdWidthCell>
         <SelectField
           name="state"
-          label={FIELD_LABELS.state}
-          options={BRAZILIAN_STATES}
+          label={C.FIELD_LABELS.state}
+          options={C.BRAZILIAN_STATES}
           autoComplete="address-level1"
         />
       </S.ThirdWidthCell>
@@ -64,7 +59,7 @@ export function AddressSection() {
       <S.ThirdWidthCell>
         <TextField
           {...register('city')}
-          label={FIELD_LABELS.city}
+          label={C.FIELD_LABELS.city}
           fullWidth
           type="text"
           autoComplete="address-level2"
@@ -75,7 +70,7 @@ export function AddressSection() {
       <S.StreetCell>
         <TextField
           {...register('street')}
-          label={FIELD_LABELS.street}
+          label={C.FIELD_LABELS.street}
           fullWidth
           type="text"
           autoComplete="address-line1"
@@ -86,7 +81,7 @@ export function AddressSection() {
       <S.StreetNumberCell>
         <TextField
           {...register('streetNumber')}
-          label={FIELD_LABELS.streetNumber}
+          label={C.FIELD_LABELS.streetNumber}
           fullWidth
           type="text"
           autoComplete="off"
@@ -96,7 +91,7 @@ export function AddressSection() {
       <S.FullWidthCell>
         <TextField
           {...register('complement')}
-          label={FIELD_LABELS.complement}
+          label={C.FIELD_LABELS.complement}
           fullWidth
           type="text"
           autoComplete="address-line2"

--- a/FateConnect/Web/src/pages/Signup/components/BirthDateField/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/BirthDateField/index.tsx
@@ -13,7 +13,7 @@ import {
   latestBirthDate,
   parseBirthDate,
 } from '../../helpers/birthDate';
-import { CALENDAR_TOGGLE_LABEL, FIELD_LABELS, FIELD_PLACEHOLDERS } from '../../constants';
+import * as C from '../../constants';
 import { useFilledLabel } from '../../hooks/useFilledLabel';
 import type { SignupFormValues } from '../../schema';
 
@@ -63,13 +63,13 @@ export function BirthDateField() {
     <>
       <TextField
         {...birthDateField}
-        label={FIELD_LABELS.birthDate}
+        label={C.FIELD_LABELS.birthDate}
         required
         fullWidth
         type="text"
         inputMode="numeric"
         autoComplete="bday"
-        placeholder={FIELD_PLACEHOLDERS.birthDate}
+        placeholder={C.FIELD_PLACEHOLDERS.birthDate}
         error={Boolean(errors.birthDate)}
         helperText={errors.birthDate?.message}
         slotProps={{
@@ -80,7 +80,7 @@ export function BirthDateField() {
               <InputAdornment position="end">
                 <IconButton
                   type="button"
-                  aria-label={CALENDAR_TOGGLE_LABEL}
+                  aria-label={C.CALENDAR_TOGGLE_LABEL}
                   onClick={handleOpenCalendar}
                 >
                   <CalendarTodayIcon fontSize="small" />

--- a/FateConnect/Web/src/pages/Signup/components/BirthDateField/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/BirthDateField/index.tsx
@@ -4,14 +4,8 @@ import { useFormContext } from 'react-hook-form';
 
 import { useMaskedField } from '@app/hooks/useMaskedField';
 import { maskBirthDate } from '@app/utils/masks/birthDateMask';
-import {
-  CalendarTodayIcon,
-  DateCalendar,
-  IconButton,
-  InputAdornment,
-  Popover,
-  TextField,
-} from '@design-system';
+import { DateCalendar, IconButton, InputAdornment, Popover, TextField } from '@design-system';
+import { CalendarTodayIcon } from '@design-system/icons';
 
 import {
   EARLIEST_BIRTH_DATE,

--- a/FateConnect/Web/src/pages/Signup/components/ConsentSection/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/ConsentSection/index.tsx
@@ -5,14 +5,7 @@ import { useFormContext } from 'react-hook-form';
 import { useNotification } from '@app/hooks/useNotification';
 import { Checkbox, FormControlLabel } from '@design-system';
 
-import {
-  CONSENT_MARKETING_LABEL,
-  CONSENT_PRIVACY_LINK,
-  CONSENT_TERMS_LINK,
-  CONSENT_TERMS_PREFIX,
-  CONSENT_TERMS_SEPARATOR,
-  LEGAL_SOON_MESSAGES,
-} from '../../constants';
+import * as C from '../../constants';
 import type { SignupFormValues } from '../../schema';
 import * as S from './styles';
 
@@ -29,7 +22,7 @@ export function ConsentSection() {
     (event: MouseEvent<HTMLElement>) => {
       event.preventDefault();
       event.stopPropagation();
-      notifyWarning(LEGAL_SOON_MESSAGES.terms);
+      notifyWarning(C.LEGAL_SOON_MESSAGES.terms);
     },
     [notifyWarning],
   );
@@ -38,7 +31,7 @@ export function ConsentSection() {
     (event: MouseEvent<HTMLElement>) => {
       event.preventDefault();
       event.stopPropagation();
-      notifyWarning(LEGAL_SOON_MESSAGES.privacy);
+      notifyWarning(C.LEGAL_SOON_MESSAGES.privacy);
     },
     [notifyWarning],
   );
@@ -49,13 +42,13 @@ export function ConsentSection() {
         control={<Checkbox {...register('acceptTerms')} />}
         label={
           <span>
-            {CONSENT_TERMS_PREFIX}{' '}
+            {C.CONSENT_TERMS_PREFIX}{' '}
             <S.InlineLink component="button" type="button" onClick={handleTermsClick}>
-              {CONSENT_TERMS_LINK}
+              {C.CONSENT_TERMS_LINK}
             </S.InlineLink>{' '}
-            {CONSENT_TERMS_SEPARATOR}{' '}
+            {C.CONSENT_TERMS_SEPARATOR}{' '}
             <S.InlineLink component="button" type="button" onClick={handlePrivacyClick}>
-              {CONSENT_PRIVACY_LINK}
+              {C.CONSENT_PRIVACY_LINK}
             </S.InlineLink>
           </span>
         }
@@ -69,7 +62,7 @@ export function ConsentSection() {
 
       <FormControlLabel
         control={<Checkbox {...register('acceptMarketing')} />}
-        label={CONSENT_MARKETING_LABEL}
+        label={C.CONSENT_MARKETING_LABEL}
       />
     </S.ConsentGroup>
   );

--- a/FateConnect/Web/src/pages/Signup/components/SelectField/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/SelectField/index.tsx
@@ -8,13 +8,13 @@ import type { SelectOption } from '../../@types';
 
 type SelectFieldName = Extract<keyof SignupFormValues, 'gender' | 'state'>;
 
-type SelectFieldProps = {
+type SelectFieldProps = Readonly<{
   name: SelectFieldName;
   label: string;
   options: readonly SelectOption[];
   autoComplete: string;
   required?: boolean;
-};
+}>;
 
 /**
  * Campo de seleção ligado ao formulário por `Controller`. O `select` do MUI

--- a/FateConnect/Web/src/pages/Signup/constants/index.ts
+++ b/FateConnect/Web/src/pages/Signup/constants/index.ts
@@ -1,4 +1,4 @@
-import { GenderValue, type SelectOption } from '../@types';
+import { GenderValueEnum, type SelectOption } from '../@types';
 
 export const SIGNUP_TITLE = 'Crie sua Conta';
 export const ADDRESS_SECTION_TITLE = 'Endereço';
@@ -64,9 +64,9 @@ export const signupSuccessMessage = (fullName: string): string =>
   `Conta criada com sucesso, ${fullName}!`;
 
 export const GENDER_OPTIONS: readonly SelectOption[] = [
-  { value: GenderValue.MALE, label: 'Masculino' },
-  { value: GenderValue.FEMALE, label: 'Feminino' },
-  { value: GenderValue.UNDISCLOSED, label: 'Prefiro não informar' },
+  { value: GenderValueEnum.MALE, label: 'Masculino' },
+  { value: GenderValueEnum.FEMALE, label: 'Feminino' },
+  { value: GenderValueEnum.UNDISCLOSED, label: 'Prefiro não informar' },
 ];
 
 /** Unidades federativas (sigla + nome em pt-BR). */

--- a/FateConnect/Web/src/pages/Signup/hooks/useFilledLabel.ts
+++ b/FateConnect/Web/src/pages/Signup/hooks/useFilledLabel.ts
@@ -8,7 +8,7 @@ type ExternallyFilledField = Extract<
   'birthDate' | 'zipCode' | 'street' | 'city'
 >;
 
-type FloatingLabelProps = { shrink?: true };
+type FloatingLabelProps = Readonly<{ shrink?: true }>;
 
 /**
  * Mantém o rótulo no alto quando o valor chega de fora — preenchimento por CEP

--- a/FateConnect/Web/src/pages/Signup/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/index.tsx
@@ -13,16 +13,7 @@ import { AccountSection } from './components/AccountSection';
 import { AddressSection } from './components/AddressSection';
 import { ConsentSection } from './components/ConsentSection';
 import { ContactSection } from './components/ContactSection';
-import {
-  ADDRESS_SECTION_TITLE,
-  CONTACT_SECTION_TITLE,
-  LOGIN_LINK_LABEL,
-  LOGIN_PROMPT,
-  SIGNUP_ERROR_MESSAGES,
-  SIGNUP_TITLE,
-  SUBMIT_LABEL,
-  signupSuccessMessage,
-} from './constants';
+import * as C from './constants';
 import { toSignupRequest } from './helpers/mapper';
 import { SIGNUP_DEFAULT_VALUES, signupSchema, type SignupFormValues } from './schema';
 import * as S from './styles';
@@ -33,10 +24,10 @@ const BAD_REQUEST = 400;
 const LOGIN_ANCHOR = `${RoutePathEnum.LANDING}#${LandingSectionEnum.LOGIN}`;
 
 function errorMessageFor(status?: number): string {
-  if (status === CONFLICT) return SIGNUP_ERROR_MESSAGES.emailTaken;
-  if (status === BAD_REQUEST) return SIGNUP_ERROR_MESSAGES.invalidData;
+  if (status === CONFLICT) return C.SIGNUP_ERROR_MESSAGES.emailTaken;
+  if (status === BAD_REQUEST) return C.SIGNUP_ERROR_MESSAGES.invalidData;
 
-  return SIGNUP_ERROR_MESSAGES.generic;
+  return C.SIGNUP_ERROR_MESSAGES.generic;
 }
 
 export function Signup() {
@@ -48,7 +39,7 @@ export function Signup() {
     // A mensagem depende do status; o aviso sai daqui, não do tratamento global.
     meta: { notifiesErrorItself: true },
     onSuccess: (response) => {
-      notifySuccess(signupSuccessMessage(response.nomeCompleto));
+      notifySuccess(C.signupSuccessMessage(response.nomeCompleto));
       navigate(LOGIN_ANCHOR);
     },
     onError: (error: ApiError) => notifyError(errorMessageFor(error.status)),
@@ -67,7 +58,7 @@ export function Signup() {
     <S.PageRoot>
       <S.SignupCard component="article" aria-labelledby={TITLE_ID}>
         <S.CardTitle variant="h2" id={TITLE_ID}>
-          {SIGNUP_TITLE}
+          {C.SIGNUP_TITLE}
         </S.CardTitle>
 
         <FormProvider {...form}>
@@ -75,11 +66,11 @@ export function Signup() {
             <AccountSection />
 
             <S.SectionDivider />
-            <S.SectionTitle variant="subtitleBold">{ADDRESS_SECTION_TITLE}</S.SectionTitle>
+            <S.SectionTitle variant="subtitleBold">{C.ADDRESS_SECTION_TITLE}</S.SectionTitle>
             <AddressSection />
 
             <S.SectionDivider />
-            <S.SectionTitle variant="subtitleBold">{CONTACT_SECTION_TITLE}</S.SectionTitle>
+            <S.SectionTitle variant="subtitleBold">{C.CONTACT_SECTION_TITLE}</S.SectionTitle>
             <ContactSection />
 
             <S.SectionDivider />
@@ -87,13 +78,13 @@ export function Signup() {
 
             <S.SubmitContainer>
               <Button type="submit" variant="contained" color="error" loading={isPending}>
-                {SUBMIT_LABEL}
+                {C.SUBMIT_LABEL}
               </Button>
 
               <S.LoginRow component="p">
-                <Typography variant="caption">{LOGIN_PROMPT}</Typography>
+                <Typography variant="caption">{C.LOGIN_PROMPT}</Typography>
                 <RouterLink to={LOGIN_ANCHOR}>
-                  <Typography variant="captionBold">{LOGIN_LINK_LABEL}</Typography>
+                  <Typography variant="captionBold">{C.LOGIN_LINK_LABEL}</Typography>
                 </RouterLink>
               </S.LoginRow>
             </S.SubmitContainer>

--- a/FateConnect/Web/src/pages/Signup/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/index.tsx
@@ -45,6 +45,8 @@ export function Signup() {
 
   const { mutate, isPending } = useMutation({
     mutationFn: signup,
+    // A mensagem depende do status; o aviso sai daqui, não do tratamento global.
+    meta: { notifiesErrorItself: true },
     onSuccess: (response) => {
       notifySuccess(signupSuccessMessage(response.nomeCompleto));
       navigate(LOGIN_ANCHOR);

--- a/FateConnect/Web/src/pages/Signup/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/index.tsx
@@ -4,7 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { Link as RouterLink, useNavigate } from 'react-router';
 
 import { useNotification } from '@app/hooks/useNotification';
-import { LandingSection, RoutePath } from '@app/routes/paths';
+import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import type { ApiError } from '@app/services/httpClient';
 import { signup } from '@app/services/signup/signupService';
 import { Button, Typography } from '@design-system';
@@ -30,7 +30,7 @@ import * as S from './styles';
 const TITLE_ID = 'signup-title';
 const CONFLICT = 409;
 const BAD_REQUEST = 400;
-const LOGIN_ANCHOR = `${RoutePath.LANDING}#${LandingSection.LOGIN}`;
+const LOGIN_ANCHOR = `${RoutePathEnum.LANDING}#${LandingSectionEnum.LOGIN}`;
 
 function errorMessageFor(status?: number): string {
   if (status === CONFLICT) return SIGNUP_ERROR_MESSAGES.emailTaken;

--- a/FateConnect/Web/src/pages/Signup/schema/schema.test.ts
+++ b/FateConnect/Web/src/pages/Signup/schema/schema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { formatBirthDate, latestBirthDate } from '../helpers/birthDate';
 import { SIGNUP_DEFAULT_VALUES, signupSchema, type SignupFormValues } from '.';
-import { GenderValue } from '../@types';
+import { GenderValueEnum } from '../@types';
 
 const ONE_DAY_MS = 86_400_000;
 
@@ -11,7 +11,7 @@ const VALID: SignupFormValues = {
   fullName: 'Maria Silva',
   fatecEmail: 'maria.silva@aluno.cps.sp.gov.br',
   birthDate: '22/05/1999',
-  gender: GenderValue.FEMALE,
+  gender: GenderValueEnum.FEMALE,
   password: 'segredo123',
   phone: '(11) 91234-5678',
   contactEmail: 'maria@exemplo.com',

--- a/FateConnect/Web/src/providers/queryClient.ts
+++ b/FateConnect/Web/src/providers/queryClient.ts
@@ -4,10 +4,29 @@ import type { ApiError } from '@app/services/httpClient';
 
 const RETRY_ATTEMPTS = 1;
 
+const FALLBACK_MESSAGE = 'Algo deu errado. Tente novamente.';
+
+/**
+ * Como cada requisição quer ser avisada em caso de erro.
+ *
+ * - `errorMessage`: a mensagem da tela, no lugar da genérica.
+ * - `notifiesErrorItself`: a tela decide a mensagem pelo status e avisa sozinha;
+ *   aqui ficamos calados para não sair notificação em dobro.
+ */
+export type RequestErrorMeta = { errorMessage?: string; notifiesErrorItself?: boolean };
+
 function messageOf(error: unknown): string {
   const apiError = error as ApiError;
 
-  return apiError?.message ?? 'Algo deu errado. Tente novamente.';
+  return apiError?.message ?? FALLBACK_MESSAGE;
+}
+
+function notifierFor(notifyError: (message: string) => void) {
+  return (error: unknown, meta: RequestErrorMeta | undefined): void => {
+    if (meta?.notifiesErrorItself) return;
+
+    notifyError(meta?.errorMessage ?? messageOf(error));
+  };
 }
 
 /**
@@ -15,12 +34,16 @@ function messageOf(error: unknown): string {
  * respondendo — o usuário é avisado, não travado.
  */
 export function createQueryClient(notifyError: (message: string) => void): QueryClient {
+  const notify = notifierFor(notifyError);
+
   return new QueryClient({
     defaultOptions: {
       queries: { retry: RETRY_ATTEMPTS, refetchOnWindowFocus: false },
       mutations: { retry: 0 },
     },
-    queryCache: new QueryCache({ onError: (error) => notifyError(messageOf(error)) }),
-    mutationCache: new MutationCache({ onError: (error) => notifyError(messageOf(error)) }),
+    queryCache: new QueryCache({ onError: (error, query) => notify(error, query.meta) }),
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => notify(error, mutation.meta),
+    }),
   });
 }

--- a/FateConnect/Web/src/routes/index.ts
+++ b/FateConnect/Web/src/routes/index.ts
@@ -1,2 +1,2 @@
 export { routeConfig } from './routeConfig';
-export { RoutePath, LandingSection } from './paths';
+export { RoutePathEnum, LandingSectionEnum } from './paths';

--- a/FateConnect/Web/src/routes/paths.ts
+++ b/FateConnect/Web/src/routes/paths.ts
@@ -2,7 +2,7 @@
  * Caminhos das rotas. Permanecem em **pt-BR e idênticos** aos do front Angular:
  * trocar um segmento quebra link salvo pelo usuário.
  */
-export enum RoutePath {
+export enum RoutePathEnum {
   ROOT = '/',
   LANDING = '/inicio',
   SIGNUP = '/cadastro',
@@ -15,7 +15,7 @@ export enum RoutePath {
 }
 
 /** Fragmentos das seções da landing, usados na navegação por âncora. */
-export enum LandingSection {
+export enum LandingSectionEnum {
   SERVICES = 'servicos',
   HOW_IT_WORKS = 'como-funciona',
   CONTACT = 'contato',

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -1,7 +1,11 @@
+import { http, HttpResponse } from 'msw';
 import { RouterProvider, createMemoryRouter } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { server } from '@app/mocks/server';
 
 import { render, screen } from '@app/test/testing-library';
+import { RIDES_TITLE } from '@app/pages/Rides/constants';
 import { SIGNUP_TITLE } from '@app/pages/Signup/constants';
 import { RoutePath } from './paths';
 import { routeConfig } from './routeConfig';
@@ -14,14 +18,19 @@ function renderRoute(initialPath: string) {
 }
 
 describe('routeConfig', () => {
+  // A tela de busca lista caronas assim que monta.
+  beforeEach(() => {
+    server.use(http.get('https://rides.fateconnect.test/caronas', () => HttpResponse.json([])));
+  });
+
   it.each([
     [RoutePath.LANDING, 'Conectando a Comunidade Acadêmica'],
     [RoutePath.SIGNUP, SIGNUP_TITLE],
     [RoutePath.MENU, 'Menu'],
     [RoutePath.LOST_AND_FOUND, 'Achados e Perdidos'],
     [RoutePath.CONTACT, 'Contato'],
-    [RoutePath.RIDES_SEARCH, 'Buscar carona'],
-    [RoutePath.RIDES_OFFER, 'Ofertar carona'],
+    [RoutePath.RIDES_SEARCH, RIDES_TITLE],
+    [RoutePath.RIDES_OFFER, RIDES_TITLE],
   ])('should resolve %s', (path, title) => {
     renderRoute(path);
 

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -7,7 +7,7 @@ import { server } from '@app/mocks/server';
 import { render, screen } from '@app/test/testing-library';
 import { RIDES_TITLE } from '@app/pages/Rides/constants';
 import { SIGNUP_TITLE } from '@app/pages/Signup/constants';
-import { RoutePath } from './paths';
+import { RoutePathEnum } from './paths';
 import { routeConfig } from './routeConfig';
 
 function renderRoute(initialPath: string) {
@@ -24,13 +24,13 @@ describe('routeConfig', () => {
   });
 
   it.each([
-    [RoutePath.LANDING, 'Conectando a Comunidade Acadêmica'],
-    [RoutePath.SIGNUP, SIGNUP_TITLE],
-    [RoutePath.MENU, 'Menu'],
-    [RoutePath.LOST_AND_FOUND, 'Achados e Perdidos'],
-    [RoutePath.CONTACT, 'Contato'],
-    [RoutePath.RIDES_SEARCH, RIDES_TITLE],
-    [RoutePath.RIDES_OFFER, RIDES_TITLE],
+    [RoutePathEnum.LANDING, 'Conectando a Comunidade Acadêmica'],
+    [RoutePathEnum.SIGNUP, SIGNUP_TITLE],
+    [RoutePathEnum.MENU, 'Menu'],
+    [RoutePathEnum.LOST_AND_FOUND, 'Achados e Perdidos'],
+    [RoutePathEnum.CONTACT, 'Contato'],
+    [RoutePathEnum.RIDES_SEARCH, RIDES_TITLE],
+    [RoutePathEnum.RIDES_OFFER, RIDES_TITLE],
   ])('should resolve %s', (path, title) => {
     renderRoute(path);
 
@@ -38,20 +38,20 @@ describe('routeConfig', () => {
   });
 
   it('should redirect the root path to the landing page', () => {
-    const router = renderRoute(RoutePath.ROOT);
+    const router = renderRoute(RoutePathEnum.ROOT);
 
-    expect(router.state.location.pathname).toBe(RoutePath.LANDING);
+    expect(router.state.location.pathname).toBe(RoutePathEnum.LANDING);
   });
 
   it('should redirect /caronas to the search screen', () => {
-    const router = renderRoute(RoutePath.RIDES);
+    const router = renderRoute(RoutePathEnum.RIDES);
 
-    expect(router.state.location.pathname).toBe(RoutePath.RIDES_SEARCH);
+    expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES_SEARCH);
   });
 
   it('should send an unknown route to the landing page', () => {
     const router = renderRoute('/rota-que-nao-existe');
 
-    expect(router.state.location.pathname).toBe(RoutePath.LANDING);
+    expect(router.state.location.pathname).toBe(RoutePathEnum.LANDING);
   });
 });

--- a/FateConnect/Web/src/routes/routeConfig.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.tsx
@@ -11,7 +11,7 @@ import { Rides } from '@app/pages/Rides';
 import { OfferRide } from '@app/pages/Rides/screens/OfferRide';
 import { SearchRide } from '@app/pages/Rides/screens/SearchRide';
 import { Signup } from '@app/pages/Signup';
-import { RoutePath } from './paths';
+import { RoutePathEnum } from './paths';
 
 /**
  * Mesma topologia do front Angular: duas cascas (visitante e interna) e as
@@ -21,32 +21,32 @@ export const routeConfig: RouteObject[] = [
   {
     element: <RootLayout />,
     children: [
-      { path: RoutePath.ROOT, element: <Navigate to={RoutePath.LANDING} replace /> },
+      { path: RoutePathEnum.ROOT, element: <Navigate to={RoutePathEnum.LANDING} replace /> },
       {
         element: <GuestLayout />,
         children: [
-          { path: RoutePath.LANDING, element: <Home /> },
-          { path: RoutePath.SIGNUP, element: <Signup /> },
+          { path: RoutePathEnum.LANDING, element: <Home /> },
+          { path: RoutePathEnum.SIGNUP, element: <Signup /> },
         ],
       },
       {
         element: <MainLayout />,
         children: [
-          { path: RoutePath.MENU, element: <Menu /> },
-          { path: RoutePath.LOST_AND_FOUND, element: <LostAndFound /> },
-          { path: RoutePath.CONTACT, element: <Contact /> },
+          { path: RoutePathEnum.MENU, element: <Menu /> },
+          { path: RoutePathEnum.LOST_AND_FOUND, element: <LostAndFound /> },
+          { path: RoutePathEnum.CONTACT, element: <Contact /> },
           {
-            path: RoutePath.RIDES,
+            path: RoutePathEnum.RIDES,
             element: <Rides />,
             children: [
-              { index: true, element: <Navigate to={RoutePath.RIDES_SEARCH} replace /> },
-              { path: RoutePath.RIDES_SEARCH, element: <SearchRide /> },
-              { path: RoutePath.RIDES_OFFER, element: <OfferRide /> },
+              { index: true, element: <Navigate to={RoutePathEnum.RIDES_SEARCH} replace /> },
+              { path: RoutePathEnum.RIDES_SEARCH, element: <SearchRide /> },
+              { path: RoutePathEnum.RIDES_OFFER, element: <OfferRide /> },
             ],
           },
         ],
       },
-      { path: '*', element: <Navigate to={RoutePath.LANDING} replace /> },
+      { path: '*', element: <Navigate to={RoutePathEnum.LANDING} replace /> },
     ],
   },
 ];

--- a/FateConnect/Web/src/services/rides/ridesService.test.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { server } from '@app/mocks/server';
 import { deleteRide, listRides } from './ridesService';
-import { RideType } from './types';
+import { RideTypeEnum } from './types';
 
 const RIDES_URL = 'https://rides.fateconnect.test/caronas';
 
@@ -21,13 +21,13 @@ describe('ridesService', () => {
       destination: 'Sorocaba',
       departureDate: '2026-08-20',
       departureTime: '07:30',
-      rideType: RideType.EGALITARIAN,
+      rideType: RideTypeEnum.EGALITARIAN,
     });
 
     expect(received!.get('Destino')).toBe('Sorocaba');
     expect(received!.get('DataPartida')).toBe('2026-08-20');
     expect(received!.get('HoraPartida')).toBe('07:30');
-    expect(received!.get('TipoCarona')).toBe(RideType.EGALITARIAN);
+    expect(received!.get('TipoCarona')).toBe(RideTypeEnum.EGALITARIAN);
   });
 
   it('should omit parameters that were not filled in', async () => {

--- a/FateConnect/Web/src/services/rides/types.ts
+++ b/FateConnect/Web/src/services/rides/types.ts
@@ -1,5 +1,5 @@
 /** Valores canônicos alinhados à serialização do backend. */
-export enum RideType {
+export enum RideTypeEnum {
   PHILANTHROPIC = 'Filantropica',
   EGALITARIAN = 'Igualitaria',
 }
@@ -12,7 +12,7 @@ export type Ride = {
   dataPartida: string;
   horaPartida: string;
   dataCadastro: string;
-  tipoCarona: RideType;
+  tipoCarona: RideTypeEnum;
   descricao: string;
   ativo: boolean;
 };
@@ -22,5 +22,5 @@ export type RideFilter = {
   destination?: string;
   departureDate?: string;
   departureTime?: string;
-  rideType?: RideType;
+  rideType?: RideTypeEnum;
 };


### PR DESCRIPTION
## Objetivo

Migrar o módulo de caronas para o React: a casca com as duas abas, a tela de busca com filtro e lista, o cartão de carona com exclusão confirmada, e a tela de ofertar. Fatia da migração #47.

## Alterações

### Módulo de caronas

- Casca com título, volta para o menu e as duas abas de rota, marcando a aba corrente com `aria-current`.
- Tela de busca com `@tanstack/react-query`: lista, estado de carregamento, lista vazia e falha de carregamento tratada.
- Filtro com os quatro campos — data, hora, destino e tipo — montando a requisição com os mesmos parâmetros de hoje (`Destino`, `DataPartida`, `HoraPartida`, `TipoCarona`).
- Cartão de carona com data, hora, vagas, descrição e etiqueta de tipo, mais editar e excluir.
- Exclusão pede confirmação e recarrega a lista; o aviso de edição indisponível continua como está no produto.
- Tela de ofertar portada como está: o cartão de chamada com o aviso de "em breve".

### Design system

- `ConfirmDialog`, prop-driven, com o corpo por composição — `<ConfirmDialog.Message prefix … emphasis … suffix />`.
- `StatusTag` com tom genérico (`neutral`, `success`, `warning`): o design system não conhece "filantrópica".
- Barrel passa a expor `Accordion`, `Tooltip`, os primitivos de diálogo, o `DatePicker` e os ícones das telas de carona.
- `PolymorphicProps` vira genérico, para o elemento alvo declarar as próprias props: `PolymorphicProps<Pick<NavLinkProps, 'to'>>`.
- Novo `compactMedia` (600px), o terceiro breakpoint do produto — usado pelo cartão ao mover a etiqueta para o rodapé.

### Duas correções que alcançam telas já entregues

- **Etiquetas ilegíveis no tema escuro.** A paleta escura declarava a cor **de fundo** como `success.main` e não tinha `light`, então o MUI derivava um tom quase igual para o fundo: texto verde-claro sobre verde-claro. Agora `light` é o fundo e `main` o texto nos **dois** temas, e os dois pares entraram no teste de contraste.
- **Notificação de erro em dobro.** O `QueryClient` avisa erro globalmente e as telas de login e cadastro também avisavam — dois alertas por falha, desde a #53. Cada requisição passa a declarar como quer ser avisada: `meta.errorMessage` para a mensagem da tela, `meta.notifiesErrorItself` para quem decide pelo status. Há teste provando que sai **um** alerta.

## Paridade visual

`getComputedStyle` nos dois apps, em 1440px e 500px, com um stub servindo as mesmas duas caronas para os dois.

| Métrica | Angular | React |
| --- | --- | --- |
| Página | padding `43.2px 100.8px` | idem |
| Botão voltar | 104×44, gap 8, raio 10, `#43545C` | idem |
| Abas | 1238×56; ativa 619×56 em `#CF2E2E` | idem |
| Painel do filtro | 1238×168; cabeçalho 64px; corpo `0 24px 32px` | idem |
| Campo do filtro | 225×56, **raio 10px**, borda 38% | idem |
| Linha de campos | gap 16, `margin-top` 16, quebra, `flex-start` | idem |
| Cartão | 1238×144 | 1238×145 |
| Linha de informações | gap 72px (5vw), altura 20 | idem |
| Etiqueta | 97×27, `#D4EDDA` / `#155724`, em linha | idem |
| Botões de ação | 32×32, glifo 16.8×16.8 | idem |
| Ofertar carona | 1238×255; botão 200×56, raio 10 | idem |
| 500px — cartão | 430×195; etiqueta desce, bloco 52 | 430×196; bloco 52 |
| 500px — página | padding `15px 35px` | idem |

O 1px do cartão é a caixa de linha da descrição: **24,5px contra 24,0px**. Medido com decimal, não arredondado — é sub-pixel.

O campo do filtro é o **único** lugar do produto em que o campo usa o raio de componente (10px); o resto da aplicação segue com o raio padrão do Material. Está escopado ao painel.

### Desvios conscientes

| Desvio | Motivo |
| --- | --- |
| Ícone quadrado no lugar do glifo mais largo que alto (20×16) | troca de biblioteca de ícone; a largura foi mantida, como já decidido na #51 |
| Vermelho do botão de filtrar `#F44336` → `#E81C0D` | contraste AA, decidido na #53 |
| Texto sobre a cor de marca em branco puro | contraste AA, decidido na #53 |
| Etiquetas com par próprio no tema escuro | o produto não tem tema escuro; o par claro seria ilegível |
| `ride-form` não portado | é scaffold do CLI que renderiza `"ride-form works!"` e nenhuma tela usa |

## Ajustes gerais de convenção

Aplicados em toda a `Web`, um commit por convenção:

- **Barrel de ícones separado**: `import { AddIcon } from '@design-system/icons'`. O lint passa a permitir esse caminho e continua barrando qualquer outro interno do design system.
- **Barrel do design system enxuto**: saiu o que a aplicação não pode consumir direto — paleta, tipografia, fábrica do tema e as larguras cruas de breakpoint.
- **`enum` com sufixo `Enum`**: `RideTypeEnum`, `RoutePathEnum`, `GenderValueEnum`, `LandingSectionEnum`, `RideTypeFilterEnum`.
- **Props de componente em `Readonly`**.
- **Constantes em namespace a partir de três nomes**: `import * as C from './constants'`, mesmo padrão do `import * as S from './styles'`.
- **"Entre em Contato" sai da navegação da área logada**; a landing mantém a âncora.

## Issue

- #55

Closes #55

## Evidências

