### PR TITLE
chore(92): report the front check on every pull request

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,14 +5,13 @@ name: Check Pull Request
 # destino no PR, porque PR empilhado (base em outra feature branch) também
 # precisa ser validado.
 #
-# O `package.json` da raiz entra no filtro por causa do passo de versão: é lá
-# que a versão do projeto mora, e mudança de versão não pode escapar da
-# validação.
+# O recorte é feito DENTRO do job, não em `paths` no gatilho, porque este check
+# é obrigatório para mergear. Workflow que não dispara não deixa o check
+# ausente: deixa ele `Pending` para sempre, e o PR fica impossível de mergear.
+# Rodando sempre, o contexto sempre reporta — e o PR que não toca o front paga
+# só a partida do runner, não a suíte.
 on:
-  pull_request:
-    paths:
-      - 'FateConnect/Web/**'
-      - 'package.json'
+  pull_request
 
 # Execução nova na mesma ref cancela a anterior.
 concurrency:
@@ -21,6 +20,8 @@ concurrency:
 
 permissions:
   contents: read
+  # Para ler a lista de arquivos do PR e decidir o que rodar.
+  pull-requests: read
 
 jobs:
   web:
@@ -31,6 +32,35 @@ jobs:
         working-directory: FateConnect/Web
     steps:
       - uses: actions/checkout@v5
+
+      # A lista vem da API do PR, não de `git diff`: o checkout traz um commit
+      # só, e comparar com a base exigiria clone completo por um dado que o
+      # GitHub já tem pronto.
+      #
+      # É a API de arquivos, paginada, e não `gh pr diff`: aquele recusa PR com
+      # mais de 300 arquivos (HTTP 406), e a release que trocou o front inteiro
+      # tinha 330. Um check obrigatório reprovaria exatamente no PR de release.
+      #
+      # A versão do projeto mora no `package.json` da raiz, então ela entra no
+      # recorte junto do front: mudança de versão não pode escapar da validação.
+      - name: Changed paths
+        id: changes
+        run: |
+          set -euo pipefail
+
+          changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
+
+          if printf '%s\n' "$changed" | grep -qE '^(FateConnect/Web/|package\.json$)'; then
+            echo 'web=true' >> "$GITHUB_OUTPUT"
+            echo 'A mudança alcança o front ou a versão do projeto — validando.'
+            exit 0
+          fi
+
+          echo 'web=false' >> "$GITHUB_OUTPUT"
+          echo 'Nada em FateConnect/Web nem na versão do projeto — nada a validar aqui.'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       # A tag da release nasce da versão do `package.json` da raiz, então PR para
       # a main é a última chance de pegar versão repetida: ou o bump foi
@@ -45,7 +75,7 @@ jobs:
       # nenhuma tag, então a busca local não acharia nada nunca e o passo
       # aprovaria tudo em silêncio.
       - name: Version
-        if: github.base_ref == 'main'
+        if: steps.changes.outputs.web == 'true' && github.base_ref == 'main'
         run: |
           set -euo pipefail
 
@@ -59,18 +89,22 @@ jobs:
           echo "Versão $version disponível para publicação."
 
       - uses: actions/setup-node@v5
+        if: steps.changes.outputs.web == 'true'
         with:
           node-version-file: FateConnect/Web/.nvmrc
           cache: yarn
           cache-dependency-path: FateConnect/Web/yarn.lock
 
       - name: Install dependencies
+        if: steps.changes.outputs.web == 'true'
         run: yarn install --frozen-lockfile
 
       - name: Types
+        if: steps.changes.outputs.web == 'true'
         run: yarn typecheck
 
       - name: Lint
+        if: steps.changes.outputs.web == 'true'
         run: yarn lint
 
       # Suíte inteira: os limites de cobertura são globais, então medi-los sobre
@@ -82,7 +116,9 @@ jobs:
       # — a API responde 404. Quem reprova por cobertura é o limite do Vitest,
       # aplicado dentro do `test:ci`.
       - name: Tests and coverage
+        if: steps.changes.outputs.web == 'true'
         run: yarn test:ci
 
       - name: Build
+        if: steps.changes.outputs.web == 'true'
         run: yarn build


### PR DESCRIPTION
## Objetivo

Deixar o check do front em condição de ser **obrigatório** para mergear. Hoje ele não pode: o filtro de `paths` está no gatilho, então em PR que não toca `FateConnect/Web/**` nem a versão o workflow não dispara — e required check que não dispara não fica ausente, fica `Pending` para sempre. O PR passa a ser impossível de mergear.

O #90 é o caso concreto: tocou só `.github/` e o README da raiz, e teria travado.

## Alterações

O recorte sai do gatilho e vai para dentro do job:

- **`on: pull_request`** sem `paths`. O job roda sempre, então o contexto `React front (Web)` sempre reporta.
- **Passo `Changed paths`** decide se a mudança alcança o front ou a versão do projeto.
- **Tipos, lint, testes, build e a validação de versão** passam a depender desse recorte. PR de back-end paga a partida do runner, não a suíte.
- **`pull-requests: read`** acrescentado, para ler a lista de arquivos do PR.

O comportamento visível não muda: os mesmos PRs que rodavam a suíte continuam rodando, e a validação de versão segue só em PR para a `main`.

## Duas decisões

**A lista de arquivos vem da API, não de `git diff`.** O checkout traz um commit só; comparar com a base exigiria clone completo por um dado que o GitHub já tem pronto.

**E vem da API de arquivos paginada, não de `gh pr diff`.** Esse é o achado da tarefa: `gh pr diff` recusa PR com mais de 300 arquivos com **HTTP 406**, e o #88 — a release que trocou o front inteiro — tinha 330. Com o check obrigatório, o PR que reprovaria seria exatamente o de release.

## Como foi verificado

O passo foi extraído do próprio YAML e rodado contra PRs reais deste repositório:

| PR | Arquivos | O que tem | Recorte |
| --- | --- | --- | --- |
| #88 | 330 | a release inteira | `web=true` |
| #91 | 13 | front | `web=true` |
| #86 | 5 | `.claude/`, changelog, README **dentro de Web** | `web=true` |
| #90 | 3 | só `.github/` e README da raiz | `web=false` |

O #90 é o que interessa: é o PR que hoje travaria, e agora reporta sem rodar a suíte.

## Depois do merge

Ligar a regra `required_status_checks` nas rulesets da `main` e da `develop`, com o contexto `React front (Web)` fixado no app do GitHub Actions (`integration_id: 15368`) — sem fixar, qualquer integração poderia publicar um status com esse nome e destravar o merge.

## Issue

- #92

Closes #92

## Evidências
