### PR TITLE
docs: add the spec-issue skill and require a PR for harness changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,7 +22,7 @@ Planejamento e rastreio ficam no **GitHub** (issues + Project board do repositó
 
 ## Fluxo de trabalho
 
-- Branch base: **`develop`**. Nomear branch como `<tipo>/<número-da-issue>` (ex.: `chore/48`).
+- Branch base: **`develop`**. ⛔ **Nunca commitar direto nela** — toda mudança sai numa branch a partir da `develop` e volta por PR, **inclusive mudança em `.claude/`**. Nomear branch como `<tipo>/<número-da-issue>` (ex.: `chore/48`); quando não houver issue, um slug descritivo (`docs/spec-issue-skill`).
 - Toda correção ou alteração começa por uma **issue no GitHub** — o número dela alimenta a branch, o título do PR e o corpo do PR.
 - Abrir PR: usar a skill `pr-creator`. Commitar: usar a skill `write-commit` — e **pedir confirmação antes de qualquer comando git**.
 - ⛔ **Nunca escrever changelog à mão** — usar a skill `changelog-writer`. À mão sai um bullet por commit, que é o oposto do formato: uma entrada principal descrevendo o efeito para quem usa. O formato está em `.claude/rules/changelog-format.md`.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,7 @@ Planejamento e rastreio ficam no **GitHub** (issues + Project board do repositó
 ## Organização desta configuração
 
 - `.claude/rules/` — regras do projeto. Sem `paths:` carregam sempre; com `paths:` carregam quando um arquivo que casa é lido.
-- `.claude/skills/` — fluxos sob demanda: `pr-creator` (abrir/atualizar PR), `write-commit` (mensagem de commit e agrupamento em commits), `changelog-writer` (entrada do CHANGELOG) e `fateconnect-create-component` (criar componente no front).
+- `.claude/skills/` — fluxos sob demanda: `spec-issue` (especificar uma issue e dividir em sub-issues), `pr-creator` (abrir/atualizar PR), `write-commit` (mensagem de commit e agrupamento em commits), `changelog-writer` (entrada do CHANGELOG) e `fateconnect-create-component` (criar componente no front).
 - `.claude/` é **versionada**: rule e skill passam por review no PR como qualquer código, e valem igual para quem clonar o repo. Por isso a restrição do repositório acima se aplica a elas também.
 
 ## Fluxo de trabalho

--- a/.claude/rules/harness-evolution.md
+++ b/.claude/rules/harness-evolution.md
@@ -58,7 +58,7 @@ Quando a pasta que uma rule descreve deixa de existir, a rule é **deletada, nã
   - **Nenhum budget de token como justificativa.** Rodar script antes de editar à mão é certo por ser completo e repetível — justifique assim. Agente instruído a economizar token começa a pular etapa.
   - **Nenhuma hedge condicional.** Sem "se disponível" ou "senão use como fallback". Nomeie a ferramenta: `AskUserQuestion` para perguntar, `Grep`/`Glob`/`Read` para inspecionar.
 - **Não deixe origem interna vazar do harness para o repo.** O harness é local, mas o que sai dele — código, commit, issue, PR, comentário — é **público**. Quando a orientação vier de fonte interna, registre no repo apenas a **decisão e a justificativa autônoma**, nunca a fonte, o nome do empregador, repositório interno, pacote privado ou ferramenta corporativa.
-- **Não crie artefato de processo para mudar o harness.** Editar `.claude/` não abre issue nem PR — vale o mesmo `⛔` do `CLAUDE.md`.
+- **Não abra issue para mudar o harness — mas o PR é obrigatório.** A dispensa é só da issue. Editar `.claude/` é editar o repositório: sai numa branch a partir da `develop` e volta por PR, como qualquer código. ⛔ **Nada vai direto para a `develop`**, nem uma linha de rule. Já commitei rule e skill direto na `develop` achando que "harness não abre PR" me liberava disso; liberava da issue, e só.
 
 ## Como escrever
 

--- a/.claude/skills/spec-issue/SKILL.md
+++ b/.claude/skills/spec-issue/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: spec-issue
+description: >-
+  Especifica uma issue do GitHub por sabatina — perguntas em blocos até fechar as ambiguidades entre
+  o que a issue diz e o que o código mostra, decisões registradas no corpo da issue e divisão em
+  sub-issues de um PR cada. Use quando o usuário pedir para especificar, detalhar, refinar, planejar
+  ou quebrar uma issue.
+---
+
+# Especificar uma issue
+
+A issue diz o que se quer; o código diz o que existe. A especificação fecha a distância entre os dois — e quem fecha é o usuário, respondendo perguntas, não eu escolhendo em silêncio.
+
+⛔ **Não crie issue, branch ou label sem o usuário pedir.** Esta skill só cria sub-issues depois de listar todas e receber o sim.
+
+## 1. Ler antes de perguntar
+
+Pergunta feita sem ler é pergunta que o repositório já respondia. Antes do primeiro bloco:
+
+- A issue e as que ela cita — `gh issue view <n> --json title,body,comments,milestone,assignees`
+- O **protótipo anexado**, quando houver: o corpo traz um `<img src="https://github.com/user-attachments/...">` e `curl -sL` baixa. Export de tela inteira vem alto demais para uma leitura só — fatiar com `sips` e ler banda a banda
+- A tela ou o módulo mais parecido que já existe — é dele que saem as opções fundamentadas
+- Os arquivos que a mudança vai tocar, com `Grep` e `Read`
+
+Separar o que foi **encontrado** do que é **suposição**. A suposição vai para o corpo da issue com esse nome.
+
+## 2. A sabatina
+
+Blocos de **no máximo quatro perguntas** via `AskUserQuestion` — quatro é o teto do formulário, não uma preferência. Repetir blocos até fechar.
+
+Cada pergunta tem:
+
+- **Opção A** — a recomendação, ancorada em código que você leu, com `caminho/arquivo.tsx:linha`
+- **Opção B** — a alternativa concreta, com o custo dela dito de verdade
+- **"Não sei"** — vira suposição registrada, e você segue com a A
+
+Priorize o que trava decisão adiante: contrato e modelo de dados primeiro, depois navegação e estrutura, por último texto e cor.
+
+⛔ **Não pergunte o que o código responde.** "Qual o limite do campo?" é leitura, não sabatina. Pergunte o que só o usuário sabe: produto, prioridade, e o que o protótipo não mostra.
+
+### A resposta em texto livre é a que muda o desenho
+
+A opção que o usuário digita vale mais que as que você ofereceu — e costuma contradizer algo já decidido. **Antes do bloco seguinte, reconcilie.**
+
+Na #29 o usuário aceitou "item cancelado não aparece na lista" e, na mesma resposta, definiu que cancelado tem a ação **Reabrir**. O que não aparece não dá para reabrir. Nomear a contradição custou uma pergunta; escolher em silêncio teria custado a tela.
+
+Mesma regra quando a resposta cresce o escopo para fora da issue: **diga em qual issue isso cai** e proponha editá-la. O upload de foto da #29 não cabia na #29 — cabia na #106.
+
+## 3. Onde a especificação mora
+
+No **corpo da issue**, que passa a ser o guarda-chuva. Nada de documento à parte: o que não está na issue não é lido por quem implementa.
+
+O corpo carrega, nessa ordem: as decisões em tabela, o modelo de dados ou contrato em bloco de código, as suposições com esse nome, e a referência ao protótipo.
+
+## 4. Dividir em sub-issues
+
+**Uma sub-issue é um PR.** O teste: dá para revisar e reverter sozinha?
+
+- Listar todas antes de criar, com a dependência de cada uma, e pedir confirmação
+- **Copiar, não referenciar** — o contrato vai literal no corpo de cada sub-issue; quem implementa não deveria precisar abrir a pai
+- Mudança de outra camada (um tom novo no design system, um contrato) pode ser sub-issue própria mesmo sem consumidor ainda; recorte de tela, não
+- Sem dependência primeiro; o resto em ordem
+
+Dividir demais é tão errado quanto juntar tudo — mesmo critério da skill `write-commit`.
+
+## 5. Criar
+
+```bash
+gh issue create --title "<pt-BR>" --body-file <arquivo> --assignee <login> --label <label> --milestone "<título>"
+```
+
+`--milestone` casa pelo **título**, não pelo número. Depois, pendurar cada uma na pai:
+
+```bash
+gh api graphql -f query='mutation { addSubIssue(input: {issueId: "<id-pai>", subIssueId: "<id-filha>"}) { subIssue { number } } }'
+```
+
+Os `id` saem de `gh api graphql -f query='{repository(owner:"...",name:"..."){issue(number:N){id}}}'`. O board adota a issue nova sozinho, em `Todo` — conferir com `gh project item-list 1 --owner <owner> --format json`, não supor.
+
+## 6. Varredura de fechamento
+
+Antes de dizer que acabou, cruzar **cada** coisa conversada contra o que entrou. Cada item termina em um de três estados ditos em voz alta: **coberto** (por qual sub-issue), **fora de escopo por decisão** (com o motivo), ou **aberto** (com quem destrava). Item conversado que evapora é o defeito clássico desta skill.
+
+## Armadilhas já pagas
+
+| Sintoma | Causa |
+| --- | --- |
+| A pergunta parece boa e a resposta é "isso está no código" | A sabatina começou antes da leitura |
+| Um bloco contradiz a decisão do bloco anterior | Resposta em texto livre não foi reconciliada |
+| A sub-issue não dá para implementar sem abrir a pai | O contrato foi referenciado em vez de copiado |
+| A issue pai cresce e nunca fecha | Virou guarda-chuva e continuou recebendo código |
+| O escopo que nasceu na conversa some | Caiu em outra issue e ninguém editou aquela issue |

--- a/FateConnect/Web/src/services/rides/types.ts
+++ b/FateConnect/Web/src/services/rides/types.ts
@@ -19,8 +19,7 @@ export type Ride = {
 
 /**
  * Corpo de criação e de atualização — a API aceita o mesmo conjunto de campos
- * nos dois verbos. Vai sempre completo: na atualização o backend atribui a
- * descrição sem checar nulo, então omitir o campo apagaria o que estava lá.
+ * nos dois verbos.
  */
 export type RideInput = Omit<Ride, 'id' | 'dataCadastro' | 'ativo'>;
 


### PR DESCRIPTION
## Objetivo

Registrar no repositório o processo de especificação usado para detalhar a #29, e corrigir a regra do harness que dizia que mudança em `.claude/` não passa por PR.

Sem issue: a mudança nasceu de uma correção durante a própria sessão e o usuário pediu para não abrir issue desta vez.

## Alterações

**Nova skill `spec-issue`** — `.claude/skills/spec-issue/SKILL.md`

- Ler a issue, as issues citadas, o protótipo anexado e o código antes da primeira pergunta, separando o que é **encontrado** do que é **suposição**
- Sabatina em blocos de **no máximo quatro perguntas** via `AskUserQuestion` — quatro é o teto do formulário. Cada pergunta traz a recomendação ancorada em `arquivo:linha`, a alternativa com o custo dela, e "Não sei", que vira suposição registrada
- Reconciliar resposta em texto livre antes do bloco seguinte: é ela que muda o desenho e costuma contradizer decisão anterior
- A especificação mora no **corpo da issue**, que vira guarda-chuva — sem documento à parte
- Divisão em sub-issues de um PR cada, com o contrato **copiado** e não referenciado, e os comandos de `gh issue create` e `addSubIssue`
- Varredura de fechamento: cada item conversado termina como coberto, fora de escopo ou aberto
- Tabela de armadilhas já pagas, ancorada nos erros da #29

**Regra de branch corrigida** — `.claude/rules/harness-evolution.md` e `.claude/CLAUDE.md`

A linha anterior dizia que editar `.claude/` "não abre issue nem PR". A dispensa é só da issue: mudança de harness sai numa branch a partir da `develop` e volta por PR, como o `CLAUDE.md` já afirmava ao descrever a pasta. O `CLAUDE.md` passa a dizer explicitamente que nada vai direto para a `develop`, e que branch sem issue usa slug descritivo.

**Comentário obsoleto removido** — `FateConnect/Web/src/services/rides/types.ts`

As duas linhas que explicavam o bug do #101 descreviam um comportamento que aquele PR corrigiu.

## Evidências

<!-- capturas, se aplicável -->
