### PR TITLE
feat(56): add the lost and found screen and drop the contact route

### DIFF
--- a/FateConnect/Web/eslint.config.js
+++ b/FateConnect/Web/eslint.config.js
@@ -33,6 +33,8 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
       // API marcada como obsoleta não entra: quando ela sair, o build quebra.
       '@typescript-eslint/no-deprecated': 'error',
+      // Nenhum console solto no código: sobra de depuração vaza para produção.
+      'no-console': 'error',
     },
   },
 

--- a/FateConnect/Web/eslint.config.js
+++ b/FateConnect/Web/eslint.config.js
@@ -136,8 +136,7 @@ export default tseslint.config(
             'Sem `sx` inline. Declare o estilo em `styles.ts` com `styled(...)` e use `<S.Componente>`.',
         },
         {
-          selector:
-            "CallExpression[callee.object.name='theme'][callee.property.name='spacing']",
+          selector: "CallExpression[callee.object.name='theme'][callee.property.name='spacing']",
           message:
             'Use o helper `spacing()` do design system. O `theme.spacing` é do MUI e sobrescrevê-lo encolhe os componentes dele (as gutters do Toolbar viraram 3px).',
         },
@@ -158,11 +157,13 @@ export default tseslint.config(
         'error',
         {
           selector: 'Literal[value=/^#[0-9a-fA-F]{3,8}$/]',
-          message: 'Sem cor literal. Leia de `theme.palette`; se falta um slot, declare-o na paleta.',
+          message:
+            'Sem cor literal. Leia de `theme.palette`; se falta um slot, declare-o na paleta.',
         },
         {
           selector: 'Literal[value=/^rgba?\\(/]',
-          message: 'Sem cor literal. Leia de `theme.palette`; se falta um slot, declare-o na paleta.',
+          message:
+            'Sem cor literal. Leia de `theme.palette`; se falta um slot, declare-o na paleta.',
         },
       ],
     },

--- a/FateConnect/Web/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/FateConnect/Web/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,56 @@
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RoutePathEnum } from '@app/routes/paths';
+import { render, screen, userEvent } from '@app/test/testing-library';
+import * as C from './constants';
+import { ErrorBoundary } from '.';
+
+function ExplodingScreen(): never {
+  throw new Error('falha proposital');
+}
+
+function renderComponent() {
+  const router = createMemoryRouter(
+    [
+      {
+        errorElement: <ErrorBoundary />,
+        children: [
+          { path: RoutePathEnum.MENU, element: <ExplodingScreen /> },
+          { path: RoutePathEnum.LANDING, element: <div>início</div> },
+        ],
+      },
+    ],
+    { initialEntries: [RoutePathEnum.MENU] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+// O React e o roteador registram o erro no console; silenciar mantém a saída da
+// suíte legível sem esconder falha de teste.
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should replace the crashed screen with a recoverable message', () => {
+    renderComponent();
+
+    expect(screen.getByRole('heading', { name: C.ERROR_TITLE })).toBeInTheDocument();
+    expect(screen.getByText(C.ERROR_DESCRIPTION)).toBeInTheDocument();
+  });
+
+  it('should take the user back to the start', async () => {
+    const router = renderComponent();
+
+    await userEvent.click(screen.getByRole('link', { name: C.BACK_TO_START_LABEL }));
+
+    expect(router.state.location.pathname).toBe(RoutePathEnum.LANDING);
+  });
+});

--- a/FateConnect/Web/src/components/ErrorBoundary/constants/index.ts
+++ b/FateConnect/Web/src/components/ErrorBoundary/constants/index.ts
@@ -1,0 +1,4 @@
+export const ERROR_TITLE = 'Algo deu errado';
+export const ERROR_DESCRIPTION =
+  'Não conseguimos exibir esta página. Você pode voltar ao início e tentar de novo.';
+export const BACK_TO_START_LABEL = 'Voltar ao início';

