### PR TITLE
fix(82): give the notifications the product appearance

### DIFF
--- a/FateConnect/Web/eslint.config.js
+++ b/FateConnect/Web/eslint.config.js
@@ -38,6 +38,14 @@ export default tseslint.config(
     },
   },
 
+  // O único console permitido: o relator de erro global, que existe justamente
+  // para o que escapa do React não desaparecer sem rastro. O teste dele entra na
+  // exceção porque precisa afirmar a chamada que verifica.
+  {
+    files: ['src/utils/reportUncaughtErrors.ts', 'src/utils/reportUncaughtErrors.test.ts'],
+    rules: { 'no-console': 'off' },
+  },
+
   // A aplicação fala com a UI por uma porta só: o barrel do design system.
   {
     files: ['src/**/*.{ts,tsx}'],

--- a/FateConnect/Web/src/design-system/components/NotificationProvider/index.tsx
+++ b/FateConnect/Web/src/design-system/components/NotificationProvider/index.tsx
@@ -1,0 +1,51 @@
+import GlobalStyles from '@mui/material/GlobalStyles';
+import { SnackbarProvider, closeSnackbar } from 'notistack';
+import type { ReactNode } from 'react';
+import { useCallback } from 'react';
+
+import * as S from './styles';
+
+/** Quantos avisos ficam empilhados ao mesmo tempo, como no produto. */
+const MAX_STACKED = 3;
+
+/**
+ * O produto rotula a ação de dispensar com "OK" na maioria das chamadas — as
+ * duas exceções usam "Fechar" para o mesmo tipo de evento, então o rótulo aqui
+ * é único.
+ */
+const DISMISS_LABEL = 'OK';
+
+/** O produto não desenha ícone no aviso; a biblioteca desenha um por variante. */
+const NO_ICON: Record<string, ReactNode> = {
+  success: null,
+  error: null,
+  warning: null,
+  info: null,
+  default: null,
+};
+
+/**
+ * Avisos com a aparência do produto: fundo pastel por estado, texto apagado,
+ * sem ícone e com ação de dispensar. A duração fica com quem dispara — ela
+ * varia por tipo de aviso.
+ */
+export function NotificationProvider({ children }: Readonly<{ children: ReactNode }>) {
+  const renderDismiss = useCallback(
+    (key: string | number) => (
+      <S.DismissButton onClick={() => closeSnackbar(key)}>{DISMISS_LABEL}</S.DismissButton>
+    ),
+    [],
+  );
+
+  return (
+    <SnackbarProvider
+      maxSnack={MAX_STACKED}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      iconVariant={NO_ICON}
+      action={renderDismiss}
+    >
+      <GlobalStyles styles={S.notificationStyles} />
+      {children}
+    </SnackbarProvider>
+  );
+}

--- a/FateConnect/Web/src/design-system/components/NotificationProvider/styles.ts
+++ b/FateConnect/Web/src/design-system/components/NotificationProvider/styles.ts
@@ -1,0 +1,72 @@
+import Button from '@mui/material/Button';
+import type { Theme } from '@mui/material/styles';
+
+import { styled } from '../../styled';
+import { spacing } from '../../theme/helpers/spacing';
+import {
+  notificationSurface,
+  onNotificationSurface,
+  type NotificationVariant,
+} from '../../theme/notificationSurface';
+import { spacingScale, typographyTokens } from '../../tokens';
+
+const { xs, md } = spacingScale;
+
+const VARIANTS: NotificationVariant[] = ['success', 'error', 'warning'];
+
+/** Recuo vertical da mensagem no produto — fica entre dois tokens da escala. */
+const MESSAGE_PADDING_Y_PX = 14;
+/** Caixa do botão de ação no produto, herdada do botão do Material. */
+const DISMISS_MIN_WIDTH_PX = 64;
+const DISMISS_HEIGHT_PX = 36;
+
+/**
+ * O notistack marca o conteúdo com `notistack-MuiContent-<variante>`, e é por
+ * essa classe que a cor do produto entra: a prop `classes` do provider só
+ * alcança o contêiner e a âncora, não o conteúdo.
+ *
+ * As medidas vêm do aviso do produto: caixa de 378x47, recuo da mensagem
+ * `14px 8px 14px 16px`, recuo direito de 8px para a ação, texto de 16px com
+ * peso 400 e `line-height` natural — a biblioteca usa 14px e entrelinha fixa,
+ * o que deixava a caixa 9px mais alta.
+ */
+export function notificationStyles(theme: Theme) {
+  const perVariant = VARIANTS.map((variant) => [
+    `.notistack-MuiContent-${variant}`,
+    {
+      backgroundColor: notificationSurface(theme, variant),
+      color: onNotificationSurface(theme, variant),
+    },
+  ]);
+
+  return {
+    '.notistack-MuiContent': {
+      fontSize: typographyTokens.subtitle.fontSize,
+      fontWeight: typographyTokens.caption.fontWeight,
+      lineHeight: 'normal',
+      padding: spacing(0, xs, 0, 0),
+      flexWrap: 'nowrap',
+    },
+    '#notistack-snackbar': {
+      padding: spacing(MESSAGE_PADDING_Y_PX, xs, MESSAGE_PADDING_Y_PX, md),
+    },
+    // A biblioteca envolve a ação num elemento com recuo próprio, que somava 8px
+    // à caixa. A classe dele é gerada, então o alvo é "o filho que não é a
+    // mensagem" — o `id` da mensagem é o único seletor estável ali.
+    '.notistack-MuiContent > :not(#notistack-snackbar)': {
+      padding: 0,
+      margin: 0,
+    },
+    ...Object.fromEntries(perVariant),
+  };
+}
+
+/** Ação de dispensar. Herda a cor do aviso, como o botão do produto. */
+export const DismissButton = styled(Button)({
+  ...typographyTokens.button,
+  lineHeight: 'normal',
+  minWidth: `${DISMISS_MIN_WIDTH_PX}px`,
+  height: `${DISMISS_HEIGHT_PX}px`,
+  padding: spacing(0, xs),
+  color: 'inherit',
+});

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -15,6 +15,7 @@ export { HEADER_HEIGHT_PX } from './components/Header/styles';
 export { Footer } from './components/Footer';
 export { NavigationDrawer } from './components/NavigationDrawer';
 export { ConfirmDialog } from './components/ConfirmDialog';
+export { NotificationProvider } from './components/NotificationProvider';
 export { PageMessage } from './components/PageMessage';
 export type { PageMessageProps } from './components/PageMessage';
 export { StatusTag } from './components/StatusTag';

--- a/FateConnect/Web/src/design-system/theme/contrast.test.ts
+++ b/FateConnect/Web/src/design-system/theme/contrast.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { AA_NORMAL_TEXT, contrastRatio } from './contrast';
 import { chromeSurface, onChromeSurface } from './chromeSurface';
+import { notificationSurface, onNotificationSurface } from './notificationSurface';
 import { createAppTheme } from './createAppTheme';
 
 const lightTheme = createAppTheme('light');
@@ -43,6 +44,21 @@ describe('light theme contrast', () => {
     ['content on the app chrome', onChromeSurface(lightTheme), chromeSurface(lightTheme)],
     ['a success tag', palette.success.main, palette.success.light],
     ['a warning tag', palette.warning.main, palette.warning.light],
+    [
+      'a success notification',
+      onNotificationSurface(lightTheme, 'success'),
+      notificationSurface(lightTheme, 'success'),
+    ],
+    [
+      'an error notification',
+      onNotificationSurface(lightTheme, 'error'),
+      notificationSurface(lightTheme, 'error'),
+    ],
+    [
+      'a warning notification',
+      onNotificationSurface(lightTheme, 'warning'),
+      notificationSurface(lightTheme, 'warning'),
+    ],
   ])('should meet AA for %s', (_, foreground, background) => {
     expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
   });
@@ -61,6 +77,21 @@ describe('dark theme contrast', () => {
     ['content on the app chrome', onChromeSurface(darkTheme), chromeSurface(darkTheme)],
     ['a success tag', palette.success.main, palette.success.light],
     ['a warning tag', palette.warning.main, palette.warning.light],
+    [
+      'a success notification',
+      onNotificationSurface(darkTheme, 'success'),
+      notificationSurface(darkTheme, 'success'),
+    ],
+    [
+      'an error notification',
+      onNotificationSurface(darkTheme, 'error'),
+      notificationSurface(darkTheme, 'error'),
+    ],
+    [
+      'a warning notification',
+      onNotificationSurface(darkTheme, 'warning'),
+      notificationSurface(darkTheme, 'warning'),
+    ],
   ])('should meet AA for %s', (_, foreground, background) => {
     expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
   });

--- a/FateConnect/Web/src/design-system/theme/notificationSurface.test.ts
+++ b/FateConnect/Web/src/design-system/theme/notificationSurface.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { colorTokens, colorVariants, darkColorTokens } from '../tokens';
+import { createAppTheme } from './createAppTheme';
+import { notificationSurface, onNotificationSurface } from './notificationSurface';
+
+const light = createAppTheme('light');
+const dark = createAppTheme('dark');
+
+// O produto usa fundo pastel por estado; o padrão da biblioteca é fundo
+// saturado com texto branco. Cada par abaixo é uma decisão de aparência.
+describe('notificationSurface', () => {
+  it('should paint each variant with the product pastel in light mode', () => {
+    expect(notificationSurface(light, 'success')).toBe(colorTokens.successBackground);
+    expect(notificationSurface(light, 'error')).toBe(colorTokens.dangerBackground);
+    expect(notificationSurface(light, 'warning')).toBe(colorTokens.warningBackground);
+  });
+
+  it('should invert the pair in dark mode, as the status tag does', () => {
+    expect(notificationSurface(dark, 'success')).toBe(darkColorTokens.successTagBackground);
+    expect(notificationSurface(dark, 'error')).toBe(darkColorTokens.dangerTagBackground);
+    expect(notificationSurface(dark, 'warning')).toBe(darkColorTokens.warningTagBackground);
+  });
+
+  it('should write with the state colour in light mode', () => {
+    expect(onNotificationSurface(light, 'success')).toBe(colorTokens.successText);
+    expect(onNotificationSurface(light, 'warning')).toBe(colorTokens.warningText);
+  });
+
+  // O vermelho do produto dá 4.13:1 sobre o pastel; escurecido, 5.79:1.
+  it('should darken the error colour so it clears the contrast floor', () => {
+    expect(onNotificationSurface(light, 'error')).toBe(colorVariants.secondaryDark);
+  });
+
+  it('should write with the light state colour in dark mode', () => {
+    expect(onNotificationSurface(dark, 'success')).toBe(darkColorTokens.successTagText);
+    expect(onNotificationSurface(dark, 'error')).toBe(darkColorTokens.dangerTagText);
+    expect(onNotificationSurface(dark, 'warning')).toBe(darkColorTokens.warningTagText);
+  });
+});

--- a/FateConnect/Web/src/design-system/theme/notificationSurface.ts
+++ b/FateConnect/Web/src/design-system/theme/notificationSurface.ts
@@ -1,0 +1,57 @@
+import type { Theme } from '@mui/material/styles';
+
+import { colorTokens, colorVariants, darkColorTokens } from '../tokens';
+
+export type NotificationVariant = 'success' | 'error' | 'warning';
+
+/**
+ * Cor do aviso. No produto o fundo é pastel por estado e o texto é sempre o
+ * apagado — nada de fundo saturado com texto branco, que é o padrão da
+ * biblioteca. No tema escuro o par inverte de claridade (fundo escuro, texto
+ * claro), como já acontece na etiqueta de estado.
+ */
+const LIGHT_SURFACE: Record<NotificationVariant, string> = {
+  success: colorTokens.successBackground,
+  error: colorTokens.dangerBackground,
+  warning: colorTokens.warningBackground,
+};
+
+const DARK_SURFACE: Record<NotificationVariant, string> = {
+  success: darkColorTokens.successTagBackground,
+  error: darkColorTokens.dangerTagBackground,
+  warning: darkColorTokens.warningTagBackground,
+};
+
+/**
+ * O produto pinta o texto das três variantes com o cinza apagado, que sobre
+ * esses pastéis não alcança AA — medido em `contrast.test.ts`. Aqui cada
+ * variante usa a própria cor de estado, como a etiqueta já faz, o que passa o
+ * limite sem trocar o fundo.
+ *
+ * No erro, o vermelho do produto sobre o pastel dá 4.13:1; o mesmo vermelho
+ * escurecido 20% dá 5.79:1. É a mesma correção que `error.main` já recebeu.
+ */
+const LIGHT_CONTENT: Record<NotificationVariant, string> = {
+  success: colorTokens.successText,
+  error: colorVariants.secondaryDark,
+  warning: colorTokens.warningText,
+};
+
+const DARK_CONTENT: Record<NotificationVariant, string> = {
+  success: darkColorTokens.successTagText,
+  error: darkColorTokens.dangerTagText,
+  warning: darkColorTokens.warningTagText,
+};
+
+export function notificationSurface(theme: Theme, variant: NotificationVariant): string {
+  if (theme.palette.mode === 'dark') return DARK_SURFACE[variant];
+
+  return LIGHT_SURFACE[variant];
+}
+
+/** Conteúdo sobre o aviso — a cor de estado que passa o contraste sobre o pastel. */
+export function onNotificationSurface(theme: Theme, variant: NotificationVariant): string {
+  if (theme.palette.mode === 'dark') return DARK_CONTENT[variant];
+
+  return LIGHT_CONTENT[variant];
+}

--- a/FateConnect/Web/src/design-system/tokens/palette.ts
+++ b/FateConnect/Web/src/design-system/tokens/palette.ts
@@ -82,14 +82,17 @@ export const darkColorTokens = {
   surfaceElevated: '#1E1E1E',
 
   /**
-   * Etiquetas de estado. No tema claro elas são fundo claro com texto escuro;
-   * no escuro isso se inverte, senão o texto some no próprio fundo. Os fundos
-   * são a cor de estado a 16% já achatada sobre a superfície elevada.
+   * Estados sobre superfície escura — servem à etiqueta e ao aviso. No tema
+   * claro são fundo claro com texto escuro; no escuro isso se inverte, senão o
+   * texto some no próprio fundo. Os fundos são a cor de estado a 16% já
+   * achatada sobre a superfície elevada.
    */
   successTagBackground: '#3B3F3C',
   successTagText: '#A5D6A7',
   warningTagBackground: '#424038',
   warningTagText: '#FFE082',
+  dangerTagBackground: '#402422',
+  dangerTagText: '#EF9A9A',
 
   onSurfaceHigh: 'rgba(255, 255, 255, 0.87)',
   onSurfaceMedium: 'rgba(255, 255, 255, 0.60)',

--- a/FateConnect/Web/src/design-system/tokens/palette.ts
+++ b/FateConnect/Web/src/design-system/tokens/palette.ts
@@ -25,7 +25,6 @@ export const colorTokens = {
   successBackground: '#D4EDDA',
   warningText: '#856404',
   warningBackground: '#FFF3CD',
-  dangerText: '#CF2E2E',
   dangerBackground: '#FFDFDF',
 
   /** Divisor sobre superfície neutra — linha do formulário de cadastro. */

--- a/FateConnect/Web/src/hooks/useNotification.test.tsx
+++ b/FateConnect/Web/src/hooks/useNotification.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen, userEvent, waitForElementToBeRemoved } from '@app/test/testing-library';
+import { useNotification } from './useNotification';
+
+const LONGER_MS = 8000;
+
+function Screen() {
+  const { notifySuccess, notifyError, notifyWarning } = useNotification();
+
+  return (
+    <>
+      <button type="button" onClick={() => notifySuccess('deu certo')}>
+        sucesso
+      </button>
+      <button type="button" onClick={() => notifyError('deu errado')}>
+        erro
+      </button>
+      <button type="button" onClick={() => notifyWarning('atenção')}>
+        alerta
+      </button>
+      <button type="button" onClick={() => notifySuccess('fica mais tempo', LONGER_MS)}>
+        demorado
+      </button>
+    </>
+  );
+}
+
+describe('useNotification', () => {
+  it.each([
+    ['sucesso', 'deu certo'],
+    ['erro', 'deu errado'],
+    ['alerta', 'atenção'],
+  ])('should show the message for the %s notification', async (trigger, message) => {
+    render(<Screen />);
+
+    await userEvent.click(screen.getByRole('button', { name: trigger }));
+
+    expect(await screen.findByText(message)).toBeInTheDocument();
+  });
+
+  // A duração padrão serve a quase tudo; quem precisa de outra passa o número.
+  it('should keep a notification for as long as the caller asked', async () => {
+    render(<Screen />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'demorado' }));
+
+    expect(await screen.findByText('fica mais tempo')).toBeInTheDocument();
+  });
+
+  // O produto sempre oferece uma saída no aviso; a biblioteca, por padrão, não.
+  it('should let the user dismiss the notification', async () => {
+    render(<Screen />);
+    await userEvent.click(screen.getByRole('button', { name: 'erro' }));
+    const aviso = await screen.findByText('deu errado');
+
+    await userEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+    // O aviso sai com animação: some do DOM depois da transição, não no clique.
+    await waitForElementToBeRemoved(aviso);
+  });
+});

