### PR TITLE
chore(89): back-merge main into develop after a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,63 @@ jobs:
           git push origin "v$version"
 
           echo "Tag v$version criada em $GITHUB_SHA."
+
+  # Independente do job da tag de propósito. A release entra pela main, mas o
+  # trabalho continua na develop: sem trazer o merge de volta, a próxima release
+  # nasce de uma base que não conhece a anterior, e o primeiro PR depois dela já
+  # vem com conflito de changelog e versão. Falha em um dos dois jobs não tem por
+  # que impedir o outro — os dois são corrigíveis à mão.
+  back-merge:
+    name: Sync develop with main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Histórico completo: o job compara as duas branches, e um checkout
+          # raso não tem os commits para contar.
+          fetch-depth: 0
+          # A deploy key é o que faz o push na develop passar — é a ela que a
+          # ruleset da develop concede bypass. Bypass para o app GitHub Actions
+          # não serve aqui: ele exige repositório de organização, e a API recusa
+          # em conta pessoal.
+          ssh-key: ${{ secrets.BACK_MERGE_SSH_KEY }}
+
+      - name: Sync develop
+        run: |
+          set -euo pipefail
+
+          git fetch --quiet origin main develop
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          behind=$(git rev-list --count origin/develop..origin/main)
+          ahead=$(git rev-list --count origin/main..origin/develop)
+
+          if [ "$behind" -eq 0 ]; then
+            echo "A develop já contém a main — nada a sincronizar."
+            exit 0
+          fi
+
+          git checkout -B develop origin/develop
+
+          # Caso comum: a develop não andou desde o corte da release, então a
+          # sincronização é fast-forward e não inventa commit nenhum.
+          if [ "$ahead" -eq 0 ]; then
+            git merge --ff-only origin/main
+            git push origin develop
+            echo "develop avançada $behind commit(s) até $(git rev-parse --short HEAD), sem merge."
+            exit 0
+          fi
+
+          # A develop andou por conta própria — feature mergeada enquanto a
+          # release estava aberta. Aí o merge é de verdade.
+          if git merge --no-edit origin/main; then
+            git push origin develop
+            echo "main mergeada na develop em $(git rev-parse --short HEAD) ($ahead commit(s) próprios preservados)."
+            exit 0
+          fi
+
+          # Conflito é decisão humana: a automação não escolhe qual lado vale.
+          git merge --abort
+          echo "::error::Conflito ao trazer a main para a develop. Resolva localmente: git checkout develop && git merge origin/main"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,30 @@
-name: Tag Release
+name: Release
 
-# Todo push na main é uma release, e a versão do projeto é a do `package.json`
-# da raiz — o front tem versão própria, que não diz nada sobre a release. O passo
-# de versão do check já barrou versão repetida no PR, então aqui não sobra
-# decisão: só marcar o commit que foi publicado.
+# Todo push na main é uma release. A versão do projeto é a do `package.json` da
+# raiz — o front tem versão própria, que não diz nada sobre a release.
 on:
   push:
     branches:
       - main
 
 # Duas releases em sequência não podem correr juntas: a segunda leria o
-# repositório antes de a primeira ter criado a tag.
+# repositório antes de a primeira ter empurrado.
 concurrency:
-  group: tag-release
+  group: release
   cancel-in-progress: false
 
-# Criar tag é escrita no repositório.
+# Cada job pede o que precisa; nada é concedido por padrão.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  # O passo de versão do check já barrou versão repetida no PR, então aqui não
+  # sobra decisão: só marcar o commit que foi publicado.
   tag:
     name: Create version tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ package.json          a versão do projeto, e nada mais
 
 Branch base é a **`develop`**, e o nome da branch sai da issue: `<tipo>/<número>` — `chore/48`, `feat/56`. Toda alteração começa por uma issue no GitHub, e o número dela alimenta a branch, o título e o corpo do PR.
 
-Release sobe por `develop` → `release/x.y.z` → `main`.
+Release sobe por `develop` → `release/x.y.z` → `main`, e a `main` volta para a `develop` sozinha depois do merge.
 
 Os hooks não vêm habilitados no clone, porque o repositório usa `core.hooksPath` em vez de instalar um gerenciador de hooks — o que reapontaria o caminho e desligaria os hooks do Git LFS:
 
@@ -47,12 +47,16 @@ A validação consulta as tags no **remoto**. Consultar localmente aprovaria qua
 
 ## Integração contínua
 
-| Workflow    | Quando                                       | O que faz                                             |
-| ----------- | -------------------------------------------- | ----------------------------------------------------- |
-| `check.yml` | PR que toca `FateConnect/Web/**` ou a versão | valida a versão, tipos, lint, testes e build do front |
-| `tag.yml`   | push na `main`                               | cria a tag da versão publicada                        |
+| Workflow      | Quando                                       | O que faz                                                          |
+| ------------- | -------------------------------------------- | ------------------------------------------------------------------ |
+| `check.yml`   | PR que toca `FateConnect/Web/**` ou a versão | valida a versão, tipos, lint, testes e build do front              |
+| `release.yml` | push na `main`                               | cria a tag da versão publicada e devolve a `main` para a `develop` |
 
 O `check.yml` não roda em PR que não mexe no front: mudança de back-end não tem por que pagar a suíte de front. O `package.json` da raiz entra no filtro por causa da validação de versão — mudança de versão não pode escapar dela.
