### PR TITLE
feat(122): add the muted and danger tones to the status tag

### DIFF
--- a/FateConnect/Web/src/design-system/components/StatusTag/StatusTag.test.tsx
+++ b/FateConnect/Web/src/design-system/components/StatusTag/StatusTag.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from '@app/test/testing-library';
+import { createAppTheme } from '../../theme';
+import { onStatusTagSurface, statusTagSurface } from '../../theme/statusTagSurface';
+import type { StatusTagTone } from '../../theme/statusTagSurface';
+import { StatusTag, type StatusTagProps } from '.';
+
+const LABEL = 'Aberto';
+
+const DEFAULT_PROPS: StatusTagProps = { children: LABEL };
+
+const renderComponent = (props = DEFAULT_PROPS) => render(<StatusTag {...props} />);
+
+/** O `getComputedStyle` devolve `rgb(...)`; os tokens são hexadecimais. */
+function toRgb(hex: string): string {
+  const value = hex.replace('#', '');
+  const [red, green, blue] = [0, 2, 4].map((start) => parseInt(value.slice(start, start + 2), 16));
+
+  return `rgb(${red}, ${green}, ${blue})`;
+}
+
+/** A caixa da etiqueta é o pai do texto, que o `Typography` renderiza. */
+function tagBox(): HTMLElement {
+  const box = screen.getByText(LABEL).parentElement;
+  if (!box) throw new Error('A etiqueta não renderizou a caixa.');
+
+  return box;
+}
+
+const lightTheme = createAppTheme('light');
+const COLOURED_TONES: StatusTagTone[] = ['muted', 'success', 'warning', 'danger'];
+
+describe('StatusTag', () => {
+  it('should render the label it receives', () => {
+    renderComponent();
+
+    expect(screen.getByText(LABEL)).toBeInTheDocument();
+  });
+
+  it.each(COLOURED_TONES)('should paint the %s tone with its own pair', (tone) => {
+    renderComponent({ ...DEFAULT_PROPS, tone });
+
+    const style = getComputedStyle(tagBox());
+
+    expect(style.backgroundColor).toBe(toRgb(statusTagSurface(lightTheme, tone)));
+    expect(style.color).toBe(toRgb(onStatusTagSurface(lightTheme, tone)));
+  });
+
+  // O jsdom resolve `transparent` para o rgba equivalente.
+  it('should leave the default tone without a surface of its own', () => {
+    renderComponent();
+
+    expect(getComputedStyle(tagBox()).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+  });
+});

--- a/FateConnect/Web/src/design-system/components/StatusTag/index.tsx
+++ b/FateConnect/Web/src/design-system/components/StatusTag/index.tsx
@@ -1,8 +1,8 @@
 import Typography from '@mui/material/Typography';
 import type { ReactNode } from 'react';
+import type { StatusTagTone } from '@src-ds/theme/statusTagSurface';
 
 import * as S from './styles';
-import type { StatusTagTone } from './types';
 
 export type StatusTagProps = Readonly<{ tone?: StatusTagTone; children: ReactNode }>;
 

--- a/FateConnect/Web/src/design-system/components/StatusTag/styles.ts
+++ b/FateConnect/Web/src/design-system/components/StatusTag/styles.ts
@@ -1,32 +1,24 @@
 import Box from '@mui/material/Box';
-
-import { styled } from '../../styled';
-import type { PolymorphicProps } from '../../styled';
-import { spacing } from '../../theme/helpers/spacing';
-import { spacingScale } from '../../tokens';
-import type { StatusTagTone } from './types';
+import { styled } from '@src-ds/styled';
+import type { PolymorphicProps } from '@src-ds/styled';
+import { spacing } from '@src-ds/theme/helpers/spacing';
+import { onStatusTagSurface, statusTagSurface } from '@src-ds/theme/statusTagSurface';
+import type { StatusTagTone } from '@src-ds/theme/statusTagSurface';
+import { spacingScale } from '@src-ds/tokens';
 
 const { xxs, sm } = spacingScale;
 
 const TAG_RADIUS_PX = 12;
 
-export const TagRoot = styled(Box)<PolymorphicProps & { tone: StatusTagTone }>(({
-  theme,
-  tone,
-}) => {
-  const tones: Record<StatusTagTone, { background: string; color: string }> = {
-    success: { background: theme.palette.success.light, color: theme.palette.success.main },
-    warning: { background: theme.palette.warning.light, color: theme.palette.warning.main },
-    neutral: { background: 'transparent', color: 'inherit' },
-  };
-
-  return {
+export const TagRoot = styled(Box)<PolymorphicProps & { tone: StatusTagTone }>(
+  ({ theme, tone }) => ({
     // Elemento em linha: a caixa acompanha a altura do texto. A entrelinha
     // neutra evita que ela cresça quando o pai é um contêiner flex.
     display: 'inline',
     lineHeight: 1,
     padding: spacing(xxs, sm),
     borderRadius: `${TAG_RADIUS_PX}px`,
-    ...tones[tone],
-  };
-});
+    background: statusTagSurface(theme, tone),
+    color: onStatusTagSurface(theme, tone),
+  }),
+);

--- a/FateConnect/Web/src/design-system/components/StatusTag/types.ts
+++ b/FateConnect/Web/src/design-system/components/StatusTag/types.ts
@@ -1,2 +1,0 @@
-/** Tom da etiqueta. A cor de cada tom vem da paleta, nos dois temas. */
-export type StatusTagTone = 'neutral' | 'success' | 'warning';

--- a/FateConnect/Web/src/design-system/index.ts
+++ b/FateConnect/Web/src/design-system/index.ts
@@ -26,7 +26,7 @@ export { PageShell } from './components/PageShell';
 export type { PageShellProps } from './components/PageShell';
 export { StatusTag } from './components/StatusTag';
 export type { StatusTagProps } from './components/StatusTag';
-export type { StatusTagTone } from './components/StatusTag/types';
+export type { StatusTagTone } from './theme/statusTagSurface';
 export type { DialogProps } from './components/Dialog';
 
 export { ThemeProvider } from './ThemeProvider';

--- a/FateConnect/Web/src/design-system/theme/contrast.test.ts
+++ b/FateConnect/Web/src/design-system/theme/contrast.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { AA_NORMAL_TEXT, contrastRatio } from './contrast';
 import { chromeSurface, onChromeSurface } from './chromeSurface';
 import { notificationSurface, onNotificationSurface } from './notificationSurface';
+import { onStatusTagSurface, statusTagSurface } from './statusTagSurface';
 import { createAppTheme } from './createAppTheme';
 
 const lightTheme = createAppTheme('light');
@@ -42,8 +43,22 @@ describe('light theme contrast', () => {
     ['content on the secondary colour', palette.secondary.contrastText, palette.secondary.main],
     ['content on the error colour', palette.error.contrastText, palette.error.main],
     ['content on the app chrome', onChromeSurface(lightTheme), chromeSurface(lightTheme)],
-    ['a success tag', palette.success.main, palette.success.light],
-    ['a warning tag', palette.warning.main, palette.warning.light],
+    ['a muted tag', onStatusTagSurface(lightTheme, 'muted'), statusTagSurface(lightTheme, 'muted')],
+    [
+      'a success tag',
+      onStatusTagSurface(lightTheme, 'success'),
+      statusTagSurface(lightTheme, 'success'),
+    ],
+    [
+      'a warning tag',
+      onStatusTagSurface(lightTheme, 'warning'),
+      statusTagSurface(lightTheme, 'warning'),
+    ],
+    [
+      'a danger tag',
+      onStatusTagSurface(lightTheme, 'danger'),
+      statusTagSurface(lightTheme, 'danger'),
+    ],
     [
       'a success notification',
       onNotificationSurface(lightTheme, 'success'),
@@ -76,8 +91,22 @@ describe('dark theme contrast', () => {
     ['content on the secondary colour', palette.secondary.contrastText, palette.secondary.main],
     ['the error colour on the background', palette.error.main, palette.background.default],
     ['content on the app chrome', onChromeSurface(darkTheme), chromeSurface(darkTheme)],
-    ['a success tag', palette.success.main, palette.success.light],
-    ['a warning tag', palette.warning.main, palette.warning.light],
+    ['a muted tag', onStatusTagSurface(darkTheme, 'muted'), statusTagSurface(darkTheme, 'muted')],
+    [
+      'a success tag',
+      onStatusTagSurface(darkTheme, 'success'),
+      statusTagSurface(darkTheme, 'success'),
+    ],
+    [
+      'a warning tag',
+      onStatusTagSurface(darkTheme, 'warning'),
+      statusTagSurface(darkTheme, 'warning'),
+    ],
+    [
+      'a danger tag',
+      onStatusTagSurface(darkTheme, 'danger'),
+      statusTagSurface(darkTheme, 'danger'),
+    ],
     [
       'a success notification',
       onNotificationSurface(darkTheme, 'success'),

--- a/FateConnect/Web/src/design-system/theme/statusTagSurface.test.ts
+++ b/FateConnect/Web/src/design-system/theme/statusTagSurface.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { colorTokens, colorVariants, darkColorTokens } from '../tokens';
+import { createAppTheme } from './createAppTheme';
+import { onStatusTagSurface, statusTagSurface } from './statusTagSurface';
+
+const light = createAppTheme('light');
+const dark = createAppTheme('dark');
+
+describe('statusTagSurface', () => {
+  it('should paint each tone with the product pastel in light mode', () => {
+    expect(statusTagSurface(light, 'muted')).toBe(colorTokens.mutedBackground);
+    expect(statusTagSurface(light, 'success')).toBe(colorTokens.successBackground);
+    expect(statusTagSurface(light, 'warning')).toBe(colorTokens.warningBackground);
+    expect(statusTagSurface(light, 'danger')).toBe(colorTokens.dangerBackground);
+  });
+
+  it('should invert the pair in dark mode, keeping each role', () => {
+    expect(statusTagSurface(dark, 'muted')).toBe(darkColorTokens.mutedTagBackground);
+    expect(statusTagSurface(dark, 'success')).toBe(darkColorTokens.successTagBackground);
+    expect(statusTagSurface(dark, 'warning')).toBe(darkColorTokens.warningTagBackground);
+    expect(statusTagSurface(dark, 'danger')).toBe(darkColorTokens.dangerTagBackground);
+  });
+
+  it('should write with the state colour in light mode', () => {
+    expect(onStatusTagSurface(light, 'muted')).toBe(colorTokens.mutedText);
+    expect(onStatusTagSurface(light, 'success')).toBe(colorTokens.successText);
+    expect(onStatusTagSurface(light, 'warning')).toBe(colorTokens.warningText);
+  });
+
+  // O vermelho do produto dá 4.13:1 sobre o pastel; escurecido, 5.79:1 — a
+  // mesma cor que o aviso de erro usa, para os dois vermelhos não divergirem.
+  it('should reuse the darkened error colour on the danger tone', () => {
+    expect(onStatusTagSurface(light, 'danger')).toBe(colorVariants.secondaryDark);
+  });
+
+  it('should write with the light state colour in dark mode', () => {
+    expect(onStatusTagSurface(dark, 'muted')).toBe(darkColorTokens.mutedTagText);
+    expect(onStatusTagSurface(dark, 'success')).toBe(darkColorTokens.successTagText);
+    expect(onStatusTagSurface(dark, 'warning')).toBe(darkColorTokens.warningTagText);
+    expect(onStatusTagSurface(dark, 'danger')).toBe(darkColorTokens.dangerTagText);
+  });
+
+  // O valor desconhecido aparece como texto corrido, sem caixa; estado que
+  // precisa parecer etiqueta usa `muted`.
+  it('should leave the neutral tone without a surface, in both themes', () => {
+    expect(statusTagSurface(light, 'neutral')).toBe('transparent');
+    expect(statusTagSurface(dark, 'neutral')).toBe('transparent');
+    expect(onStatusTagSurface(light, 'neutral')).toBe('inherit');
+    expect(onStatusTagSurface(dark, 'neutral')).toBe('inherit');
+  });
+});

--- a/FateConnect/Web/src/design-system/theme/statusTagSurface.ts
+++ b/FateConnect/Web/src/design-system/theme/statusTagSurface.ts
@@ -1,0 +1,61 @@
+import type { Theme } from '@mui/material/styles';
+
+import { colorTokens, colorVariants, darkColorTokens } from '../tokens';
+
+/**
+ * Tom da etiqueta de estado. `neutral` é o único que **não desenha caixa**: ele
+ * serve o valor desconhecido, que aparece como texto corrido. Estado que precisa
+ * parecer etiqueta usa `muted`, e não `neutral`.
+ */
+export type StatusTagTone = 'neutral' | 'muted' | 'success' | 'warning' | 'danger';
+
+const NO_SURFACE = 'transparent';
+const INHERITED_CONTENT = 'inherit';
+
+const LIGHT_SURFACE: Record<StatusTagTone, string> = {
+  neutral: NO_SURFACE,
+  muted: colorTokens.mutedBackground,
+  success: colorTokens.successBackground,
+  warning: colorTokens.warningBackground,
+  danger: colorTokens.dangerBackground,
+};
+
+const DARK_SURFACE: Record<StatusTagTone, string> = {
+  neutral: NO_SURFACE,
+  muted: darkColorTokens.mutedTagBackground,
+  success: darkColorTokens.successTagBackground,
+  warning: darkColorTokens.warningTagBackground,
+  danger: darkColorTokens.dangerTagBackground,
+};
+
+const LIGHT_CONTENT: Record<StatusTagTone, string> = {
+  neutral: INHERITED_CONTENT,
+  muted: colorTokens.mutedText,
+  success: colorTokens.successText,
+  warning: colorTokens.warningText,
+  // O vermelho do produto não passa AA sobre o pastel; o mesmo escurecido passa.
+  // É a cor que o aviso de erro já usa, então os dois vermelhos combinam.
+  danger: colorVariants.secondaryDark,
+};
+
+const DARK_CONTENT: Record<StatusTagTone, string> = {
+  neutral: INHERITED_CONTENT,
+  muted: darkColorTokens.mutedTagText,
+  success: darkColorTokens.successTagText,
+  warning: darkColorTokens.warningTagText,
+  danger: darkColorTokens.dangerTagText,
+};
+
+/** Fundo da etiqueta. No tema escuro o par inverte de claridade, não de papel. */
+export function statusTagSurface(theme: Theme, tone: StatusTagTone): string {
+  if (theme.palette.mode === 'dark') return DARK_SURFACE[tone];
+
+  return LIGHT_SURFACE[tone];
+}
+
+/** Cor do texto da etiqueta, medida contra o fundo em `contrast.test.ts`. */
+export function onStatusTagSurface(theme: Theme, tone: StatusTagTone): string {
+  if (theme.palette.mode === 'dark') return DARK_CONTENT[tone];
+
+  return LIGHT_CONTENT[tone];
+}

--- a/FateConnect/Web/src/design-system/tokens/palette.ts
+++ b/FateConnect/Web/src/design-system/tokens/palette.ts
@@ -32,6 +32,9 @@ export const colorTokens = {
   warningText: '#856404',
   warningBackground: '#FFF3CD',
   dangerBackground: '#FFDFDF',
+  /** Estado em repouso: cinza da mesma família dos pastéis acima. */
+  mutedText: '#383D41',
+  mutedBackground: '#E2E3E5',
 
   /** Divisor sobre superfície neutra — linha do formulário de cadastro. */
   divider: '#D9D9D9',
@@ -98,6 +101,8 @@ export const darkColorTokens = {
   warningTagText: '#FFE082',
   dangerTagBackground: '#402422',
   dangerTagText: '#EF9A9A',
+  mutedTagBackground: '#37393B',
+  mutedTagText: '#CFD8DC',
 
   onSurfaceHigh: 'rgba(255, 255, 255, 0.87)',
   onSurfaceMedium: 'rgba(255, 255, 255, 0.60)',


### PR DESCRIPTION
## Objetivo

Dar ao `StatusTag` os dois tons que faltam para as situações de achados e perdidos: **cinza** para o item aberto e **vermelho** para o cancelado. O verde já servia ao concluído.

Segunda das seis sub-issues da #29. Sem consumidor ainda — o cartão da #123 é quem vai usar.

## Alterações

**Helper de cor no tema** — `theme/statusTagSurface.ts`

- `statusTagSurface(theme, tone)` e `onStatusTagSurface(theme, tone)`, no mesmo formato do `notificationSurface.ts` que já existia: mapeiam tom para token e invertem o par no tema escuro
- `StatusTagTone` passou a viver aqui e virou `'neutral' | 'muted' | 'success' | 'warning' | 'danger'`. O `components/StatusTag/types.ts` saiu e o barrel aponta para o helper — o import de fora continua `@design-system`
- `StatusTag/styles.ts` lê o helper no lugar de `theme.palette.success` e `theme.palette.warning`

**Tokens** — `tokens/palette.ts`

- Claro: `mutedText` `#383D41` e `mutedBackground` `#E2E3E5`, na mesma família dos pastéis que já existiam
- Escuro: `mutedTagBackground` `#37393B` e `mutedTagText` `#CFD8DC`. Os tokens de `danger` já estavam lá, servindo o aviso de erro

**Testes**

- `theme/statusTagSurface.test.ts` fixa o par de cada tom nos dois temas
- `components/StatusTag/StatusTag.test.tsx` mede o que o componente renderiza, tom a tom
- `contrast.test.ts` passou a medir os quatro tons **pelos helpers**, e não mais por `palette.success` / `palette.warning`: a etiqueta não lê mais a paleta, então medir a paleta seria medir algo que ninguém desenha

### Por que um helper e não uma chave nova na paleta

`palette.error` já existe, mas com outro contrato: ali `light` é vermelho forte e `contrastText` é branco. Usá-lo na etiqueta daria vermelho sobre vermelho. O repositório já tinha resolvido esse mesmo problema no aviso, com um helper no `theme/` — este segue o mesmo caminho.

O vermelho do tom `danger` **reaproveita o do aviso de erro**: o vermelho cru do produto dá 4,13:1 sobre o pastel e reprova AA; o escurecido passa, e os dois vermelhos do produto não divergem.

`neutral` continua **sem caixa** — ele serve o valor desconhecido, que aparece como texto corrido. Quem precisa parecer etiqueta usa `muted`.

### Contraste medido

| tom | tema claro | tema escuro |
| --- | --- | --- |
| `muted` | 8,55:1 | 8,01:1 |
| `danger` | 5,79:1 | 6,53:1 |

Verificado no `contrast.test.ts` e conferido no navegador, com `getComputedStyle` nos dois temas.

### Sem entrada no CHANGELOG

Os tons novos ainda não têm consumidor, e `success` e `warning` continuam com os mesmos valores — nada muda para quem usa a aplicação hoje. A entrada nasce na #123, com o cartão.

## Issue

- #122

Closes #122

## Evidências

<img width="1340" height="948" alt="image" src="https://github.com/user-attachments/assets/a3e146d7-5907-42ad-907c-fe6c721f3d7c" />
<img width="1340" height="948" alt="image" src="https://github.com/user-attachments/assets/70481169-ff42-40ac-8412-56e8165919ac" />