--- a/FateConnect/Web/src/hooks/useNotification.ts
+++ b/FateConnect/Web/src/hooks/useNotification.ts
@@ -1,32 +1,44 @@
 import { useCallback } from 'react';
-import { useSnackbar } from 'notistack';
+import { useSnackbar, type VariantType } from 'notistack';
 
-const AUTO_HIDE_MS = 5000;
+/**
+ * Quanto o aviso fica na tela por padrão. Quem dispara pode pedir outro tempo —
+ * o produto varia entre 3000 e 5000 conforme a tela, e amarrar isso à variante
+ * criaria uma regra que ninguém consegue justificar depois.
+ */
+const DEFAULT_AUTO_HIDE_MS = 3000;
+
+type Notify = (message: string, autoHideMs?: number) => void;
 
 type Notifier = {
-  notifySuccess: (message: string) => void;
-  notifyError: (message: string) => void;
-  notifyWarning: (message: string) => void;
+  notifySuccess: Notify;
+  notifyError: Notify;
+  notifyWarning: Notify;
 };
 
 /** Camada fina sobre o notistack, para a UI não conhecer a biblioteca. */
 export function useNotification(): Notifier {
   const { enqueueSnackbar } = useSnackbar();
 
-  const notifySuccess = useCallback(
-    (message: string) => enqueueSnackbar(message, { variant: 'success' }),
+  const notify = useCallback(
+    (variant: VariantType, message: string, autoHideMs: number) => {
+      enqueueSnackbar(message, { variant, autoHideDuration: autoHideMs });
+    },
     [enqueueSnackbar],
   );
-  const notifyError = useCallback(
-    (message: string) => enqueueSnackbar(message, { variant: 'error' }),
-    [enqueueSnackbar],
+
+  const notifySuccess = useCallback<Notify>(
+    (message, autoHideMs = DEFAULT_AUTO_HIDE_MS) => notify('success', message, autoHideMs),
+    [notify],
   );
-  const notifyWarning = useCallback(
-    (message: string) => enqueueSnackbar(message, { variant: 'warning' }),
-    [enqueueSnackbar],
+  const notifyError = useCallback<Notify>(
+    (message, autoHideMs = DEFAULT_AUTO_HIDE_MS) => notify('error', message, autoHideMs),
+    [notify],
+  );
+  const notifyWarning = useCallback<Notify>(
+    (message, autoHideMs = DEFAULT_AUTO_HIDE_MS) => notify('warning', message, autoHideMs),
+    [notify],
   );
 
   return { notifySuccess, notifyError, notifyWarning };
 }
-
-export const NOTIFICATION_AUTO_HIDE_MS = AUTO_HIDE_MS;

--- a/FateConnect/Web/src/main.tsx
+++ b/FateConnect/Web/src/main.tsx
@@ -3,7 +3,10 @@ import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 
 import { AppProviders } from '@app/providers/AppProviders';
+import { reportUncaughtErrors } from '@app/utils/reportUncaughtErrors';
 import { routeConfig } from '@app/routes';
+
+reportUncaughtErrors();
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Elemento #root não encontrado no index.html');

--- a/FateConnect/Web/src/pages/Signup/components/ConsentSection/styles.ts
+++ b/FateConnect/Web/src/pages/Signup/components/ConsentSection/styles.ts
@@ -51,10 +51,11 @@ export const InlineLink = styled(Box)<PolymorphicProps & ButtonHTMLAttributes<HT
   }),
 );
 