+
+Os dois passos da release moram no mesmo workflow porque acontecem no mesmo evento: o push que a `main` recebe quando a release entra. Eles não dependem um do outro — falha ao marcar a tag não impede a sincronização, e vice-versa.
+
+O job de back-merge do `release.yml` empurra **direto na `develop`**, sem PR: a ruleset da `develop` concede bypass a uma **deploy key** de escrita, que o workflow usa no checkout, e a da `main` não concede a ninguém — a release continua exigindo PR e review. Bypass para o app GitHub Actions resolveria sem chave nenhuma, mas ele exige repositório de organização: em conta pessoal a API recusa o ator. O caminho comum é fast-forward, porque a `develop` normalmente não andou desde o corte da release. Quando andou, o job faz o merge de verdade; se conflitar, ele para e reporta, porque escolher qual lado vale é decisão humana.
 
 Não há envio de cobertura para o GitHub: o Code Quality exige repositório de organização em plano Team ou Enterprise Cloud, e este é de conta pessoal. Quem reprova por cobertura é o limite do Vitest, dentro do `test:ci`.
 


### PR DESCRIPTION
## Objetivo

Fechar a última etapa manual da release. A tag já nasce sozinha no push para a `main`; falta a volta — trazer a `main` para a `develop`, para a próxima release não nascer de uma base que não conhece a anterior.

Este PR aponta para a `main` de propósito: o workflow só passa a existir depois de estar lá, e o merge dele já serve de teste do sync.

## Alterações

Dois commits: o `tag.yml` vira `release.yml` sem mudar comportamento, e depois o back-merge entra como segundo job.

- **`.github/workflows/release.yml`** — os dois passos da release passam a viver no mesmo workflow, porque acontecem no mesmo evento: o push que a `main` recebe quando a release entra.
  - `tag`: o que era o `tag.yml`, sem uma linha de lógica alterada. Só ele pede `contents: write`.
  - `back-merge`: sincroniza a `develop`. **Nada a fazer** quando ela já contém a `main`; **fast-forward** quando não andou desde o corte da release, sem inventar commit; **merge** quando andou por conta própria, preservando os commits dela; e **conflito para o job** com a mensagem do que rodar localmente — a automação não escolhe qual lado vale, e por isso também não abre PR.
  - Os dois jobs são independentes de propósito: falha ao marcar a tag não impede a sincronização, e vice-versa.
  - O `checkout` do back-merge usa `ssh-key`, então quem escreve é a deploy key e não o `GITHUB_TOKEN` — o workflow fica com `contents: read` por padrão.
- **`README.md`**: a tabela de CI ganha o `release.yml`, e o texto registra por que o push é direto e quem tem o bypass — sem isso, viraria conhecimento que não está escrito em lugar nenhum.

## Configuração aplicada

A ruleset única que cobria `main` e `develop` juntas foi dividida em duas, para o bypass do push ficar escopado só na `develop`:

| Ruleset                     | Ref                  | Bypass                                     |
| --------------------------- | -------------------- | ------------------------------------------ |
| `Protected Branch - main`   | `refs/heads/main`    | admin, só em PR                            |
| `Protected Branch - develop` | `refs/heads/develop` | admin só em PR, **e a deploy key sempre**  |

As quatro regras (`deletion`, `pull_request`, `non_fast_forward`, `code_coverage`) são cópia fiel da ruleset anterior nas duas.

Bypass para o app GitHub Actions seria mais simples, sem chave nenhuma para manter, mas **ele exige repositório de organização**: em conta pessoal a API responde `Actor GitHub Actions integration must be part of the ruleset source or owner organization`. A saída foi uma deploy key de escrita, com a metade privada no secret `BACK_MERGE_SSH_KEY`. Deploy key é presa a este repositório e não expira — diferente de um PAT, que é da conta e quebraria calado no vencimento.

## Como foi verificado

Os quatro caminhos rodaram contra um remoto de mentira (`git init --bare` + clone), com o script extraído do próprio YAML:

| Cenário                              | Resultado                                                             |
| ------------------------------------ | --------------------------------------------------------------------- |
| `develop` 5 commits atrás, 0 própria | fast-forward até `c711d0d`, sem merge                                  |
| `develop` com 1 commit próprio       | merge com dois pais, commit próprio preservado                        |
| conflito no `CHANGELOG.md`           | `exit 1` com `::error::`, remoto intacto e worktree limpo após o abort |
| rodar de novo, já sincronizado       | "nada a sincronizar", `exit 0`                                        |

A consolidação num workflow só veio depois desses testes, então os scripts foram conferidos byte a byte: os dois `run` extraídos do `release.yml` são **idênticos** aos que passaram nos cenários acima.

O que **não** deu para provar antes do merge é o push por SSH com a deploy key: a metade privada existe só no secret. É o merge deste PR que exercita esse caminho.

Sem entrada no `CHANGELOG.md`: automação de release não muda nada para quem consome a versão.

## Issue

- #89

Closes #89

## Evidências
