### PR TITLE
feat(78): add the logged area menu screen

### DIFF
--- a/FateConnect/Web/src/pages/Menu/@types/index.ts
+++ b/FateConnect/Web/src/pages/Menu/@types/index.ts
@@ -1,0 +1,4 @@
+import type { RoutePathEnum } from '@app/routes/paths';
+import type { SvgIconComponent } from '@design-system/icons';
+
+export type MenuService = { label: string; path: RoutePathEnum; Icon: SvgIconComponent };

--- a/FateConnect/Web/src/pages/Menu/Menu.test.tsx
+++ b/FateConnect/Web/src/pages/Menu/Menu.test.tsx
@@ -1,0 +1,51 @@
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { RoutePathEnum } from '@app/routes/paths';
+import { render, screen, userEvent } from '@app/test/testing-library';
+import * as C from './constants';
+import { Menu } from '.';
+
+function renderComponent() {
+  const router = createMemoryRouter(
+    [
+      { path: RoutePathEnum.MENU, element: <Menu /> },
+      { path: RoutePathEnum.LOST_AND_FOUND, element: <div>achados</div> },
+      { path: RoutePathEnum.RIDES, element: <div>caronas</div> },
+    ],
+    { initialEntries: [RoutePathEnum.MENU] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+describe('Menu', () => {
+  it('should greet the user and explain what to do next', () => {
+    renderComponent();
+
+    expect(screen.getByRole('heading', { name: C.MENU_TITLE })).toBeInTheDocument();
+    expect(screen.getByText(C.MENU_INTRO)).toBeInTheDocument();
+  });
+
+  it('should offer one link per service, in the order of the product', () => {
+    renderComponent();
+
+    const links = screen.getAllByRole('link');
+
+    expect(links.map((link) => link.textContent)).toEqual(
+      C.MENU_SERVICES.map(({ label }) => label),
+    );
+    expect(links.map((link) => link.getAttribute('href'))).toEqual(
+      C.MENU_SERVICES.map(({ path }) => path),
+    );
+  });
+
+  it('should navigate to the service the user picks', async () => {
+    const router = renderComponent();
+
+    await userEvent.click(screen.getByRole('link', { name: 'Caronas' }));
+
+    expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES);
+  });
+});

--- a/FateConnect/Web/src/pages/Menu/constants/index.ts
+++ b/FateConnect/Web/src/pages/Menu/constants/index.ts
@@ -1,0 +1,13 @@
+import { RoutePathEnum } from '@app/routes/paths';
+import { DirectionsCarIcon, SearchIcon } from '@design-system/icons';
+
+import type { MenuService } from '../@types';
+
+export const MENU_TITLE = 'Bem-vindo ao FateConnect';
+export const MENU_INTRO = 'Escolha um dos serviços abaixo para começar.';
+
+/** Mesma ordem do produto: achados e perdidos antes de caronas. */
+export const MENU_SERVICES: MenuService[] = [
+  { label: 'Achados & Perdidos', path: RoutePathEnum.LOST_AND_FOUND, Icon: SearchIcon },
+  { label: 'Caronas', path: RoutePathEnum.RIDES, Icon: DirectionsCarIcon },
+];

--- a/FateConnect/Web/src/pages/Menu/index.tsx
+++ b/FateConnect/Web/src/pages/Menu/index.tsx
@@ -1,6 +1,33 @@
+import { Link as RouterLink } from 'react-router';
+
 import { Typography } from '@design-system';
 
-/** Placeholder — a tela é migrada na #51. */
+import * as C from './constants';
+import * as S from './styles';
+
+/** Tela inicial da área logada: saudação e os serviços disponíveis. */
 export function Menu() {
-  return <Typography variant="h1">Menu</Typography>;
+  return (
+    <S.MenuRoot>
+      <Typography variant="h1">{C.MENU_TITLE}</Typography>
+
+      <S.MenuIntro>
+        <Typography variant="subtitle" color="inherit">
+          {C.MENU_INTRO}
+        </Typography>
+      </S.MenuIntro>
+
+      <S.CardsContainer>
+        {C.MENU_SERVICES.map(({ label, path, Icon }) => (
+          <S.ServiceCard key={path} component={RouterLink} to={path}>
+            <S.IconDisc aria-hidden="true">
+              <Icon />
+            </S.IconDisc>
+
+            <Typography variant="h2">{label}</Typography>
+          </S.ServiceCard>
+        ))}
+      </S.CardsContainer>
+    </S.MenuRoot>
+  );
 }

--- a/FateConnect/Web/src/pages/Menu/styles.ts
+++ b/FateConnect/Web/src/pages/Menu/styles.ts
@@ -1,0 +1,81 @@
+import {
+  iconSizeTokens,
+  mobileMedia,
+  radius,
+  radiusScale,
+  shadowTokens,
+  spacing,
+  spacingScale,
+  Stack,
+  styled,
+} from '@design-system';
+import type { PolymorphicProps } from '@design-system';
+import type { LinkProps } from 'react-router';
+
+const { md, xl } = spacingScale;
+
+/** Recuo da tela em unidade de viewport, como no produto. */
+const PAGE_PADDING = '7vw';
+const CARD_MIN_WIDTH_PX = 300;
+const ICON_DISC_SIZE_PX = 70;
+/** O cartão cresce um pouco sob o cursor — mesma proporção e curva do produto. */
+const CARD_HOVER_SCALE = 1.05;
+const CARD_TRANSITION = 'transform 0.3s ease';
+
+type CardProps = PolymorphicProps<Pick<LinkProps, 'to'>>;
+
+export const MenuRoot = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  flex: 1,
+  width: '100%',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
+  gap: spacing(md),
+  padding: PAGE_PADDING,
+});
+
+/** O texto de apoio é mais apagado que o título. */
+export const MenuIntro = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.secondary,
+}));
+
+export const CardsContainer = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  gap: spacing(xl),
+
+  [mobileMedia]: { flexDirection: 'column' },
+});
+
+export const ServiceCard = styled(Stack)<CardProps>(({ theme }) => ({
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: spacing(md),
+  padding: spacing(xl),
+  minWidth: `${CARD_MIN_WIDTH_PX}px`,
+  height: 'auto',
+  borderRadius: radius(radiusScale.lg),
+  backgroundColor: theme.palette.background.paper,
+  boxShadow: shadowTokens.component,
+  color: theme.palette.text.primary,
+  textDecoration: 'none',
+  cursor: 'pointer',
+  transition: CARD_TRANSITION,
+
+  '&:hover': { transform: `scale(${CARD_HOVER_SCALE})` },
+}));
+
+export const IconDisc = styled(Stack)<PolymorphicProps>(({ theme }) => ({
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: `${ICON_DISC_SIZE_PX}px`,
+  height: `${ICON_DISC_SIZE_PX}px`,
+  borderRadius: '50%',
+  backgroundColor: theme.palette.secondary.main,
+
+  '& svg': {
+    fontSize: `${iconSizeTokens.lg}px`,
+    color: theme.palette.common.white,
+  },
+}));

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -6,6 +6,7 @@ import { server } from '@app/mocks/server';
 
 import { render, screen, within } from '@app/test/testing-library';
 import { LOST_AND_FOUND_TITLE } from '@app/pages/LostAndFound/constants';