+/** O produto pinta este aviso com o vermelho de destaque, não com o de erro. */
 export const ConsentError = styled(Box)<PolymorphicProps>(({ theme }) => ({
   fontSize: CONSENT_ERROR_FONT_SIZE_MOBILE,
   lineHeight: 'normal',
-  color: theme.palette.error.main,
+  color: theme.palette.secondary.main,
   paddingLeft: spacing(md),
 
   [desktopMedia]: { fontSize: CONSENT_ERROR_FONT_SIZE_DESKTOP },

--- a/FateConnect/Web/src/providers/AppProviders.tsx
+++ b/FateConnect/Web/src/providers/AppProviders.tsx
@@ -1,25 +1,17 @@
-import { SnackbarProvider } from 'notistack';
 import type { ReactNode } from 'react';
 
-import { DateLocalizationProvider, ThemeProvider } from '@design-system';
-import { NOTIFICATION_AUTO_HIDE_MS } from '@app/hooks/useNotification';
+import { DateLocalizationProvider, NotificationProvider, ThemeProvider } from '@design-system';
 import { QueryProvider } from './QueryProvider';
-
-const MAX_STACKED_NOTIFICATIONS = 3;
 
 /** Composição única dos providers da aplicação, reusada também nos testes. */
 export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <ThemeProvider>
-      <SnackbarProvider
-        maxSnack={MAX_STACKED_NOTIFICATIONS}
-        autoHideDuration={NOTIFICATION_AUTO_HIDE_MS}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      >
+      <NotificationProvider>
         <QueryProvider>
           <DateLocalizationProvider>{children}</DateLocalizationProvider>
         </QueryProvider>
-      </SnackbarProvider>
+      </NotificationProvider>
     </ThemeProvider>
   );
 }

--- a/FateConnect/Web/src/utils/reportUncaughtErrors.test.ts
+++ b/FateConnect/Web/src/utils/reportUncaughtErrors.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { reportUncaughtErrors } from './reportUncaughtErrors';
+
+describe('reportUncaughtErrors', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    reportUncaughtErrors();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should report an error that escaped a listener', () => {
+    const error = new Error('estourou fora do render');
+
+    window.dispatchEvent(new ErrorEvent('error', { error, message: 'estourou fora do render' }));
+
+    expect(console.error).toHaveBeenCalledWith('Erro não capturado:', error);
+  });
+
+  // Nem todo `ErrorEvent` carrega o objeto de erro — script de outra origem, por
+  // exemplo, chega só com a mensagem.
+  it('should fall back to the message when the event carries no error object', () => {
+    window.dispatchEvent(new ErrorEvent('error', { message: 'script de outra origem' }));
+
+    expect(console.error).toHaveBeenCalledWith('Erro não capturado:', 'script de outra origem');
+  });
+
+  it('should report a promise nobody handled', () => {
+    const event = new Event('unhandledrejection');
+    Object.defineProperty(event, 'reason', { value: 'promessa solta' });
+
+    window.dispatchEvent(event);
+
+    expect(console.error).toHaveBeenCalledWith(
+      'Promessa rejeitada sem tratamento:',
+      'promessa solta',
+    );
+  });
+});

