### PR TITLE
feat(30): show the logged user initials in the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Adiciona as iniciais de quem está logado no topo da área logada (#91)
+
 ## [0.2.0] - 2026-08-20
 
 ### Changed

--- a/FateConnect/Web/src/design-system/components/Header/styles.ts
+++ b/FateConnect/Web/src/design-system/components/Header/styles.ts
@@ -73,6 +73,9 @@ export const DesktopNav = styled(Stack)<PolymorphicProps>(({ theme }) => ({
 export const ActionsSlot = styled(Stack)<PolymorphicProps>({
   flexDirection: 'row',
   alignItems: 'center',
+  // Separa uma ação da outra. Com um filho só isso não aparecia, e duas
+  // ações adjacentes ficavam encostadas.
+  gap: spacing(xs),
   marginLeft: NAV_COLUMN_GAP,
 });
 

--- a/FateConnect/Web/src/design-system/components/InitialsAvatar/InitialsAvatar.test.tsx
+++ b/FateConnect/Web/src/design-system/components/InitialsAvatar/InitialsAvatar.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from '@app/test/testing-library';
+import { InitialsAvatar } from '.';
+
+const DEFAULT_PROPS = { initials: 'MS', label: 'Maria Silva' };
+
+const renderComponent = (props = DEFAULT_PROPS) => render(<InitialsAvatar {...props} />);
+
+describe('InitialsAvatar', () => {
+  it('should announce the full name and show the initials', () => {
+    renderComponent();
+
+    const avatar = screen.getByRole('img', { name: 'Maria Silva' });
+
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveTextContent('MS');
+  });
+
+  it('should paint the circle with the accent colour of the theme', () => {
+    renderComponent();
+
+    // O par de contraste dessa combinação é verificado em `contrast.test.ts`.
+    expect(screen.getByRole('img', { name: 'Maria Silva' })).toHaveStyle({
+      backgroundColor: 'rgb(207, 46, 46)',
+    });
+  });
+});

--- a/FateConnect/Web/src/design-system/components/InitialsAvatar/index.tsx
+++ b/FateConnect/Web/src/design-system/components/InitialsAvatar/index.tsx
@@ -1,0 +1,20 @@
+import * as S from './styles';
+
+type InitialsAvatarProps = Readonly<{
+  /** Iniciais já derivadas — o design system não conhece regra de nome. */
+  initials: string;
+  /** O que o leitor de tela anuncia no lugar das iniciais. */
+  label: string;
+}>;
+
+/**
+ * Marca de identidade no cromo: círculo na cor de destaque com as iniciais.
+ * Anunciado como imagem, porque duas letras soltas não dizem nada em voz alta.
+ */
+export function InitialsAvatar({ initials, label }: InitialsAvatarProps) {
+  return (
+    <S.InitialsCircle role="img" aria-label={label}>
+      {initials}
+    </S.InitialsCircle>
+  );
+}

--- a/FateConnect/Web/src/design-system/components/InitialsAvatar/styles.ts
+++ b/FateConnect/Web/src/design-system/components/InitialsAvatar/styles.ts
@@ -1,0 +1,19 @@
+import Avatar from '@mui/material/Avatar';
+
+import { styled } from '../../styled';
+import { spacingScale } from '../../tokens';
+
+/**
+ * Diâmetro do círculo. O desenho da tarefa põe o círculo em 42% da altura do
+ * topo, e a escala do projeto não tem 28: com 24 as duas letras encostam na
+ * borda no corpo de 0.875rem, então este é o token que respeita a proporção.
+ */
+const CIRCLE_SIZE_PX = spacingScale.xl;
+
+export const InitialsCircle = styled(Avatar)(({ theme }) => ({
+  width: `${CIRCLE_SIZE_PX}px`,
+  height: `${CIRCLE_SIZE_PX}px`,
+  backgroundColor: theme.palette.secondary.main,
+  color: theme.palette.secondary.contrastText,
+  ...theme.typography.captionBold,
+}));

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -14,6 +14,7 @@ export { Header } from './components/Header';
 export { HEADER_HEIGHT_PX } from './components/Header/styles';
 export { Footer } from './components/Footer';
 export { NavigationDrawer } from './components/NavigationDrawer';
+export { InitialsAvatar } from './components/InitialsAvatar';
 export { ConfirmDialog } from './components/ConfirmDialog';
 export { NotificationProvider } from './components/NotificationProvider';
 export { PageMessage } from './components/PageMessage';

--- a/FateConnect/Web/src/design-system/theme/contrast.test.ts
+++ b/FateConnect/Web/src/design-system/theme/contrast.test.ts
@@ -73,6 +73,7 @@ describe('dark theme contrast', () => {
     ['secondary text on the page background', palette.text.secondary, palette.background.default],
     ['the primary colour on the background', palette.primary.main, palette.background.default],
     ['the secondary colour on the background', palette.secondary.main, palette.background.default],
+    ['content on the secondary colour', palette.secondary.contrastText, palette.secondary.main],
     ['the error colour on the background', palette.error.main, palette.background.default],
     ['content on the app chrome', onChromeSurface(darkTheme), chromeSurface(darkTheme)],
     ['a success tag', palette.success.main, palette.success.light],

--- a/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
@@ -2,6 +2,7 @@ import { RouterProvider, createMemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { RoutePathEnum } from '@app/routes/paths';
+import { tokenStorage } from '@app/services/auth/tokenStorage';
 import { render, screen, userEvent, within } from '@app/test/testing-library';
 import { MainLayout } from '.';
 
@@ -42,6 +43,19 @@ describe('MainLayout', () => {
     await userEvent.click(within(drawer).getByRole('link', { name: 'Caronas' }));
 
     expect(router.state.location.pathname).toBe(RoutePathEnum.RIDES);
+  });
+
+  it('should show the initials of the logged user', () => {
+    tokenStorage.save('token-de-teste', 'Maria da Silva');
+    renderLayout();
+
+    expect(screen.getByRole('img', { name: 'Maria da Silva' })).toHaveTextContent('MS');
+  });
+
+  it('should not show the avatar when no name is stored', () => {
+    renderLayout();
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 
   it('should point the logo to the menu', () => {

--- a/FateConnect/Web/src/layouts/MainLayout/components/HeaderActions/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/components/HeaderActions/index.tsx
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+
+import { tokenStorage } from '@app/services/auth/tokenStorage';
+import { getInitials } from '@app/utils/initials';
+import { InitialsAvatar, ThemeToggleButton } from '@design-system';
+
+/**
+ * Ações fixas do topo da área logada. O nome vem do login, guardado junto do
+ * token: sem nome guardado não há iniciais, e um círculo vazio diria menos que
+ * nada.
+ */
+export function HeaderActions() {
+  const userName = tokenStorage.getUserName() ?? '';
+  const initials = useMemo(() => getInitials(userName), [userName]);
+
+  return (
+    <>
+      <ThemeToggleButton />
+      {initials ? <InitialsAvatar initials={initials} label={userName} /> : null}
+    </>
+  );
+}

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -11,9 +11,9 @@ import {
   ListItemButton,
   ListItemText,
   NavigationDrawer,
-  ThemeToggleButton,
   Typography,
 } from '@design-system';
+import { HeaderActions } from './components/HeaderActions';
 import * as S from '../shell.styles';
 
 const MENU_BUTTON_LABEL = 'Abrir menu';
@@ -37,7 +37,7 @@ export function MainLayout() {
     <S.ShellRoot>
       <Header
         logo={logo}
-        actions={<ThemeToggleButton />}
+        actions={<HeaderActions />}
         menuButtonLabel={MENU_BUTTON_LABEL}
         onMenuClick={handleMenuClick}
         navigation={APP_LINKS.map(({ path, label }) => (

--- a/FateConnect/Web/src/services/auth/tokenStorage.ts
+++ b/FateConnect/Web/src/services/auth/tokenStorage.ts
@@ -10,6 +10,10 @@ export const tokenStorage = {
     return window.localStorage.getItem(TOKEN_KEY);
   },
 
+  getUserName(): string | null {
+    return window.localStorage.getItem(USER_NAME_KEY);
+  },
+
   save(token: string, userName: string): void {
     window.localStorage.setItem(TOKEN_KEY, token);
     window.localStorage.setItem(USER_NAME_KEY, userName);

--- a/FateConnect/Web/src/utils/initials.test.ts
+++ b/FateConnect/Web/src/utils/initials.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getInitials } from './initials';
+
+describe('getInitials', () => {
+  it('should take the first letter of the first and last name', () => {
+    expect(getInitials('Maria Silva')).toBe('MS');
+    expect(getInitials('Maria Silva Santos')).toBe('MS');
+  });
+
+  it('should skip name particles so the last name is the one that counts', () => {
+    expect(getInitials('Maria da Silva')).toBe('MS');
+    expect(getInitials('Pedro de Alcântara dos Santos')).toBe('PS');
+    expect(getInitials('Ana e Costa')).toBe('AC');
+  });
+
+  it('should return a single letter for a single name', () => {
+    expect(getInitials('Maria')).toBe('M');
+  });
+
+  it('should uppercase the letters and ignore surrounding whitespace', () => {
+    expect(getInitials('  maria   silva  ')).toBe('MS');
+  });
+
+  it('should return an empty string when there is no name', () => {
+    expect(getInitials('')).toBe('');
+    expect(getInitials('   ')).toBe('');
+  });
+
+  it('should fall back to the first word when every word is a particle', () => {
+    expect(getInitials('da e')).toBe('D');
+  });
+});

--- a/FateConnect/Web/src/utils/initials.ts
+++ b/FateConnect/Web/src/utils/initials.ts
@@ -1,0 +1,30 @@
+/**
+ * Partícula de nome não conta como sobrenome: "Maria da Silva" abrevia para MS,
+ * não MD.
+ */
+const NAME_PARTICLES: ReadonlySet<string> = new Set(['de', 'da', 'do', 'das', 'dos', 'e']);
+
+function firstLetter(namePart: string): string {
+  return namePart.charAt(0).toUpperCase();
+}
+
+/**
+ * Iniciais das pontas da lista. Uma palavra só rende uma letra: tirar a segunda
+ * da mesma palavra inventaria um sobrenome que não existe.
+ */
+function edgeInitials(names: readonly string[]): string {
+  if (names.length <= 1) return names.map(firstLetter).join('');
+
+  return [...names.slice(0, 1), ...names.slice(-1)].map(firstLetter).join('');
+}
+
+/** Iniciais do primeiro e do último nome, em maiúsculas. */
+export function getInitials(fullName: string): string {
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+  const names = parts.filter((part) => !NAME_PARTICLES.has(part.toLowerCase()));
+  if (names.length > 0) return edgeInitials(names);
+
+  // Sem nenhuma palavra que não seja partícula, não há primeiro e último a
+  // distinguir — o que sobra é a primeira palavra do que veio.
+  return edgeInitials(parts.slice(0, 1));
+}


### PR DESCRIPTION
## Objetivo

Mostrar as iniciais de quem está logado no topo da área logada, como o desenho da issue pede. O nome já era gravado no login junto do token — só não tinha quem o lesse.

## Alterações

### Design system

- **`InitialsAvatar`**: círculo na cor de destaque com as iniciais. Recebe `initials` e `label` prontos: o design system não conhece regra de nome. É anunciado como `role="img"` com o nome completo no rótulo, porque duas letras soltas não dizem nada em voz alta.
- **`ActionsSlot` do `Header`** ganhou `gap`. Ele só tinha margem externa, e com uma ação só isso nunca apareceu; com duas, o avatar e o botão de tema ficavam **encostados**. A landing segue com uma ação só, sem mudança.
- **`contrast.test.ts`**: a suíte do tema escuro não cobria conteúdo sobre a cor de destaque — que é justamente o que o círculo desenha. Sem essa linha, um ajuste futuro no vermelho escuro derrubaria o contraste em silêncio.

### Área logada

- **`HeaderActions`**: componente dedicado com as ações fixas do topo. Lê o nome, deriva as iniciais e monta o par com o botão de tema.
- **`getInitials`**: primeira e última inicial, ignorando partícula — "Maria da Silva" abrevia para **MS**, não MD. Nome de uma palavra rende uma letra: tirar a segunda da mesma palavra inventaria um sobrenome.
- **`tokenStorage.getUserName`**: o getter que faltava para o `user_name` que o login já gravava.

Sem nome guardado, nada é renderizado — um círculo vazio diria menos que nada.

## Paridade medida

Não havia implementação anterior para igualar: o header do front removido **não tinha avatar**. Então a referência é o desenho da issue, e o desenho **não é captura do app** — decodifiquei o PNG e ele usa `8,3vw` de padding lateral onde a aplicação usa `7vw`, além de mostrar "Entre em Contato", rota que a área logada não tem. O que se aproveita dele é o que é escala-independente:

| Medida no desenho | Valor | No código |
| --- | --- | --- |
| Cor do círculo | `rgb(207,46,46)` | `#CF2E2E`, o token `accent` — **idêntico** |
| Fundo da barra | `rgb(67,84,92)` | `#43545C`, o token `primary` |
| Diâmetro | 42% da altura da barra | 50% (32px de 64px) — **divergência consciente** |

O diâmetro é o único desvio: 42% de 64px daria 27px, a escala do projeto não tem 28, e 24px com duas letras de 14px encosta na borda. Ficou em `spacingScale.xl`.

`getComputedStyle` no navegador:

| | 1440px | 700px |
| --- | --- | --- |
| Caixa | 32×32, raio 50% | 32×32 |
| Fundo / texto | `#CF2E2E` / branco | idem |
| Tipografia | 14px / 700 (`captionBold`) | idem |
| Folga à direita | 101px = **7vw exato** | 105px = 7vw + botão de menu + vão |
| Vão até o botão de tema | 8px | 8px |
| Navegação | visível | oculta, hambúrguer no lugar |

Tema escuro, medido no navegador: círculo `#D84E4E`, texto `#121212`, contraste **4.57:1** — acima do mínimo AA de 4.5, e agora com par no teste.

## Issue

- #30

Closes #30

## Evidências
<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/036d89af-a0d1-4c50-89a5-47ff6444560d" />