--- a/FateConnect/Web/src/components/ErrorBoundary/index.tsx
+++ b/FateConnect/Web/src/components/ErrorBoundary/index.tsx
@@ -1,0 +1,29 @@
+import { Link as RouterLink } from 'react-router';
+
+import { RoutePathEnum } from '@app/routes/paths';
+import { Button, PageMessage } from '@design-system';
+
+import * as C from './constants';
+import * as S from './styles';
+
+/**
+ * Última barreira das rotas: qualquer erro que escape de uma tela cai aqui, no
+ * lugar da página de diagnóstico do roteador. A tela mostra só o que o usuário
+ * consegue fazer a respeito — o rastro técnico fica com o roteador.
+ */
+export function ErrorBoundary() {
+  return (
+    <S.ErrorScreen>
+      <PageMessage title={C.ERROR_TITLE} description={C.ERROR_DESCRIPTION}>
+        <Button
+          variant="contained"
+          color="secondary"
+          component={RouterLink}
+          to={RoutePathEnum.LANDING}
+        >
+          {C.BACK_TO_START_LABEL}
+        </Button>
+      </PageMessage>
+    </S.ErrorScreen>
+  );
+}

--- a/FateConnect/Web/src/components/ErrorBoundary/styles.ts
+++ b/FateConnect/Web/src/components/ErrorBoundary/styles.ts
@@ -1,0 +1,11 @@
+import { Stack, styled } from '@design-system';
+import type { PolymorphicProps } from '@design-system';
+
+/**
+ * A tela de erro substitui a casca inteira — sem topo e sem rodapé para
+ * reservar espaço, ela mesma precisa ocupar a altura da janela.
+ */
+export const ErrorScreen = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  minHeight: '100vh',
+});

--- a/FateConnect/Web/src/design-system/components/Footer/styles.ts
+++ b/FateConnect/Web/src/design-system/components/Footer/styles.ts
@@ -29,13 +29,18 @@ export const FooterRoot = styled(Stack)<PolymorphicProps>(({ theme }) => ({
   },
 }));
 
+/**
+ * No mobile o produto centraliza também as linhas de texto, não só as caixas:
+ * o alinhamento fica no contêiner e é herdado, no lugar do `:host-context` que
+ * a tipografia usava para alcançar o pai.
+ */
 export const ContactsContainer = styled(Stack)<PolymorphicProps>({
   flexDirection: 'column',
   justifyContent: 'center',
   gap: spacing(md),
   width: '100%',
 
-  [mobileMedia]: { alignItems: 'center' },
+  [mobileMedia]: { alignItems: 'center', textAlign: 'center' },
 });
 
 export const ContactItem = styled(Stack)<PolymorphicProps>({
@@ -60,5 +65,5 @@ export const CopyrightContainer = styled(Stack)<PolymorphicProps>({
   gap: spacing(md),
   width: '100%',
 
-  [mobileMedia]: { alignItems: 'center' },
+  [mobileMedia]: { alignItems: 'center', textAlign: 'center' },
 });

--- a/FateConnect/Web/src/design-system/components/Header/styles.ts
+++ b/FateConnect/Web/src/design-system/components/Header/styles.ts
@@ -19,6 +19,9 @@ const NAV_FONT_SIZE = '1rem';
 const NAV_FONT_WEIGHT = 500;
 const CTA_FONT_WEIGHT = 400;
 
+/** Largura do botão de menu no mobile, como no produto. */
+const MENU_BUTTON_WIDTH = '48px';
+
 /** Espaço horizontal entre os itens do topo — vale também entre a navegação e as ações. */
 const NAV_COLUMN_GAP = '1.5vw';
 
@@ -73,13 +76,19 @@ export const ActionsSlot = styled(Stack)<PolymorphicProps>({
   marginLeft: NAV_COLUMN_GAP,
 });
 
+/**
+ * Só existe abaixo do breakpoint mobile. O `display: flex` na consulta é o que
+ * volta a exibir o botão: sem ele o `display: none` da base vale em toda
+ * largura e o ícone de menu nunca aparece.
+ */
 export const MenuButtonSlot = styled(Stack)<PolymorphicProps>({
   display: 'none',
 
   [mobileMedia]: {
+    display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    width: '48px',
+    width: MENU_BUTTON_WIDTH,
   },
 });

--- a/FateConnect/Web/src/design-system/components/PageMessage/index.tsx
+++ b/FateConnect/Web/src/design-system/components/PageMessage/index.tsx
@@ -1,0 +1,28 @@
+import Typography from '@mui/material/Typography';
+import type { ReactNode } from 'react';
+
+import * as S from './styles';
+
+export type PageMessageProps = Readonly<{
+  title: string;
+  description: string;
+  /** Ação de saída — normalmente um botão de volta. */
+  children?: ReactNode;
+}>;
+
+/**
+ * Recado que ocupa a área de conteúdo: título, texto e uma ação opcional.
+ * Serve tanto para área ainda não disponível quanto para erro não capturado.
+ */
+export function PageMessage({ title, description, children }: PageMessageProps) {
+  return (
+    <S.PageMessageRoot>
+      <S.MessageContent>
+        <Typography variant="h1">{title}</Typography>
+        <Typography variant="subtitle">{description}</Typography>
+
+        {children}
+      </S.MessageContent>
+    </S.PageMessageRoot>
+  );
+}

--- a/FateConnect/Web/src/design-system/components/PageMessage/styles.ts
+++ b/FateConnect/Web/src/design-system/components/PageMessage/styles.ts
@@ -1,0 +1,28 @@
+import Stack from '@mui/material/Stack';
+
+import { styled } from '../../styled';
+import type { PolymorphicProps } from '../../styled';
+import { spacing } from '../../theme/helpers/spacing';
+import { spacingScale } from '../../tokens';
+
+const { md, xl } = spacingScale;
+
+/** Largura da coluna de texto, como no produto. */
+const CONTENT_MAX_WIDTH_REM = 28;
+
+/** Ocupa a área de conteúdo e centraliza — papel do `:host` da tela no produto. */
+export const PageMessageRoot = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  flex: 1,
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: spacing(xl),
+});
+
+export const MessageContent = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  maxWidth: `${CONTENT_MAX_WIDTH_REM}rem`,
+  alignItems: 'center',
+  gap: spacing(md),
+  textAlign: 'center',
+});

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -15,6 +15,8 @@ export { HEADER_HEIGHT_PX } from './components/Header/styles';
 export { Footer } from './components/Footer';
 export { NavigationDrawer } from './components/NavigationDrawer';
 export { ConfirmDialog } from './components/ConfirmDialog';