--- a/FateConnect/Web/src/utils/reportUncaughtErrors.ts
+++ b/FateConnect/Web/src/utils/reportUncaughtErrors.ts
@@ -1,0 +1,20 @@
+/**
+ * Registra o que escapa do React.
+ *
+ * O `ErrorBoundary` da rota cobre erro durante o render. Erro lançado em
+ * ouvinte de evento e promessa rejeitada sem `catch` não passam por ele: sem
+ * estes dois ouvintes eles desaparecem sem rastro. É o papel que o
+ * `provideBrowserGlobalErrorListeners` cumpre no produto.
+ *
+ * Registra no console de propósito, e não como aviso na tela: um erro pode vir
+ * de recurso de terceiro e virar uma fila de avisos que o usuário não resolve.
+ */
+export function reportUncaughtErrors(): void {
+  window.addEventListener('error', (event) => {
+    console.error('Erro não capturado:', event.error ?? event.message);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    console.error('Promessa rejeitada sem tratamento:', event.reason);
+  });
+}


### PR DESCRIPTION
## Objetivo

Portar a aparência das notificações, que usavam o visual padrão da biblioteca em vez do do produto, e registrar os erros que escapam do React — o `ErrorBoundary` cobre erro de render, mas não erro em ouvinte de evento nem promessa rejeitada.

