### PR TITLE
chore(85): adopt a changelog following keep a changelog

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,7 @@ Planejamento e rastreio ficam no **GitHub** (issues + Project board do repositó
 ## Organização desta configuração
 
 - `.claude/rules/` — regras do projeto. Sem `paths:` carregam sempre; com `paths:` carregam quando um arquivo que casa é lido.
-- `.claude/skills/` — fluxos sob demanda: `pr-creator` (abrir/atualizar PR), `write-commit` (mensagem de commit e agrupamento em commits) e `fateconnect-create-component` (criar componente no front).
+- `.claude/skills/` — fluxos sob demanda: `pr-creator` (abrir/atualizar PR), `write-commit` (mensagem de commit e agrupamento em commits), `changelog-writer` (entrada do CHANGELOG) e `fateconnect-create-component` (criar componente no front).
 - `.claude/` é **versionada**: rule e skill passam por review no PR como qualquer código, e valem igual para quem clonar o repo. Por isso a restrição do repositório acima se aplica a elas também.
 
 ## Fluxo de trabalho
@@ -25,6 +25,7 @@ Planejamento e rastreio ficam no **GitHub** (issues + Project board do repositó
 - Branch base: **`develop`**. Nomear branch como `<tipo>/<número-da-issue>` (ex.: `chore/48`).
 - Toda correção ou alteração começa por uma **issue no GitHub** — o número dela alimenta a branch, o título do PR e o corpo do PR.
 - Abrir PR: usar a skill `pr-creator`. Commitar: usar a skill `write-commit` — e **pedir confirmação antes de qualquer comando git**.
+- ⛔ **Nunca escrever changelog à mão** — usar a skill `changelog-writer`. À mão sai um bullet por commit, que é o oposto do formato: uma entrada principal descrevendo o efeito para quem usa. O formato está em `.claude/rules/changelog-format.md`.
 - ⛔ **Não criar artefato de processo por conta própria** — issue, branch, PR, label, milestone. A regra "toda alteração começa por uma issue" vale para o que o usuário tratou como **tarefa**, não para todo ajuste solto. Pedido pequeno e avulso ("adiciona o codeowner pra mim") entra na tarefa em andamento ou na próxima, em **commit separado**. Na dúvida, perguntar: uma pergunta custa menos que fechar issue, branch e PR depois.
 
 ## Comandos

--- a/.claude/rules/changelog-format.md
+++ b/.claude/rules/changelog-format.md
@@ -1,0 +1,50 @@
+---
+description: Formato das entradas do CHANGELOG — Keep a Changelog, cabeçalho em inglês, conteúdo em pt-BR no imperativo, uma entrada principal por tarefa, terminando no número do PR
+paths:
+  - "CHANGELOG.md"
+---
+
+# Formato do changelog
+
+O `CHANGELOG.md` da raiz segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) e cobre o repositório inteiro.
+
+**Entradas entram direto em `## [Unreleased]`.** Não há diretório de fragmentos: aquilo existe para evitar conflito quando várias frentes mergeiam em paralelo, e depende de automação de release para consolidar — nada disso existe aqui.
+
+## Estrutura
+
+Cabeçalhos **em inglês**, conteúdo **em pt-BR** — é o idioma do produto:
+
+`### Added` · `### Changed` · `### Deprecated` · `### Removed` · `### Fixed` · `### Security`
+
+Só as seções com mudança de verdade aparecem. Seção vazia não fica no arquivo.
+
+## Como escrever a entrada
+
+- **Imperativo.** "Adiciona", "Corrige", "Remove", "Reescreve" — nunca "Adicionado", "Foi adicionado", "Adicionando".
+- **Uma entrada principal por tarefa.** A entrada descreve o **efeito para quem consome**, não a implementação. Agrupe as mudanças relacionadas numa linha concisa.
+- **Uma linha curta por mudança.** Sem lista de arquivo, camada ou nome interno.
+- **Termina no número do PR**, entre parênteses: `(#84)`. **Sempre o PR, nunca a issue** — o link precisa cair no diff e no review, não no planejamento. Se o PR ainda não existe, use `(#?)` e troque antes do merge.
+- **Item puramente interno não entra.** Remoção de helper morto, refactor sem efeito externo, ajuste de teste: isso vive no histórico de commit, não no changelog.
+
+### Faça
+
+```markdown
+- Adiciona a tela de menu da área logada (#81)
+- Corrige o aviso que não aparecia sobre superfície clara (#84)
+- Remove a tela de contato; o contato passa a ser seção da landing (#79)
+```
+
+### Não faça
+
+```markdown
+- Adiciona o componente `PageMessage` no design system (#79)     <- implementação, não efeito
+- Adiciona `constants/index.ts` em `pages/Menu` (#81)            <- detalhe de arquivo
+- Corrigido bug no hover                                          <- não é imperativo
+- Foi adicionada a tela de menu                                   <- não é imperativo
+- Adiciona a tela de menu                                         <- falta o PR
+- Adiciona a tela de menu (#78)                                   <- é a issue, não o PR
+```
+
+## Um bullet por commit é o sintoma
+
+Changelog com uma linha por commit é changelog escrito no automático: ele repete o `git log` e não responde o que mudou para quem usa. Se a tarefa rendeu seis commits e uma frase, é uma entrada.

--- a/.claude/skills/changelog-writer/SKILL.md
+++ b/.claude/skills/changelog-writer/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: changelog-writer
+description: >-
+  Escreve a entrada do CHANGELOG para a mudança da branch atual, no formato do Keep a Changelog.
+  Use quando o usuário pedir para escrever, preencher ou revisar changelog, ou ao fechar uma tarefa
+  cujo efeito o usuário final percebe. Cobre inferir a mudança pelo diff, escolher a seção, escrever
+  no imperativo e fechar com o número do PR.
+---
+
+# Escrever a entrada do changelog
+
+O formato está em `.claude/rules/changelog-format.md` — esta skill é o procedimento. Entradas vão direto em `## [Unreleased]` no `CHANGELOG.md` da raiz.
+
+## 1. Descobrir o que mudou
+
+```bash
+git diff origin/develop...HEAD --stat
+git log origin/develop..HEAD --oneline
+```
+
+O diff e os commits dizem **o que** foi tocado. A entrada precisa dizer **o efeito para quem usa** — e isso o diff quase nunca entrega sozinho. Se não estiver claro qual é o efeito, **pergunte**; não deduza a partir de nomes de arquivo.
+
+## 2. Decidir se a mudança entra
+
+Entra quando alguém que usa a aplicação percebe: tela nova, comportamento diferente, correção visível, remoção de funcionalidade.
+
+**Não entra:** refactor sem efeito externo, remoção de código morto, ajuste de teste, mudança de configuração de lint ou de CI. Isso vive no histórico de commit.
+
+Na dúvida, a pergunta é: *alguém que não leu o PR se importaria?*
+
+## 3. Escolher a seção
+
+| Seção | Quando |
+| ----- | ------ |
+| `Added` | funcionalidade que não existia |
+| `Changed` | comportamento existente que passou a funcionar diferente |
+| `Fixed` | defeito corrigido |
+| `Removed` | funcionalidade que saiu |
+| `Deprecated` | ainda existe, mas vai sair |
+| `Security` | correção com impacto de segurança |
+
+Reescrever algo por dentro sem mudar o que o usuário vê é `Changed`, não `Added`: para quem usa, nada foi adicionado.
+
+## 4. Escrever
+
+Uma entrada principal, imperativo, linha curta, terminando no número do PR:
+
+```bash
+gh pr view --json number --jq .number
+```
+
+Se o PR ainda não foi aberto, escreva `(#?)` e **avise na resposta** que precisa ser trocado antes do merge.
+
+## 5. Reler antes de entregar
+
+Confira linha por linha — é o que a review pega:
+
+- [ ] começa com verbo no imperativo (`Adiciona`, `Corrige`, `Remove`, `Reescreve`)
+- [ ] descreve o **efeito**, não a implementação: sem nome de arquivo, de componente ou de camada
+- [ ] termina com `(#<número do PR>)` — o PR, nunca a issue
+- [ ] a seção existe e tem mudança de verdade; seção vazia não fica no arquivo
+- [ ] é **uma** entrada para a tarefa, não uma por commit
+
+## Armadilha
+
+Se a tarefa rendeu vários commits e você escreveu vários bullets, provavelmente descreveu o `git log` em vez da mudança. Agrupe: seis commits e uma frase é o resultado esperado.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Todas as mudanças relevantes deste repositório ficam documentadas aqui.
+
+O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed
+
+- Reescreve o front em React + Vite, com design system próprio e paridade visual medida (#84)

--- a/FateConnect/Web/README.md
+++ b/FateConnect/Web/README.md
@@ -126,7 +126,7 @@ A pasta **`.claude/`**, na raiz do repositório, guarda o contexto que um agente
 | `rules/*.md`        | Padrão que vale para uma área do código                               | pelo `paths:` do arquivo — ao abrir um arquivo que casa                |
 | `skills/*/SKILL.md` | Procedimento sob demanda, com passos                                  | quando a tarefa casa com a `description`, ou pelo nome (`/pr-creator`) |
 
-As skills de hoje: **`pr-creator`** (abrir e atualizar PR), **`write-commit`** (mensagem de commit e agrupamento em commits) e **`fateconnect-create-component`** (criar componente no front).
+As skills de hoje: **`pr-creator`** (abrir e atualizar PR), **`write-commit`** (mensagem de commit e agrupamento em commits), **`changelog-writer`** (entrada do `CHANGELOG.md`) e **`fateconnect-create-component`** (criar componente no front).
 
 ### Como mexer nela
 


### PR DESCRIPTION
## Objetivo

Adotar changelog no repositório seguindo o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Até aqui "o que mudou" só existia espalhado nos PRs; passa a existir num lugar só, no idioma do produto.

## Alterações

### `CHANGELOG.md` na raiz

Cobre o repositório inteiro — front, API e o que mais mudar. Cabeçalho do Keep a Changelog e a seção `## [Unreleased]`, onde as entradas entram **direto**.

Sem diretório de fragmentos: aquele mecanismo existe para evitar conflito quando várias frentes mergeiam em paralelo, e depende de automação de release para consolidar. Aqui não há tag nem release, e os PRs entram em sequência — fragmento sem automação viraria arquivo que ninguém junta.

Uma entrada retroativa registra a reescrita do front, o único marco anterior que vale documentar. Os outros 29 PRs não foram reconstruídos: viraria uma lista de detalhe técnico, que é o oposto do formato.

### Regra de formato

`.claude/rules/changelog-format.md`, carregando pelo `paths` ao abrir o `CHANGELOG.md`. Fixa as convenções:

- **Cabeçalho em inglês** (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`), **conteúdo em pt-BR**.
- **Imperativo** — "Adiciona", "Corrige", "Reescreve"; nunca "Adicionado" ou "Foi adicionado".
- **Uma entrada principal por tarefa**, descrevendo o efeito para quem consome — não uma entrada por commit nem por detalhe de implementação.
- **Termina no número do PR** entre parênteses. Sempre o PR, nunca a issue: o link precisa cair no diff e no review, não no planejamento.
- **Item puramente interno não entra** — refactor sem efeito externo, código morto, ajuste de teste e configuração ficam no histórico de commit.

A regra traz exemplos de "faça" e "não faça" lado a lado, incluindo os dois erros mais fáceis de cometer: citar a issue no lugar do PR, e descrever a implementação em vez do efeito.

### Skill `changelog-writer`

O procedimento: inferir a mudança pelo diff da branch, **decidir se ela entra**, escolher a seção, escrever no imperativo e fechar com o número do PR. Inclui a checagem final que a review costuma pegar e a distinção entre `Added` e `Changed` — reescrever algo por dentro sem mudar o que o usuário vê é `Changed`, porque para quem usa nada foi adicionado.

O `CLAUDE.md` ganhou a proibição de escrever changelog à mão, com o motivo: à mão sai um bullet por commit.

### Sem entrada para este PR

Adotar a ferramenta é item interno, e a regra escrita aqui diz que configuração fica no histórico de commit. Adicionar uma entrada seria violar a regra no primeiro uso.

## Issue

- #85

Closes #85

## Evidências
