### PR TITLE
fix(100): keep the ride description when the update omits it

### DIFF
--- a/.claude/rules/changelog-format.md
+++ b/.claude/rules/changelog-format.md
@@ -25,7 +25,8 @@ Só as seções com mudança de verdade aparecem. Seção vazia não fica no arq
 - **Uma linha curta por mudança.** Sem lista de arquivo, camada ou nome interno.
 - **Termina no número do PR**, entre parênteses: `(#84)`. **Sempre o PR, nunca a issue** — o link precisa cair no diff e no review, não no planejamento. Se o PR ainda não existe, use `(#?)` e troque antes do merge.
 - **Fecha com o lado que mudou:** `[Frontend]` ou `[Backend]`, **depois** do número do PR. O repositório guarda o front e dois serviços .NET, e quem lê a release precisa saber o que precisa subir. Mudança que só funciona com os dois lados leva os dois marcadores, nessa ordem — e se cada lado produzir um efeito diferente, são duas entradas, não uma com dois marcadores.
-- **Item puramente interno não entra.** Remoção de helper morto, refactor sem efeito externo, ajuste de teste: isso vive no histórico de commit, não no changelog.
+- **Correção entra mesmo sem efeito visível hoje.** O changelog é registro de alteração, não nota de divulgação: defeito corrigido em serviço publicado entra ainda que nenhum cliente atual chegue nele — e o marcador de lado é o que avisa quem precisa subir. Descreva o defeito **como ele era**, sem sugerir que alguém o sofreu quando ninguém sofreu.
+- **Item que não muda comportamento não entra.** Remoção de helper morto, refactor sem efeito externo, ajuste de teste, configuração de lint ou de CI: isso vive no histórico de commit, não no changelog.
 
 ### Faça
 