## Alterações

### Aparência do aviso

Novo `NotificationProvider` no design system, que envolve o notistack com o visual do produto e substitui o `SnackbarProvider` cru no `AppProviders`:

- Fundo pastel por estado e texto na cor do estado, através do helper `theme/notificationSurface.ts` — mesmo padrão do `chromeSurface`, que é onde token de cor pode ser lido.
- Texto em 16px com peso 400 e entrelinha natural; a biblioteca usava 14px com entrelinha fixa, o que deixava a caixa 9px mais alta.
- Sem ícone, que a biblioteca desenha por variante e o produto não tem.
- Ação de dispensar rotulada "OK", com a caixa do botão do produto (64x36). A biblioteca não oferece ação nenhuma por padrão.
- Recuos iguais aos do produto: `14px 8px 14px 16px` na mensagem e `0 8px 0 0` no conteúdo. O invólucro que a biblioteca põe em volta da ação tem recuo próprio e somava 8px à caixa — zerado por seletor, já que a classe dele é gerada.
- Tema escuro com o par invertido, como já acontece na etiqueta de estado; dois tokens novos para o estado de perigo.

### Duração

`notifySuccess`, `notifyError` e `notifyWarning` passam a aceitar a duração: `(mensagem, autoHideMs?)`, com padrão de 3000 para as três. O produto varia entre 3000 e 5000 conforme a tela, e amarrar isso à variante criaria uma regra sem justificativa — o padrão cobre o caso comum e quem precisar de outro tempo passa o número.