+import { MENU_TITLE } from '@app/pages/Menu/constants';
 import { RIDES_TITLE } from '@app/pages/Rides/constants';
 import { SIGNUP_TITLE } from '@app/pages/Signup/constants';
 import { RoutePathEnum } from './paths';
@@ -27,7 +28,7 @@ describe('routeConfig', () => {
   it.each([
     [RoutePathEnum.LANDING, 'Conectando a Comunidade Acadêmica'],
     [RoutePathEnum.SIGNUP, SIGNUP_TITLE],
-    [RoutePathEnum.MENU, 'Menu'],
+    [RoutePathEnum.MENU, MENU_TITLE],
     [RoutePathEnum.LOST_AND_FOUND, LOST_AND_FOUND_TITLE],
     [RoutePathEnum.RIDES_SEARCH, RIDES_TITLE],
     [RoutePathEnum.RIDES_OFFER, RIDES_TITLE],


### PR DESCRIPTION
## Objetivo

Portar a tela inicial da área logada, que em `Web` ainda era placeholder. Ela é o destino do logo do topo e do "Voltar ao menu" das outras telas, e nenhuma sub-issue da migração cobria — a milestone ia da #56 direto para automação e remoção do Angular, então a #58 removeria o front levando uma tela nunca migrada.

## Alterações

`src/pages/Menu/` passa a renderizar a tela: saudação, texto de apoio em tom apagado e os dois cartões de serviço, cada um com o disco de ícone e o efeito de escala sob o cursor.

- `constants/` guarda os textos e a lista de serviços, na mesma ordem do produto; o tipo da lista fica em `@types/`.
- `styles.ts` traduz o SCSS de origem valor a valor: recuo em `7vw`, `gap` de 1rem na coluna e 2rem entre cartões, cartão com `min-width` 300px, `padding` 2rem, raio 1rem, fundo branco e a sombra de componente; disco de 70px em círculo com a cor de destaque; empilhamento abaixo de 768px.
- O teste de rotas passa a afirmar o título real da tela, no lugar do texto do placeholder.

### Navegação como link

O produto usa `<button routerLink>`; aqui o cartão é um link (`component={RouterLink}`), como o resto do app React navega. Muda o elemento no DOM e melhora a acessibilidade — navegação pertence a um link, não a um botão. As medições abaixo comparam o link migrado com o botão de origem.

## Paridade

Medido com `getComputedStyle` nos dois apps, elemento a elemento.

### 1440px

| Elemento | Angular | React |
| -------- | ------- | ----- |
| Raiz | col, `flex:1`, gap 16px, padding 100.8px, 1440×611.63 | idem, 1440×610.41 |
| Título | 32px/700, lh 38.4, `#43545C`, 417.80×38.40 | idêntico |
| Texto de apoio | 16px/500, lh 24, `rgb(108,117,125)` | idêntico |
| Fila de cartões | row, gap 32px, 632×181.20 | idêntico |
| Cartão | raio 16px, `#FFF`, sombra `0 2px 5px rgba(0,0,0,.08)`, min-width 300px, `transform .3s`, 300×181.20 | idêntico |
| Disco do ícone | 70×70, raio 50%, `rgb(207,46,46)` | idêntico |
| Título do cartão | 24px/600, lh 31.2, 231.98×31.20 | idêntico |

### 700px

Idêntico em todas as propriedades medidas: raiz 700×577.19 com padding 49px, fila empilhada em coluna 300×394.39, cartão 300×181.20 e título reduzido a 24px/lh 28.8.

### Estado interativo

`transform` sob o cursor: `matrix(1.05, 0, 0, 1.05, 0, 0)` apenas no cartão apontado, com `transition: transform 0.3s` igual à origem.

### Divergências

- **Altura da raiz em 1440px, 1.22px.** Vem do rodapé, não desta tela: o ícone de contato mede 20px contra a linha de texto de 19.59px, em três linhas. Herdado da #51.
- **Glifo do ícone.** Busca desenha 32×32 no produto contra 29.15×29.15 aqui; carro, 32×28 contra 30×26.67. A **caixa do svg tem 40px de largura nos dois** — o critério que o token `iconSizeTokens.lg` documenta. É diferença de métrica entre bibliotecas de ícone: com o mesmo `font-size`, os ícones do Material desenham glifos de tamanhos diferentes entre si (30×26.67, 29.15×29.15, 40×20, 30×36.67 na landing), então nenhum valor único alinha todos, e mexer no token desalinharia a landing.

## Issue

- #78

Closes #78

## Evidências