@@ -47,6 +48,7 @@ Só as seções com mudança de verdade aparecem. Seção vazia não fica no arq
 - Adiciona a tela de menu (#78)                                   <- é a issue, não o PR
 - Adiciona a tela de menu (#81)                                   <- falta o lado que mudou
 - Adiciona a tela de menu [Frontend] (#81)                        <- o marcador vem depois do PR
+- Corrige a perda de descrição sofrida por quem editava carona    <- defeito que ninguém alcançou; não invente a vítima
 ```
 
 ## Um bullet por commit é o sintoma

--- a/.claude/skills/changelog-writer/SKILL.md
+++ b/.claude/skills/changelog-writer/SKILL.md
@@ -22,11 +22,15 @@ O diff e os commits dizem **o que** foi tocado. A entrada precisa dizer **o efei
 
 ## 2. Decidir se a mudança entra
 
-Entra quando alguém que usa a aplicação percebe: tela nova, comportamento diferente, correção visível, remoção de funcionalidade.
+Entra toda alteração de comportamento do produto: tela nova, comportamento diferente, defeito corrigido, remoção de funcionalidade.
 
-**Não entra:** refactor sem efeito externo, remoção de código morto, ajuste de teste, mudança de configuração de lint ou de CI. Isso vive no histórico de commit.
+**Correção entra mesmo que nenhum usuário chegue nela hoje.** O changelog é registro do que foi alterado. Defeito de API que só outro cliente alcançaria continua sendo correção feita — e o marcador de lado é o que avisa qual serviço precisa subir.
 
-Na dúvida, a pergunta é: *alguém que não leu o PR se importaria?*
+**Não entra** o que não muda comportamento: refactor sem efeito externo, remoção de código morto, ajuste de teste, mudança de configuração de lint ou de CI. Isso vive no histórico de commit.
+
+Na dúvida, a pergunta é: *o comportamento mudou?* — não *o usuário perceberia?*
+
+⛔ Aconteceu na #100: o `PUT` de carona apagava a descrição quando o corpo não trazia o campo, e eu recomendei deixar de fora porque a tela sempre envia o campo, então ninguém via o defeito. Correção do Victor: *"ele é um registro de alterações feitas, mesmo que não afete usuários hoje é uma correção que foi feita então vale entrar"*. Daquela análise sobrevive só o cuidado com a **frase**: descreva o defeito como ele era, sem inventar uma vítima que não existiu.
 
 ## 3. Escolher a seção
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige a comunicação com a API, que falhava por divergência de caminho e por origem bloqueada (#99) [Backend]
 - Corrige a recusa de carona marcada para as próximas horas, tratada como data passada (#99) [Backend]
 - Corrige ofertar e editar carona, que falhavam quando a hora vinha sem os segundos (#99) [Backend]
+- Corrige a atualização de carona, que apagava a descrição quando o campo não era reenviado (#101) [Backend]
 
 ## [0.2.0] - 2026-08-20
 

--- a/FateConnect/Carona/Domain/Entities/Carona.cs
+++ b/FateConnect/Carona/Domain/Entities/Carona.cs
@@ -56,7 +56,9 @@ namespace Domain.Entities
             if (tipoCarona.HasValue)
                 TipoCarona = tipoCarona.Value;
 
-            Descricao = descricao;
+            // Ausente mantém o texto atual; string vazia é como a edição o apaga.
+            if (descricao is not null)
+                Descricao = descricao;
         }
 
         public void AlterarDataPartida(DateOnly? dataPartida, TimeOnly? horaPartida)


### PR DESCRIPTION
## Objetivo

O `PUT /caronas/{id}` apagava a descrição da carona sempre que o corpo da requisição não trazia o campo `descricao`. Quem editasse só o horário perdia o texto escrito.

O defeito não aparece pela aplicação: o diálogo de editar carona envia o formulário inteiro, com `descricao` sempre presente. É a API que estava errada, para qualquer cliente que faça atualização parcial.

## Alterações

**Correção** — `Carona.AtualizarAtributosBasicos` protegia todos os campos contra a ausência, menos a descrição. Agora ela só é sobrescrita quando o campo vem no corpo:

- campo **ausente** mantém o texto atual;
- **string vazia** limpa, que é como a tela de edição apaga o texto.

A guarda é `is not null`, e não o `IsNullOrWhiteSpace` que protege o destino logo acima: com aquela, `""` seria ignorado e não haveria como apagar a descrição.

`null` explícito e campo ausente são indistinguíveis na desserialização, então os dois significam "não mexer".

**Changelog** — a regra `changelog-format.md` e a skill `changelog-writer` diziam que entra o que o usuário percebe, o que deixaria esta correção de fora. O critério passa a ser mudança de comportamento: correção entra mesmo que nenhum cliente atual chegue nela, porque o changelog é registro do que foi alterado, e o marcador de lado é o que avisa qual serviço precisa subir. O limite de fora continua igual — refactor sem efeito externo, código morto, teste, lint e CI não entram.

Junto foi um exemplo no bloco **Não faça**: descrever o defeito como se alguém o tivesse sofrido, quando ninguém sofreu.

## Validação

Feita com o serviço em execução, contra o banco, sobre uma carona com descrição preenchida:

| Requisição | Descrição depois |
| --- | --- |
| `PUT {"horaPartida":"20:15"}` | preservada — era o caso que voltava `null` |
| `PUT {"descricao":"texto trocado"}` | `texto trocado` |
| `PUT {"descricao":""}` | vazia |
| `PUT {"descricao":null,"qtdVagas":5}` | inalterada |

Os dois serviços .NET compilam do zero com **0 warnings e 0 erros**. A carona usada no teste foi removida.

**O front não precisa de mudança**, e isso foi conferido em vez de suposto: no schema o campo `description` é obrigatório, o formulário vazio nasce com `''`, e `updateRide` recebe o payload completo — não existe atualização parcial no front. Se o formulário pudesse mandar `undefined`, apagar a descrição pela tela deixaria de funcionar depois desta correção; não é o caso.

## Issue

- #100

Closes #100

## Evidências