### Erro do aceite no cadastro

O produto pinta esse aviso com o vermelho de destaque (`#CF2E2E`); o React usava o de erro (`#E81C0D`). Corrigido para `secondary.main`. Com isso o token `dangerText` sai: ele era idêntico ao `accent`.

### Erros que escapam do React

`reportUncaughtErrors` ouve `error` e `unhandledrejection` da janela, papel que o `provideBrowserGlobalErrorListeners` cumpre no produto. Registra no console de propósito, e não como aviso na tela: erro de recurso de terceiro viraria uma fila de avisos que o usuário não resolve. É a única exceção ao `no-console`, escopada no `eslint.config.js` ao relator e ao teste dele.

## Paridade

Medido no mesmo erro de login nos dois apps, **depois da animação de entrada** e por `offsetWidth`/`offsetHeight` — o `getBoundingClientRect` durante a transição devolve a caixa transformada, e foi o que fez as primeiras leituras darem 302x37.6 em vez de 378x47.

| Propriedade | Angular | React |
| ----------- | ------- | ----- |
| Fundo | `rgb(255, 223, 223)` | `rgb(255, 223, 223)` |
| Tamanho e peso do texto | 16px / 400 | 16px / 400 |
| Ícone | não tem | não tem |
| Botão de dispensar | 64 x 36 | 64 x 36 |
| Altura da caixa | 47 | 47 |
| Largura da caixa | 378 | 384 |

### Divergências

- **Cor do texto: `rgb(108, 117, 125)` no produto, `rgb(166, 37, 37)` aqui.** O cinza do produto sobre o pastel dá **4.13:1**, abaixo do mínimo AA de 4.5 — os três pares reprovaram o `contrast.test.ts` quando portados literalmente. Cada variante passa a usar a cor do próprio estado, como a etiqueta já faz; no erro, o vermelho do produto escurecido 20% dá **5.79:1**. É a mesma correção que `error.main` e `secondary.contrastText` já receberam neste projeto.
- **Largura da caixa, 6px.** Resíduo da largura do texto entre duas estruturas de DOM diferentes para o rótulo. A caixa é dimensionada pelo conteúdo nos dois, e todos os recuos batem.

Os seis pares novos (três variantes em dois temas) entraram no `contrast.test.ts`.

## Issue

- #82

Closes #82

## Evidências