+export { PageMessage } from './components/PageMessage';
+export type { PageMessageProps } from './components/PageMessage';
 export { StatusTag } from './components/StatusTag';
 export type { StatusTagProps } from './components/StatusTag';
 export type { StatusTagTone } from './components/StatusTag/types';

--- a/FateConnect/Web/src/design-system/theme/createAppTheme.test.ts
+++ b/FateConnect/Web/src/design-system/theme/createAppTheme.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { colorTokens, spacingScale, typographyTokens } from '../tokens';
+import { colorTokens, mobileMedia, spacingScale, typographyTokens } from '../tokens';
+import type { TypographyToken } from '../tokens';
 import { createAppTheme } from './createAppTheme';
 import { spacing } from './helpers/spacing';
 
@@ -30,11 +31,15 @@ describe('createAppTheme', () => {
     expect(typography.logo).toMatchObject(typographyTokens.logo);
   });
 
-  it('should shrink h1 on narrow screens keeping weight and line height', () => {
+  // A consulta precisa ser a do produto (768px). Com o `sm` do MUI (600px) o
+  // título ficava grande entre os dois pontos, e o teste antigo — que só
+  // procurava o tamanho reduzido em algum lugar do objeto — não acusava.
+  it('should shrink h1 at the product breakpoint keeping weight and line height', () => {
     const { typography } = createAppTheme();
+    const h1 = typography.h1 as unknown as Record<string, TypographyToken>;
 
     expect(typography.h1.fontSize).toBe(typographyTokens.h1.fontSize);
-    expect(JSON.stringify(typography.h1)).toContain(typographyTokens.h1Narrow.fontSize);
+    expect(h1[mobileMedia]).toMatchObject(typographyTokens.h1Narrow);
   });
 
   it('should apply the product palette', () => {

--- a/FateConnect/Web/src/design-system/theme/createAppTheme.ts
+++ b/FateConnect/Web/src/design-system/theme/createAppTheme.ts
@@ -2,12 +2,9 @@ import { ptBR as corePtBR } from '@mui/material/locale';
 import { createTheme, type Theme } from '@mui/material/styles';
 import { ptBR as pickersPtBR } from '@mui/x-date-pickers/locales';
 
-import { fontFamily, typographyTokens } from '../tokens';
+import { fontFamily, mobileMedia, typographyTokens } from '../tokens';
 import { darkPalette, lightPalette } from './palettes';
 import { components } from './components';
-
-/** Acima deste ponto o `h1` usa o tamanho cheio; abaixo, o reduzido. */
-const NARROW_BREAKPOINT = 'sm';
 
 declare module '@mui/material/styles' {
   interface TypographyVariants {
@@ -38,17 +35,17 @@ export type ThemeMode = 'light' | 'dark';
 
 /** Modo claro é o padrão; o escuro segue o sistema de cor do Material Design. */
 export function createAppTheme(mode: ThemeMode = 'light'): Theme {
-  const base = createTheme();
-
   return createTheme(
     {
       components,
       palette: mode === 'dark' ? darkPalette : lightPalette,
       typography: {
         fontFamily,
+        // O ponto de virada é o do produto (768px), não o `sm` do MUI (600px):
+        // entre os dois o título ficava grande enquanto o produto já reduzia.
         h1: {
           ...typographyTokens.h1,
-          [base.breakpoints.down(NARROW_BREAKPOINT)]: typographyTokens.h1Narrow,
+          [mobileMedia]: typographyTokens.h1Narrow,
         },
         h2: typographyTokens.h2,
         subtitle: typographyTokens.subtitle,

--- a/FateConnect/Web/src/hooks/useLandingAnchor.test.tsx
+++ b/FateConnect/Web/src/hooks/useLandingAnchor.test.tsx
@@ -19,7 +19,7 @@ function renderAt(initialPath: string) {
   const router = createMemoryRouter(
     [
       { path: RoutePathEnum.LANDING, element: <SectionButton /> },
-      { path: RoutePathEnum.CONTACT, element: <SectionButton /> },
+      { path: RoutePathEnum.MENU, element: <SectionButton /> },
     ],
     { initialEntries: [initialPath] },
   );
@@ -34,7 +34,7 @@ describe('useLandingAnchor', () => {
   });
 
   it('should navigate to the landing page with the fragment when on another route', async () => {
-    const router = renderAt(RoutePathEnum.CONTACT);
+    const router = renderAt(RoutePathEnum.MENU);
 
     await userEvent.click(screen.getByRole('button', { name: 'Serviços' }));
 

--- a/FateConnect/Web/src/pages/Contact/index.tsx
+++ b/FateConnect/Web/src/pages/Contact/index.tsx
@@ -1,6 +1,0 @@
-import { Typography } from '@design-system';
-
-/** Placeholder — a tela é migrada na #56. */
-export function Contact() {
-  return <Typography variant="h1">Contato</Typography>;
-}

--- a/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
@@ -1,0 +1,37 @@
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { RoutePathEnum } from '@app/routes/paths';
+import { render, screen, userEvent } from '@app/test/testing-library';
+import * as C from './constants';
+import { LostAndFound } from '.';
+
+function renderComponent() {
+  const router = createMemoryRouter(
+    [
+      { path: RoutePathEnum.LOST_AND_FOUND, element: <LostAndFound /> },
+      { path: RoutePathEnum.MENU, element: <div>menu</div> },
+    ],
+    { initialEntries: [RoutePathEnum.LOST_AND_FOUND] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+describe('LostAndFound', () => {
+  it('should render the title as the page heading and the notice below it', () => {
+    renderComponent();
+
+    expect(screen.getByRole('heading', { name: C.LOST_AND_FOUND_TITLE })).toBeInTheDocument();
+    expect(screen.getByText(C.LOST_AND_FOUND_DESCRIPTION)).toBeInTheDocument();
+  });
+
+  it('should take the user back to the menu from the action', async () => {
+    const router = renderComponent();
+
+    await userEvent.click(screen.getByRole('link', { name: C.BACK_TO_MENU_LABEL }));
+
+    expect(router.state.location.pathname).toBe(RoutePathEnum.MENU);
+  });
+});

--- a/FateConnect/Web/src/pages/LostAndFound/constants/index.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/constants/index.ts
@@ -1,0 +1,3 @@
+export const LOST_AND_FOUND_TITLE = 'Achados e perdidos';
+export const LOST_AND_FOUND_DESCRIPTION = 'Esta área estará disponível em breve.';
+export const BACK_TO_MENU_LABEL = 'Voltar ao menu';

--- a/FateConnect/Web/src/pages/LostAndFound/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/index.tsx
@@ -1,6 +1,17 @@
-import { Typography } from '@design-system';
+import { Link as RouterLink } from 'react-router';
 
-/** Placeholder — a tela é migrada na #56. */
+import { RoutePathEnum } from '@app/routes/paths';
+import { Button, PageMessage } from '@design-system';
+
+import * as C from './constants';
+
+/** Aviso de área ainda não implementada, com o caminho de volta ao menu. */
 export function LostAndFound() {
-  return <Typography variant="h1">Achados e Perdidos</Typography>;
+  return (
+    <PageMessage title={C.LOST_AND_FOUND_TITLE} description={C.LOST_AND_FOUND_DESCRIPTION}>
+      <Button variant="contained" color="secondary" component={RouterLink} to={RoutePathEnum.MENU}>
+        {C.BACK_TO_MENU_LABEL}
+      </Button>
+    </PageMessage>
+  );
 }

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -11,6 +11,9 @@ import { OFFER_TITLE } from './screens/OfferRide/constants';
 
 const RIDES_URL = 'https://rides.fateconnect.test/caronas';
 
+/** Cobre a tentativa inicial, os 2s de espera e a repetição. */
+const RETRY_WINDOW_MS = 5000;
+
 function renderRides(initialPath: string = RoutePathEnum.RIDES_SEARCH) {
   const router = createMemoryRouter(routeConfig, { initialEntries: [initialPath] });
   render(<RouterProvider router={router} />);
@@ -52,6 +55,24 @@ describe('Rides', () => {
 
     expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES_OFFER);
     expect(await screen.findByRole('heading', { name: OFFER_TITLE })).toBeInTheDocument();
+  });
+
+  // Sem endereço de API a requisição cai no servidor de desenvolvimento, que
+  // responde o HTML da aplicação com status 200. Antes de validar o formato, a
+  // tela recebia texto no lugar da lista e quebrava no `map`.
+  it('should notify instead of breaking when the api does not return a list', async () => {
+    server.use(http.get(RIDES_URL, () => HttpResponse.text('<!doctype html><html></html>')));
+
+    renderRides();
+
+    // A consulta tenta de novo antes de desistir, com 2s de espera entre as
+    // tentativas — mais que o limite padrão do `findBy`.
+    const notice = await screen.findByText(C.RIDE_LIST_MESSAGES.loadFailed, undefined, {
+      timeout: RETRY_WINDOW_MS,
+    });
+
+    expect(notice).toBeInTheDocument();
+    expect(screen.getByText(C.EMPTY_LIST_MESSAGE)).toBeInTheDocument();
   });
 
   it('should send the bare rides path to the search screen', () => {

--- a/FateConnect/Web/src/routes/paths.ts
+++ b/FateConnect/Web/src/routes/paths.ts
@@ -8,7 +8,6 @@ export enum RoutePathEnum {
   SIGNUP = '/cadastro',
   MENU = '/menu',
   LOST_AND_FOUND = '/achados-perdidos',
-  CONTACT = '/contato',
   RIDES = '/caronas',
   RIDES_SEARCH = '/caronas/buscar',
   RIDES_OFFER = '/caronas/ofertar',

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -29,7 +29,6 @@ describe('routeConfig', () => {
     [RoutePathEnum.SIGNUP, SIGNUP_TITLE],
     [RoutePathEnum.MENU, 'Menu'],
     [RoutePathEnum.LOST_AND_FOUND, LOST_AND_FOUND_TITLE],
-    [RoutePathEnum.CONTACT, 'Contato'],
     [RoutePathEnum.RIDES_SEARCH, RIDES_TITLE],
     [RoutePathEnum.RIDES_OFFER, RIDES_TITLE],
     // Dentro de `main`: o título da tela vive na área de conteúdo, não no cromo.
@@ -52,6 +51,12 @@ describe('routeConfig', () => {
     const router = renderRoute(RoutePathEnum.RIDES);
 
     expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES_SEARCH);
+  });
+
+  it('should send the dropped contact route to the landing page', () => {
+    const router = renderRoute('/contato');
+
+    expect(router.state.location.pathname).toBe(RoutePathEnum.LANDING);
   });
 
   it('should send an unknown route to the landing page', () => {

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { server } from '@app/mocks/server';
 
-import { render, screen } from '@app/test/testing-library';
+import { render, screen, within } from '@app/test/testing-library';
+import { LOST_AND_FOUND_TITLE } from '@app/pages/LostAndFound/constants';
 import { RIDES_TITLE } from '@app/pages/Rides/constants';
 import { SIGNUP_TITLE } from '@app/pages/Signup/constants';
 import { RoutePathEnum } from './paths';
@@ -27,14 +28,18 @@ describe('routeConfig', () => {
     [RoutePathEnum.LANDING, 'Conectando a Comunidade Acadêmica'],
     [RoutePathEnum.SIGNUP, SIGNUP_TITLE],
     [RoutePathEnum.MENU, 'Menu'],
-    [RoutePathEnum.LOST_AND_FOUND, 'Achados e Perdidos'],
+    [RoutePathEnum.LOST_AND_FOUND, LOST_AND_FOUND_TITLE],
     [RoutePathEnum.CONTACT, 'Contato'],
     [RoutePathEnum.RIDES_SEARCH, RIDES_TITLE],
     [RoutePathEnum.RIDES_OFFER, RIDES_TITLE],
+    // Dentro de `main`: o título da tela vive na área de conteúdo, não no cromo.
+    // Buscar na página toda casaria com um título do rodapé de mesmo texto.
   ])('should resolve %s', (path, title) => {
     renderRoute(path);
 
-    expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
+    expect(
+      within(screen.getByRole('main')).getByRole('heading', { name: title }),
+    ).toBeInTheDocument();
   });
 
   it('should redirect the root path to the landing page', () => {

--- a/FateConnect/Web/src/routes/routeConfig.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.tsx
@@ -1,5 +1,6 @@
 import { Navigate, type RouteObject } from 'react-router';
 
+import { ErrorBoundary } from '@app/components/ErrorBoundary';
 import { GuestLayout } from '@app/layouts/GuestLayout';
 import { MainLayout } from '@app/layouts/MainLayout';
 import { RootLayout } from '@app/layouts/RootLayout';
@@ -20,6 +21,7 @@ import { RoutePathEnum } from './paths';
 export const routeConfig: RouteObject[] = [
   {
     element: <RootLayout />,
+    errorElement: <ErrorBoundary />,
     children: [
       { path: RoutePathEnum.ROOT, element: <Navigate to={RoutePathEnum.LANDING} replace /> },
       {

--- a/FateConnect/Web/src/routes/routeConfig.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.tsx
@@ -3,7 +3,6 @@ import { Navigate, type RouteObject } from 'react-router';
 import { GuestLayout } from '@app/layouts/GuestLayout';
 import { MainLayout } from '@app/layouts/MainLayout';
 import { RootLayout } from '@app/layouts/RootLayout';
-import { Contact } from '@app/pages/Contact';
 import { Home } from '@app/pages/Home';
 import { LostAndFound } from '@app/pages/LostAndFound';
 import { Menu } from '@app/pages/Menu';
@@ -14,8 +13,9 @@ import { Signup } from '@app/pages/Signup';
 import { RoutePathEnum } from './paths';
 
 /**
- * Mesma topologia do front Angular: duas cascas (visitante e interna) e as
- * telas de carona aninhadas sob `/caronas`.
+ * Duas cascas (visitante e interna) e as telas de carona aninhadas sob
+ * `/caronas`, como no front Angular. A exceção é `/contato`: o contato existe
+ * só como seção da landing, então a rota não é portada e cai no curinga.
  */
 export const routeConfig: RouteObject[] = [
   {
@@ -34,7 +34,6 @@ export const routeConfig: RouteObject[] = [
         children: [
           { path: RoutePathEnum.MENU, element: <Menu /> },
           { path: RoutePathEnum.LOST_AND_FOUND, element: <LostAndFound /> },
-          { path: RoutePathEnum.CONTACT, element: <Contact /> },
           {
             path: RoutePathEnum.RIDES,
             element: <Rides />,

--- a/FateConnect/Web/src/services/rides/ridesService.test.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.test.ts
@@ -52,6 +52,12 @@ describe('ridesService', () => {
     expect(rides).toHaveLength(1);
   });
 
+  it('should fail when the response is not a list', async () => {
+    server.use(http.get(RIDES_URL, () => HttpResponse.text('<!doctype html><html></html>')));
+
+    await expect(listRides()).rejects.toThrow(/não é uma lista/);
+  });
+
   it('should delete a ride by id', async () => {
     let deletedId: string | undefined;
     server.use(

--- a/FateConnect/Web/src/services/rides/ridesService.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.ts
@@ -3,6 +3,8 @@ import type { Ride, RideFilter } from './types';
 
 const RIDES_PATH = '/caronas';
 
+const INVALID_LIST_PAYLOAD_MESSAGE = 'A API de caronas respondeu algo que não é uma lista.';
+
 /** Tradução dos filtros do front para os nomes de parâmetro da API. */
 function toQueryParams(filters: RideFilter = {}): Record<string, string> {
   const params: Record<string, string> = {};
@@ -17,6 +19,12 @@ function toQueryParams(filters: RideFilter = {}): Record<string, string> {
 
 export async function listRides(filters?: RideFilter): Promise<Ride[]> {
   const { data } = await rideApiClient.get<Ride[]>(RIDES_PATH, { params: toQueryParams(filters) });
+
+  // O tipo do axios é uma promessa de contrato, não uma garantia: sem o endereço
+  // da API a requisição cai no próprio servidor de desenvolvimento, que responde
+  // o HTML da aplicação com status 200. Falhar aqui transforma isso na
+  // notificação de erro da tela, em vez de estourar depois ao percorrer a lista.
+  if (!Array.isArray(data)) throw new Error(INVALID_LIST_PAYLOAD_MESSAGE);
 
   return data;
 }


### PR DESCRIPTION
## Objetivo

Portar as telas simples que faltavam da área logada e resolver os overrides de tipografia que dependiam do contexto do pai (`:host-context`). No caminho, três correções que a migração desta fatia revelou — duas de paridade e uma de robustez —, além do error boundary de rota.

## Alterações

### Tela de achados e perdidos

- `pages/LostAndFound/` passa a renderizar a tela de verdade: título, aviso e o caminho de volta ao menu. Textos em `constants/`, layout no `PageMessage`.
- Novo `PageMessage` no design system (`design-system/components/PageMessage/`): coluna centralizada que ocupa a área de conteúdo, com título, texto e uma ação por slot. Sem conhecimento de domínio — quem compõe fornece o botão e a rota.
- Paridade medida entre os dois fronts em 1440px e 700px: coluna de conteúdo, título, subtítulo e botão com as mesmas caixas.

### A rota `/contato` não foi portada

O contato existe só como seção da landing, atendida pelo rodapé. A rota sai do `RoutePathEnum` e do `routeConfig`; link antigo cai no curinga e vai para a landing, com teste cobrindo esse redirecionamento.

### `:host-context` resolvido

No mobile, o alinhamento central do texto do rodapé passa a viver nos contêineres de contato e de copyright (`Footer/styles.ts`) e é herdado pelos filhos, no lugar do seletor que alcançava o pai.

### Correções que a migração revelou

- **Título grande demais entre 600px e 768px.** O tema usava `breakpoints.down('sm')`, que é 600px no MUI, enquanto o produto vira em 768px — todo `h1` ficava grande na faixa, incluindo o herói da landing. Passa a usar o breakpoint do produto. O teste que existia procurava o tamanho reduzido em qualquer lugar do objeto e passava com qualquer breakpoint; agora afirma a consulta de 768px.
- **Botão de menu invisível no mobile.** `MenuButtonSlot` tinha `display: none` na base e a consulta de mobile ajustava as demais propriedades sem devolver o `display`, então o ícone não aparecia em largura nenhuma. Medido em 655px contra o front de origem: mesmo `flex` e mesma largura de 48px.
- **Lista de caronas com formato inesperado.** `listRides` declarava `Promise<Ride[]>` mas devolvia o que viesse; sem endereço de API configurado a requisição cai no próprio servidor de desenvolvimento, que responde HTML com status 200, e a tela quebrava ao percorrer a lista. Agora falha na borda do serviço, virando a notificação de erro da tela. Coberto por teste de serviço e por teste da tela.

### Error boundary de rota

`components/ErrorBoundary/` como `errorElement` da rota raiz: substitui a página de diagnóstico do roteador por uma tela com recado e caminho de volta ao início.

### Lint

- `no-console` como erro, em qualquer arquivo: depuração não vai para produção.
- `eslint.config.js` formatado — o arquivo já estava fora do padrão do prettier e nunca havia sido lintado, porque o gate só cobria `.ts`/`.tsx`.

## Issue

- #56

Closes #56

## Evidências
