### PR TITLE
feat(124): register and edit a lost item in a dialog

### DIFF
--- a/.claude/rules/comentarios.md
+++ b/.claude/rules/comentarios.md
@@ -1,0 +1,20 @@
+---
+description: Quando comentar — só o estritamente essencial, e o teste é se o comentário impede uma mudança errada
+---
+
+# Comentário
+
+⛔ **Comentário só quando for estritamente essencial:** trecho não óbvio, que não se explica sozinho. **Se o código precisa ser explicado, o problema é o código** — renomeie, extraia, simplifique, e o comentário deixa de ser necessário.
+
+**O teste, antes de escrever qualquer um:** este comentário impede alguém de fazer uma mudança errada? Se sim, fica. Se ele só conta o que o código já diz, sai.
+
+Fica: `Concluido` viaja sem acento **porque o backend serializa assim** (sem isso alguém "corrige" o typo). O `Array.isArray` **porque sem endereço de API o dev server responde HTML com 200** (sem isso alguém apaga a guarda como código morto).
+
+Sai, sempre:
+
+- JSDoc que repete a assinatura ou o nome do símbolo — `/** A fileira de ações do cartão. */` sobre `LostItemActions`.
+- Narração do passo seguinte: `// monta os filtros`, `// abre o diálogo`.
+- Parágrafo de contexto que pertence ao corpo do PR ou à issue — por que a API ainda não guarda o arquivo, o que a #106 vai implementar.
+- Comentário que repete a constante declarada logo acima.
+
+⛔ **Cobrança repetida do Victor**, a última em 2026-08-24 com os três PRs de achados e perdidos abertos: *"já falei um milhão de vezes, só colocar comentários quando for estritamente essencial… se o código precisa ser explicado é pq ele está mal escrito"*. A varredura tirou **90 linhas líquidas de comentário de 25 arquivos** nos três PRs, e nenhum teste caiu — nenhuma delas estava segurando nada.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Adiciona o contato de quem ofertou a carona, com o e-mail copiável e a conversa no WhatsApp (#94) [Frontend]
 - Adiciona ofertar e editar carona, que antes só avisavam que a função viria em breve (#97) [Frontend]
 - Adiciona o mural de achados e perdidos, com filtros e a lista de itens, no lugar do aviso de área em breve (#131) [Frontend]
+- Adiciona o cadastro e a edição de item de achados e perdidos, em diálogo sobre a própria lista (#133) [Frontend]
 
 ### Changed
 

--- a/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
@@ -16,6 +16,7 @@ import {
   FILTER_PANEL_TITLE,
   FILTER_SUBMIT_LABEL,
 } from './components/LostItemFilter/constants';
+import { REGISTER_MODE } from './components/LostItemFormDialog/constants';
 import * as C from './constants';
 import { LostAndFound } from '.';
 
@@ -173,5 +174,54 @@ describe('LostAndFound', () => {
     await screen.findAllByText(LOST_ITEM.nome);
     expect(screen.getByTestId('NoBackpackOutlinedIcon')).toBeInTheDocument();
     expect(screen.getByTestId('BackHandOutlinedIcon')).toBeInTheDocument();
+  });
+
+  it('should open on the search tab, with the register dialog closed', () => {
+    listReturning([]);
+
+    renderComponent();
+
+    expect(screen.getByRole('tab', { name: C.SEARCH_TAB_LABEL })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', { name: C.REGISTER_TAB_LABEL })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+    expect(screen.queryByRole('heading', { name: REGISTER_MODE.title })).not.toBeInTheDocument();
+  });
+
+  it('should open the register dialog from the tab, without leaving the route', async () => {
+    listReturning([]);
+    const router = renderComponent();
+
+    await userEvent.click(screen.getByRole('tab', { name: C.REGISTER_TAB_LABEL }));
+
+    expect(await screen.findByRole('heading', { name: REGISTER_MODE.title })).toBeInTheDocument();
+    // O diálogo é modal e esconde a página atrás dele da árvore de
+    // acessibilidade: a aba só é alcançável com `hidden`. O destaque dela é
+    // visual enquanto o diálogo cobre a tela.
+    expect(screen.getByRole('tab', { name: C.REGISTER_TAB_LABEL, hidden: true })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(router.state.location.pathname).toBe(RoutePathEnum.LOST_AND_FOUND);
+  });
+
+  it('should hand the highlight back to the search tab when the dialog is dismissed', async () => {
+    listReturning([]);
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('tab', { name: C.REGISTER_TAB_LABEL }));
+    await screen.findByRole('dialog');
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: C.SEARCH_TAB_LABEL })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      ),
+    );
   });
 });

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/@types/index.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/@types/index.ts
@@ -1,6 +1,5 @@
 import type { SvgIconComponent } from '@design-system/icons';
 
-/** Textos e ícone que separam cadastrar de editar; o resto do diálogo é igual. */
 export type LostItemFormMode = Readonly<{
   title: string;
   submitLabel: string;

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/@types/index.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/@types/index.ts
@@ -1,0 +1,10 @@
+import type { SvgIconComponent } from '@design-system/icons';
+
+/** Textos e ícone que separam cadastrar de editar; o resto do diálogo é igual. */
+export type LostItemFormMode = Readonly<{
+  title: string;
+  submitLabel: string;
+  submitIcon: SvgIconComponent;
+  succeeded: string;
+  failed: string;
+}>;

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormDialog.test.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormDialog.test.tsx
@@ -1,0 +1,237 @@
+import { format } from 'date-fns';
+import { http, HttpResponse } from 'msw';
+
+import { server } from '@app/mocks/server';
+import {
+  LostItemKindEnum,
+  LostItemStatusEnum,
+  type LostItem,
+  type LostItemInput,
+} from '@app/services/lostAndFound/types';
+import { fireEvent, render, screen, userEvent, waitFor } from '@app/test/testing-library';
+import { toApiDate } from '@app/utils/apiDate';
+
+import {
+  EDIT_MODE,
+  LOST_ITEM_FORM_LABELS,
+  MAX_PHOTO_BYTES,
+  PHOTO_ACTIONS,
+  REGISTER_MODE,
+} from './constants';
+import { LostItemFormDialog, type LostItemFormDialogProps } from '.';
+
+const LOST_AND_FOUND_URL = 'https://api.fateconnect.test/achado';
+
+const PREVIEW_URL = 'blob:https://fateconnect.test/preview';
+
+const OCCURRED_AT = new Date(2026, 7, 11);
+/** O seletor do MUI recebe a data seção a seção, na ordem de pt-BR. */
+const TYPED_DATE = format(OCCURRED_AT, 'ddMMyyyy');
+
+const LOST_ITEM: LostItem = {
+  id: 'c4a1f0d2-5b3e-4a6c-9f81-7d2e5b0a3c14',
+  nome: 'Carteira preta',
+  tipo: LostItemKindEnum.LOST,
+  local: 'Biblioteca',
+  dataOcorrido: '2026-08-11T00:00:00',
+  descricao: 'Carteira de couro preta com documentos.',
+  fotoUrl: null,
+  situacao: LostItemStatusEnum.OPEN,
+  motivoCancelamento: null,
+  meuItem: true,
+  dataCadastro: '2026-08-12T00:00:00',
+};
+
+const onClose = vi.fn();
+
+const DEFAULT_PROPS: LostItemFormDialogProps = { open: true, onClose, item: undefined };
+
+const renderComponent = (props = DEFAULT_PROPS) => render(<LostItemFormDialog {...props} />);
+
+const nameField = () =>
+  screen.getByRole('textbox', { name: new RegExp(LOST_ITEM_FORM_LABELS.name) });
+
+const photoInput = () => screen.getByLabelText(LOST_ITEM_FORM_LABELS.photo);
+
+function photoOf(fileName: string, type: string, sizeInBytes?: number): File {
+  const photo = new File(['conteúdo'], fileName, { type });
+  if (sizeInBytes !== undefined) Object.defineProperty(photo, 'size', { value: sizeInBytes });
+
+  return photo;
+}
+
+describe('LostItemFormDialog', () => {
+  beforeEach(() => {
+    // jsdom não implementa a fábrica de URL de objeto, e é dela que sai a prévia.
+    URL.createObjectURL = vi.fn(() => PREVIEW_URL);
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should register an item when it gets no item to edit', async () => {
+    renderComponent();
+
+    expect(await screen.findByRole('heading', { name: REGISTER_MODE.title })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: REGISTER_MODE.submitLabel })).toBeInTheDocument();
+    expect(nameField()).toHaveValue('');
+  });
+
+  it('should edit the item it gets, already filled in', async () => {
+    renderComponent({ ...DEFAULT_PROPS, item: LOST_ITEM });
+
+    expect(await screen.findByRole('heading', { name: EDIT_MODE.title })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: EDIT_MODE.submitLabel })).toBeInTheDocument();
+    expect(nameField()).toHaveValue(LOST_ITEM.nome);
+    expect(
+      screen.getByRole('textbox', { name: new RegExp(LOST_ITEM_FORM_LABELS.place) }),
+    ).toHaveValue(LOST_ITEM.local);
+    expect(
+      screen.getByRole('textbox', { name: new RegExp(LOST_ITEM_FORM_LABELS.description) }),
+    ).toHaveValue(LOST_ITEM.descricao);
+  });
+
+  it('should refuse to submit an empty form and say what is missing', async () => {
+    renderComponent();
+    await screen.findByRole('heading', { name: REGISTER_MODE.title });
+    let requested = false;
+    server.use(
+      http.post(LOST_AND_FOUND_URL, () => {
+        requested = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: REGISTER_MODE.submitLabel }));
+
+    expect(await screen.findByText(/nome deve ter ao menos/i)).toBeInTheDocument();
+    expect(screen.getByText(/local deve ter ao menos/i)).toBeInTheDocument();
+    expect(requested).toBe(false);
+  });
+
+  it('should send the whole item on update, so the description survives', async () => {
+    let body: LostItemInput | null = null;
+    server.use(
+      http.put(`${LOST_AND_FOUND_URL}/:id`, async ({ request }) => {
+        body = (await request.json()) as LostItemInput;
+        return HttpResponse.json({ id: LOST_ITEM.id });
+      }),
+    );
+    renderComponent({ ...DEFAULT_PROPS, item: LOST_ITEM });
+    await screen.findByRole('heading', { name: EDIT_MODE.title });
+
+    await userEvent.click(screen.getByRole('button', { name: EDIT_MODE.submitLabel }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(body).toEqual({
+      nome: LOST_ITEM.nome,
+      tipo: LOST_ITEM.tipo,
+      local: LOST_ITEM.local,
+      dataOcorrido: '2026-08-11',
+      descricao: LOST_ITEM.descricao,
+    });
+  });
+
+  it('should keep the dialog open when the api fails, with what was typed', async () => {
+    server.use(
+      http.put(`${LOST_AND_FOUND_URL}/:id`, () => new HttpResponse(null, { status: 500 })),
+    );
+    renderComponent({ ...DEFAULT_PROPS, item: LOST_ITEM });
+    await screen.findByRole('heading', { name: EDIT_MODE.title });
+
+    await userEvent.click(screen.getByRole('button', { name: EDIT_MODE.submitLabel }));
+
+    expect(await screen.findByText(EDIT_MODE.failed)).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(nameField()).toHaveValue(LOST_ITEM.nome);
+  });
+
+  it('should register the item the form describes', async () => {
+    let body: LostItemInput | null = null;
+    server.use(
+      http.post(LOST_AND_FOUND_URL, async ({ request }) => {
+        body = (await request.json()) as LostItemInput;
+        return HttpResponse.json({ id: 'novo' }, { status: 201 });
+      }),
+    );
+    renderComponent();
+    await screen.findByRole('heading', { name: REGISTER_MODE.title });
+
+    await userEvent.type(nameField(), 'Garrafa térmica');
+    await userEvent.click(
+      screen.getByRole('combobox', { name: new RegExp(LOST_ITEM_FORM_LABELS.kind) }),
+    );
+    await userEvent.click(await screen.findByRole('option', { name: LostItemKindEnum.FOUND }));
+    await userEvent.type(
+      screen.getByRole('textbox', { name: new RegExp(LOST_ITEM_FORM_LABELS.place) }),
+      'Bloco C',
+    );
+    await userEvent.click(
+      screen.getByRole('group', { name: new RegExp(LOST_ITEM_FORM_LABELS.occurredOn) }),
+    );
+    await userEvent.keyboard(TYPED_DATE);
+
+    await userEvent.click(screen.getByRole('button', { name: REGISTER_MODE.submitLabel }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(body).toEqual({
+      nome: 'Garrafa térmica',
+      tipo: LostItemKindEnum.FOUND,
+      local: 'Bloco C',
+      dataOcorrido: toApiDate(OCCURRED_AT),
+      descricao: '',
+    });
+  });
+
+  it('should show the chosen photo and let the user drop it', async () => {
+    renderComponent();
+    await screen.findByRole('heading', { name: REGISTER_MODE.title });
+
+    await userEvent.upload(photoInput(), photoOf('achado.png', 'image/png'));
+
+    const preview = await screen.findByRole('img', { name: PHOTO_ACTIONS.previewAlt });
+    expect(preview).toHaveAttribute('src', PREVIEW_URL);
+    expect(screen.getByRole('button', { name: PHOTO_ACTIONS.replace })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: PHOTO_ACTIONS.remove }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole('img', { name: PHOTO_ACTIONS.previewAlt })).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: PHOTO_ACTIONS.pick })).toBeInTheDocument();
+  });
+
+  it('should refuse a photo in a format the server will not take', async () => {
+    let requested = false;
+    server.use(
+      http.post(LOST_AND_FOUND_URL, () => {
+        requested = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+    );
+    renderComponent();
+    await screen.findByRole('heading', { name: REGISTER_MODE.title });
+
+    // Pelo `userEvent` o arquivo nem chega ao campo: o atributo `accept` o
+    // descarta antes. Quem tem de barrá-lo é a validação, e é ela que este caso
+    // exercita — o atributo é conveniência, não a regra.
+    fireEvent.change(photoInput(), { target: { files: [photoOf('achado.gif', 'image/gif')] } });
+
+    expect(await screen.findByText(/foto deve ser JPG, PNG ou WebP/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: REGISTER_MODE.submitLabel }));
+
+    expect(requested).toBe(false);
+  });
+
+  it('should refuse a photo heavier than the limit', async () => {
+    renderComponent();
+    await screen.findByRole('heading', { name: REGISTER_MODE.title });
+
+    await userEvent.upload(photoInput(), photoOf('achado.png', 'image/png', MAX_PHOTO_BYTES + 1));
+
+    expect(await screen.findByText(/foto deve ter no máximo/i)).toBeInTheDocument();
+  });
+});

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
@@ -8,11 +8,6 @@ import type { LostItemFormInput, LostItemFormValues } from '../../schema';
 import * as C from '../../constants';
 import * as S from './styles';
 
-/**
- * Enquanto a API não guarda o arquivo, a prévia sai de `URL.createObjectURL` e
- * vive só enquanto a página estiver aberta. A validação de formato e tamanho já
- * é a regra que o servidor vai repetir.
- */
 export function LostItemPhotoField() {
   const {
     control,
@@ -22,8 +17,6 @@ export function LostItemPhotoField() {
   const photo = useWatch({ control, name: 'photo' });
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // O endereço é derivado do arquivo, não guardado em estado: assim ele nunca
-  // sobrevive à foto que o descreve — nem quando o formulário é reiniciado.
   const previewUrl = useMemo(() => {
     if (!photo) return null;
 
@@ -42,8 +35,7 @@ export function LostItemPhotoField() {
     (event: ChangeEvent<HTMLInputElement>) => {
       const [chosen] = event.target.files ?? [];
       setValue('photo', chosen ?? null, { shouldValidate: true });
-      // Zerar o campo faz o mesmo arquivo, escolhido de novo depois de removido,
-      // voltar a disparar a troca.
+      // Zerar o campo deixa o mesmo arquivo, escolhido de novo, disparar a troca.
       event.target.value = '';
     },
     [setValue],

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, type ChangeEvent } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
+import * as C from '@app/pages/LostAndFound/components/LostItemFormDialog/constants';
+import type {
+  LostItemFormInput,
+  LostItemFormValues,
+} from '@app/pages/LostAndFound/components/LostItemFormDialog/schema';
 import { Typography } from '@design-system';
 import { DeleteIcon, ImageIcon } from '@design-system/icons';
 
-import type { LostItemFormInput, LostItemFormValues } from '../../schema';
-import * as C from '../../constants';
 import * as S from './styles';
 
 export function LostItemPhotoField() {

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useMemo, useRef, type ChangeEvent } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { Typography } from '@design-system';
+import { DeleteIcon, ImageIcon } from '@design-system/icons';
+
+import type { LostItemFormInput, LostItemFormValues } from '../../schema';
+import * as C from '../../constants';
+import * as S from './styles';
+
+/**
+ * Enquanto a API não guarda o arquivo, a prévia sai de `URL.createObjectURL` e
+ * vive só enquanto a página estiver aberta. A validação de formato e tamanho já
+ * é a regra que o servidor vai repetir.
+ */
+export function LostItemPhotoField() {
+  const {
+    control,
+    setValue,
+    formState: { errors, disabled },
+  } = useFormContext<LostItemFormInput, unknown, LostItemFormValues>();
+  const photo = useWatch({ control, name: 'photo' });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // O endereço é derivado do arquivo, não guardado em estado: assim ele nunca
+  // sobrevive à foto que o descreve — nem quando o formulário é reiniciado.
+  const previewUrl = useMemo(() => {
+    if (!photo) return null;
+
+    return URL.createObjectURL(photo);
+  }, [photo]);
+
+  useEffect(() => {
+    if (!previewUrl) return;
+
+    return () => URL.revokeObjectURL(previewUrl);
+  }, [previewUrl]);
+
+  const handlePick = useCallback(() => fileInputRef.current?.click(), []);
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const [chosen] = event.target.files ?? [];
+      setValue('photo', chosen ?? null, { shouldValidate: true });
+      // Zerar o campo faz o mesmo arquivo, escolhido de novo depois de removido,
+      // voltar a disparar a troca.
+      event.target.value = '';
+    },
+    [setValue],
+  );
+
+  const handleRemove = useCallback(
+    () => setValue('photo', null, { shouldValidate: true }),
+    [setValue],
+  );
+
+  const pickLabel = useMemo(() => {
+    if (photo) return C.PHOTO_ACTIONS.replace;
+
+    return C.PHOTO_ACTIONS.pick;
+  }, [photo]);
+
+  const errorMessage = errors.photo?.message;
+
+  return (
+    <S.PhotoField>
+      <Typography variant="caption">{C.LOST_ITEM_FORM_LABELS.photo}</Typography>
+
+      <S.PhotoRow>
+        {previewUrl && <S.PhotoPreview src={previewUrl} alt={C.PHOTO_ACTIONS.previewAlt} />}
+
+        <S.PhotoActions>
+          <S.PhotoActionButton variant="outlined" onClick={handlePick} disabled={disabled}>
+            <ImageIcon fontSize="small" />
+            <Typography variant="caption" color="inherit">
+              {pickLabel}
+            </Typography>
+          </S.PhotoActionButton>
+
+          {photo && (
+            <S.PhotoActionButton
+              variant="outlined"
+              color="error"
+              onClick={handleRemove}
+              disabled={disabled}
+            >
+              <DeleteIcon fontSize="small" />
+              <Typography variant="caption" color="inherit">
+                {C.PHOTO_ACTIONS.remove}
+              </Typography>
+            </S.PhotoActionButton>
+          )}
+        </S.PhotoActions>
+      </S.PhotoRow>
+
+      <S.HiddenFileInput
+        ref={fileInputRef}
+        type="file"
+        accept={C.PHOTO_ACCEPT_ATTRIBUTE}
+        aria-label={C.LOST_ITEM_FORM_LABELS.photo}
+        disabled={disabled}
+        onChange={handleFileChange}
+      />
+
+      {errorMessage && (
+        <S.PhotoError>
+          <Typography variant="caption" color="inherit">
+            {errorMessage}
+          </Typography>
+        </S.PhotoError>
+      )}
+
+      {!errorMessage && (
+        <S.PhotoHint>
+          <Typography variant="caption" color="inherit">
+            {C.PHOTO_HINT}
+          </Typography>
+        </S.PhotoHint>
+      )}
+    </S.PhotoField>
+  );
+}

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
@@ -83,6 +83,22 @@ export function LostItemPhotoField() {
             </S.PhotoActionButton>
           )}
         </S.PhotoActions>
+
+        {errorMessage && (
+          <S.PhotoError>
+            <Typography variant="caption" color="inherit">
+              {errorMessage}
+            </Typography>
+          </S.PhotoError>
+        )}
+
+        {!errorMessage && (
+          <S.PhotoHint>
+            <Typography variant="caption" color="inherit">
+              {C.PHOTO_HINT}
+            </Typography>
+          </S.PhotoHint>
+        )}
       </S.PhotoRow>
 
       <S.HiddenFileInput
@@ -93,22 +109,6 @@ export function LostItemPhotoField() {
         disabled={disabled}
         onChange={handleFileChange}
       />
-
-      {errorMessage && (
-        <S.PhotoError>
-          <Typography variant="caption" color="inherit">
-            {errorMessage}
-          </Typography>
-        </S.PhotoError>
-      )}
-
-      {!errorMessage && (
-        <S.PhotoHint>
-          <Typography variant="caption" color="inherit">
-            {C.PHOTO_HINT}
-          </Typography>
-        </S.PhotoHint>
-      )}
     </S.PhotoField>
   );
 }

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
@@ -1,0 +1,66 @@
+import {
+  Box,
+  Button,
+  compactMedia,
+  radius,
+  radiusScale,
+  spacing,
+  spacingScale,
+  Stack,
+  styled,
+  type PolymorphicProps,
+} from '@design-system';
+
+const { xxs, xs, sm } = spacingScale;
+
+const PREVIEW_SIZE_PX = 96;
+
+export const PhotoField = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'column',
+  gap: spacing(xxs),
+});
+
+export const PhotoRow = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: spacing(sm),
+
+  [compactMedia]: { flexDirection: 'column', alignItems: 'flex-start' },
+});
+
+export const PhotoPreview = styled('img')({
+  width: `${PREVIEW_SIZE_PX}px`,
+  height: `${PREVIEW_SIZE_PX}px`,
+  flexShrink: 0,
+  objectFit: 'cover',
+  borderRadius: radius(radiusScale.md),
+});
+
+export const PhotoActions = styled(Stack)<PolymorphicProps>({
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  gap: spacing(xs),
+});
+
+export const PhotoActionButton = styled(Button)({
+  gap: spacing(xxs),
+  borderRadius: radius(radiusScale.component),
+});
+
+/** Fora da vista, mas ainda focável e rotulado: o botão é quem o aciona. */
+export const HiddenFileInput = styled('input')({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+});
+
+export const PhotoHint = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.text.secondary,
+}));
+
+export const PhotoError = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  color: theme.palette.error.main,
+}));

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
@@ -23,7 +23,6 @@ export const PhotoField = styled(Stack)<PolymorphicProps>({
 export const PhotoRow = styled(Stack)<PolymorphicProps>({
   flexDirection: 'row',
   alignItems: 'center',
-  justifyContent: 'space-between',
   gap: spacing(sm),
 
   [compactMedia]: { flexDirection: 'column', alignItems: 'flex-start' },
@@ -58,9 +57,11 @@ export const HiddenFileInput = styled('input')({
 });
 
 export const PhotoHint = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  flex: 1,
   color: theme.palette.text.secondary,
 }));
 
 export const PhotoError = styled(Box)<PolymorphicProps>(({ theme }) => ({
+  flex: 1,
   color: theme.palette.error.main,
 }));

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
@@ -37,7 +37,6 @@ export const PhotoPreview = styled('img')({
   borderRadius: radius(radiusScale.md),
 });
 
-/** Empilhadas, as duas ações saem com a mesma largura e não disputam a linha. */
 export const PhotoActions = styled(Stack)<PolymorphicProps>({
   flexDirection: 'column',
   gap: spacing(xs),
@@ -48,7 +47,7 @@ export const PhotoActionButton = styled(Button)({
   borderRadius: radius(radiusScale.component),
 });
 
-/** Fora da vista, mas ainda focável e rotulado: o botão é quem o aciona. */
+/** Fora da vista, mas focável e rotulado: quem o aciona é o botão. */
 export const HiddenFileInput = styled('input')({
   position: 'absolute',
   width: '1px',

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
@@ -23,6 +23,7 @@ export const PhotoField = styled(Stack)<PolymorphicProps>({
 export const PhotoRow = styled(Stack)<PolymorphicProps>({
   flexDirection: 'row',
   alignItems: 'center',
+  justifyContent: 'space-between',
   gap: spacing(sm),
 
   [compactMedia]: { flexDirection: 'column', alignItems: 'flex-start' },
@@ -36,9 +37,9 @@ export const PhotoPreview = styled('img')({
   borderRadius: radius(radiusScale.md),
 });
 
+/** Empilhadas, as duas ações saem com a mesma largura e não disputam a linha. */
 export const PhotoActions = styled(Stack)<PolymorphicProps>({
-  flexDirection: 'row',
-  flexWrap: 'wrap',
+  flexDirection: 'column',
   gap: spacing(xs),
 });
 

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/styles.ts
@@ -14,6 +14,8 @@ import {
 const { xxs, xs, sm } = spacingScale;
 
 const PREVIEW_SIZE_PX = 96;
+/** No estreito a miniatura encolhe para a foto e os botões caberem na mesma linha. */
+const COMPACT_PREVIEW_SIZE_PX = 72;
 
 export const PhotoField = styled(Stack)<PolymorphicProps>({
   flexDirection: 'column',
@@ -23,14 +25,18 @@ export const PhotoField = styled(Stack)<PolymorphicProps>({
 export const PhotoRow = styled(Stack)<PolymorphicProps>({
   flexDirection: 'row',
   alignItems: 'center',
+  flexWrap: 'wrap',
   gap: spacing(sm),
-
-  [compactMedia]: { flexDirection: 'column', alignItems: 'flex-start' },
 });
 
 export const PhotoPreview = styled('img')({
   width: `${PREVIEW_SIZE_PX}px`,
   height: `${PREVIEW_SIZE_PX}px`,
+
+  [compactMedia]: {
+    width: `${COMPACT_PREVIEW_SIZE_PX}px`,
+    height: `${COMPACT_PREVIEW_SIZE_PX}px`,
+  },
   flexShrink: 0,
   objectFit: 'cover',
   borderRadius: radius(radiusScale.md),
@@ -56,12 +62,17 @@ export const HiddenFileInput = styled('input')({
   whiteSpace: 'nowrap',
 });
 
+/** No estreito a foto e os botões seguem lado a lado, e o texto desce inteiro. */
 export const PhotoHint = styled(Box)<PolymorphicProps>(({ theme }) => ({
   flex: 1,
   color: theme.palette.text.secondary,
+
+  [compactMedia]: { flexBasis: '100%' },
 }));
 
 export const PhotoError = styled(Box)<PolymorphicProps>(({ theme }) => ({
   flex: 1,
   color: theme.palette.error.main,
+
+  [compactMedia]: { flexBasis: '100%' },
 }));

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/index.tsx
@@ -1,0 +1,91 @@
+import { useMemo } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+import { fromFormDate, toFormDate } from '@app/utils/apiDate';
+import { Input } from '@design-system';
+
+import type { LostItemFormInput, LostItemFormValues } from '../schema';
+import * as C from '../constants';
+import { LostItemPhotoField } from './LostItemPhotoField';
+import * as S from './styles';
+
+/** Os seis campos do item: duas colunas, descrição e foto na linha inteira. */
+export function LostItemFormFields() {
+  const {
+    control,
+    register,
+    formState: { errors },
+  } = useFormContext<LostItemFormInput, unknown, LostItemFormValues>();
+  // Item achado ou perdido só pode ter ocorrido até hoje.
+  const today = useMemo(() => new Date(), []);
+
+  return (
+    <S.FieldsGrid>
+      <Input
+        {...register('name')}
+        label={C.LOST_ITEM_FORM_LABELS.name}
+        required
+        fullWidth
+        placeholder={C.LOST_ITEM_FORM_PLACEHOLDERS.name}
+        error={errors.name?.message}
+      />
+
+      <Controller
+        name="kind"
+        control={control}
+        render={({ field }) => (
+          <Input.Select
+            {...field}
+            label={C.LOST_ITEM_FORM_LABELS.kind}
+            options={C.LOST_ITEM_KIND_SELECT_OPTIONS}
+            required
+            error={errors.kind?.message}
+          />
+        )}
+      />
+
+      <Input
+        {...register('place')}
+        label={C.LOST_ITEM_FORM_LABELS.place}
+        required
+        fullWidth
+        placeholder={C.LOST_ITEM_FORM_PLACEHOLDERS.place}
+        error={errors.place?.message}
+      />
+
+      <Controller
+        name="occurredOn"
+        control={control}
+        render={({ field }) => (
+          <Input.Date
+            name={field.name}
+            label={C.LOST_ITEM_FORM_LABELS.occurredOn}
+            required
+            value={fromFormDate(field.value)}
+            onChange={(date) => field.onChange(toFormDate(date))}
+            onBlur={field.onBlur}
+            disabled={field.disabled}
+            maxDate={today}
+            error={errors.occurredOn?.message}
+          />
+        )}
+      />
+
+      <S.WideCell>
+        <Input
+          {...register('description')}
+          label={C.LOST_ITEM_FORM_LABELS.description}
+          fullWidth
+          multiline
+          rows={C.DESCRIPTION_ROWS}
+          placeholder={C.LOST_ITEM_FORM_PLACEHOLDERS.description}
+          error={errors.description?.message}
+        />
+      </S.WideCell>
+
+      <S.WideCell>
+        <LostItemPhotoField />
+      </S.WideCell>
+    </S.FieldsGrid>
+  );
+}

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/index.tsx
@@ -9,14 +9,12 @@ import * as C from '../constants';
 import { LostItemPhotoField } from './LostItemPhotoField';
 import * as S from './styles';
 
-/** Os seis campos do item: duas colunas, descrição e foto na linha inteira. */
 export function LostItemFormFields() {
   const {
     control,
     register,
     formState: { errors },
   } = useFormContext<LostItemFormInput, unknown, LostItemFormValues>();
-  // Item achado ou perdido só pode ter ocorrido até hoje.
   const today = useMemo(() => new Date(), []);
 
   return (

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/styles.ts
@@ -1,0 +1,17 @@
+import { Box, mobileMedia, spacing, spacingScale, styled } from '@design-system';
+
+const { sm, md } = spacingScale;
+
+export const FieldsGrid = styled(Box)({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: spacing(md),
+  // Editando, os campos chegam preenchidos e o rótulo sobe acima da borda. Sem
+  // este respiro a primeira linha sairia cortada pela rolagem do diálogo.
+  paddingTop: spacing(sm),
+
+  [mobileMedia]: { gridTemplateColumns: '1fr' },
+});
+
+/** Ocupa a linha inteira, em qualquer largura. */
+export const WideCell = styled(Box)({ gridColumn: '1 / -1' });

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/styles.ts
@@ -6,12 +6,10 @@ export const FieldsGrid = styled(Box)({
   display: 'grid',
   gridTemplateColumns: '1fr 1fr',
   gap: spacing(md),
-  // Editando, os campos chegam preenchidos e o rótulo sobe acima da borda. Sem
-  // este respiro a primeira linha sairia cortada pela rolagem do diálogo.
+  // Respiro para o rótulo do campo preenchido não sair cortado na rolagem.
   paddingTop: spacing(sm),
 
   [mobileMedia]: { gridTemplateColumns: '1fr' },
 });
 
-/** Ocupa a linha inteira, em qualquer largura. */
 export const WideCell = styled(Box)({ gridColumn: '1 / -1' });

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/constants/index.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/constants/index.ts
@@ -4,7 +4,6 @@ import { AddIcon, SaveIcon } from '@design-system/icons';
 
 import type { LostItemFormMode } from '../@types';
 
-/** Limites do contrato do módulo, espelhados no front. */
 export const LOST_ITEM_LIMITS = {
   minName: 3,
   maxName: 100,
@@ -12,21 +11,19 @@ export const LOST_ITEM_LIMITS = {
   maxPlace: 100,
   maxDescription: 300,
   maxPhotoMegabytes: 5,
-  /** `File.size` vem em bytes, e o limite de produto é falado em megabytes. */
   bytesPerMegabyte: 1_048_576,
 };
 
 export const MAX_PHOTO_BYTES =
   LOST_ITEM_LIMITS.maxPhotoMegabytes * LOST_ITEM_LIMITS.bytesPerMegabyte;
 
-/** A mesma regra que o servidor vai repetir quando a #106 guardar o arquivo. */
 export const ACCEPTED_PHOTO_TYPES: ReadonlySet<string> = new Set([
   'image/jpeg',
   'image/png',
   'image/webp',
 ]);
 
-/** O que o seletor do sistema oferece; o schema não confia nisso. */
+/** Só filtra o seletor do sistema; quem valida o formato é o schema. */
 export const PHOTO_ACCEPT_ATTRIBUTE = [...ACCEPTED_PHOTO_TYPES].join(',');
 
 export const REGISTER_MODE: LostItemFormMode = {
@@ -74,7 +71,6 @@ export const PHOTO_HINT = `JPG, PNG ou WebP, até ${LOST_ITEM_LIMITS.maxPhotoMeg
 
 const EMPTY_CHOICE: SelectOption = { value: '', label: LOST_ITEM_FORM_PLACEHOLDERS.select };
 
-/** As escolhas do campo, já com a opção vazia na frente. */
 export const LOST_ITEM_KIND_SELECT_OPTIONS: readonly SelectOption[] = [
   EMPTY_CHOICE,
   ...LOST_ITEM_KIND_OPTIONS,

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/constants/index.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/constants/index.ts
@@ -1,0 +1,94 @@
+import { LOST_ITEM_KIND_OPTIONS } from '@app/pages/LostAndFound/helpers/lostItemKind';
+import type { SelectOption } from '@design-system';
+import { AddIcon, SaveIcon } from '@design-system/icons';
+
+import type { LostItemFormMode } from '../@types';
+
+/** Limites do contrato do módulo, espelhados no front. */
+export const LOST_ITEM_LIMITS = {
+  minName: 3,
+  maxName: 100,
+  minPlace: 3,
+  maxPlace: 100,
+  maxDescription: 300,
+  maxPhotoMegabytes: 5,
+  /** `File.size` vem em bytes, e o limite de produto é falado em megabytes. */
+  bytesPerMegabyte: 1_048_576,
+};
+
+export const MAX_PHOTO_BYTES =
+  LOST_ITEM_LIMITS.maxPhotoMegabytes * LOST_ITEM_LIMITS.bytesPerMegabyte;
+
+/** A mesma regra que o servidor vai repetir quando a #106 guardar o arquivo. */
+export const ACCEPTED_PHOTO_TYPES: ReadonlySet<string> = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+/** O que o seletor do sistema oferece; o schema não confia nisso. */
+export const PHOTO_ACCEPT_ATTRIBUTE = [...ACCEPTED_PHOTO_TYPES].join(',');
+
+export const REGISTER_MODE: LostItemFormMode = {
+  title: 'Cadastrar Item',
+  submitLabel: 'Cadastrar Item',
+  submitIcon: AddIcon,
+  succeeded: 'Item cadastrado com sucesso.',
+  failed: 'Erro ao cadastrar o item. Tente novamente.',
+};
+
+export const EDIT_MODE: LostItemFormMode = {
+  title: 'Editar Item',
+  submitLabel: 'Salvar Alterações',
+  submitIcon: SaveIcon,
+  succeeded: 'Item atualizado com sucesso.',
+  failed: 'Erro ao atualizar o item. Tente novamente.',
+};
+
+export const LOST_ITEM_FORM_LABELS = {
+  name: 'Nome do Item',
+  kind: 'Tipo',
+  place: 'Local',
+  occurredOn: 'Data do Ocorrido',
+  description: 'Descrição',
+  photo: 'Foto',
+};
+
+export const LOST_ITEM_FORM_PLACEHOLDERS = {
+  name: 'Digite o nome do item',
+  place: 'Onde o item foi achado ou perdido',
+  select: 'Selecione',
+  description: 'Descreva o item com detalhes',
+};
+
+export const DESCRIPTION_ROWS = 3;
+
+export const PHOTO_ACTIONS = {
+  pick: 'Escolher Foto',
+  replace: 'Trocar Foto',
+  remove: 'Remover Foto',
+  previewAlt: 'Prévia da foto escolhida',
+};
+
+export const PHOTO_HINT = `JPG, PNG ou WebP, até ${LOST_ITEM_LIMITS.maxPhotoMegabytes} MB.`;
+
+const EMPTY_CHOICE: SelectOption = { value: '', label: LOST_ITEM_FORM_PLACEHOLDERS.select };
+
+/** As escolhas do campo, já com a opção vazia na frente. */
+export const LOST_ITEM_KIND_SELECT_OPTIONS: readonly SelectOption[] = [
+  EMPTY_CHOICE,
+  ...LOST_ITEM_KIND_OPTIONS,
+];
+
+export const LOST_ITEM_FORM_MESSAGES = {
+  nameTooShort: `O nome deve ter ao menos ${LOST_ITEM_LIMITS.minName} caracteres`,
+  nameTooLong: `O nome deve ter no máximo ${LOST_ITEM_LIMITS.maxName} caracteres`,
+  kindRequired: 'Selecione o tipo',
+  placeTooShort: `O local deve ter ao menos ${LOST_ITEM_LIMITS.minPlace} caracteres`,
+  placeTooLong: `O local deve ter no máximo ${LOST_ITEM_LIMITS.maxPlace} caracteres`,
+  occurredOnRequired: 'Informe a data do ocorrido',
+  occurredOnInFuture: 'A data do ocorrido não pode ser futura',
+  descriptionTooLong: `A descrição pode ter no máximo ${LOST_ITEM_LIMITS.maxDescription} caracteres`,
+  photoFormatInvalid: 'A foto deve ser JPG, PNG ou WebP',
+  photoTooLarge: `A foto deve ter no máximo ${LOST_ITEM_LIMITS.maxPhotoMegabytes} MB`,
+};

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/helpers/mapper.test.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/helpers/mapper.test.ts
@@ -1,0 +1,66 @@
+import {
+  LostItemKindEnum,
+  LostItemStatusEnum,
+  type LostItem,
+} from '@app/services/lostAndFound/types';
+
+import { EMPTY_LOST_ITEM_FORM, type LostItemFormValues } from '../schema';
+import { toFormValues, toLostItemInput } from './mapper';
+
+const LOST_ITEM: LostItem = {
+  id: 'c4a1f0d2-5b3e-4a6c-9f81-7d2e5b0a3c14',
+  nome: 'Carteira preta',
+  tipo: LostItemKindEnum.LOST,
+  local: 'Biblioteca',
+  dataOcorrido: '2026-08-11T00:00:00',
+  descricao: 'Carteira de couro preta.',
+  fotoUrl: 'https://fotos.fateconnect.test/carteira.png',
+  situacao: LostItemStatusEnum.OPEN,
+  motivoCancelamento: null,
+  meuItem: true,
+  dataCadastro: '2026-08-12T00:00:00',
+};
+
+describe('toFormValues', () => {
+  it('should open empty when there is no item to edit', () => {
+    expect(toFormValues(undefined)).toEqual(EMPTY_LOST_ITEM_FORM);
+  });
+
+  it('should cut the api date down to what the field accepts', () => {
+    const values = toFormValues(LOST_ITEM);
+
+    expect(values.occurredOn).toBe('2026-08-11');
+    expect(values.name).toBe('Carteira preta');
+    expect(values.place).toBe('Biblioteca');
+    expect(values.kind).toBe(LostItemKindEnum.LOST);
+  });
+
+  it('should start without a file even when the item already has a stored photo', () => {
+    expect(toFormValues(LOST_ITEM).photo).toBeNull();
+  });
+
+  it('should turn a missing description into an empty field', () => {
+    expect(toFormValues({ ...LOST_ITEM, descricao: null }).description).toBe('');
+  });
+});
+
+describe('toLostItemInput', () => {
+  it('should carry every field the api owns and leave the photo out', () => {
+    const values: LostItemFormValues = {
+      name: 'Carteira preta',
+      kind: LostItemKindEnum.LOST,
+      place: 'Biblioteca',
+      occurredOn: '2026-08-11',
+      description: 'Carteira de couro preta.',
+      photo: new File(['foto'], 'carteira.png', { type: 'image/png' }),
+    };
+
+    expect(toLostItemInput(values)).toEqual({
+      nome: 'Carteira preta',
+      tipo: LostItemKindEnum.LOST,
+      local: 'Biblioteca',
+      dataOcorrido: '2026-08-11',
+      descricao: 'Carteira de couro preta.',
+    });
+  });
+});

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/helpers/mapper.ts
@@ -1,0 +1,33 @@
+import type { LostItem, LostItemInput } from '@app/services/lostAndFound/types';
+
+import { EMPTY_LOST_ITEM_FORM, type LostItemFormInput, type LostItemFormValues } from '../schema';
+
+/** `aaaa-mm-dd` do contrato; o resto do carimbo, quando vier, não serve ao campo. */
+const DATE_LENGTH = 10;
+
+/** Sem item é cadastro, e o formulário abre vazio. */
+export function toFormValues(item: LostItem | undefined): LostItemFormInput {
+  if (!item) return EMPTY_LOST_ITEM_FORM;
+
+  return {
+    name: item.nome,
+    kind: item.tipo,
+    place: item.local,
+    occurredOn: item.dataOcorrido.slice(0, DATE_LENGTH),
+    description: item.descricao ?? '',
+    // A foto guardada é uma URL, e o campo só sabe lidar com arquivo escolhido
+    // agora: editar começa sem foto e só troca quem escolher outra.
+    photo: null,
+  };
+}
+
+/** O schema já entregou os campos aparados e o tipo estreitado. */
+export function toLostItemInput(values: LostItemFormValues): LostItemInput {
+  return {
+    nome: values.name,
+    tipo: values.kind,
+    local: values.place,
+    dataOcorrido: values.occurredOn,
+    descricao: values.description,
+  };
+}

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/helpers/mapper.ts
@@ -2,10 +2,8 @@ import type { LostItem, LostItemInput } from '@app/services/lostAndFound/types';
 
 import { EMPTY_LOST_ITEM_FORM, type LostItemFormInput, type LostItemFormValues } from '../schema';
 
-/** `aaaa-mm-dd` do contrato; o resto do carimbo, quando vier, não serve ao campo. */
 const DATE_LENGTH = 10;
 
-/** Sem item é cadastro, e o formulário abre vazio. */
 export function toFormValues(item: LostItem | undefined): LostItemFormInput {
   if (!item) return EMPTY_LOST_ITEM_FORM;
 
@@ -15,13 +13,11 @@ export function toFormValues(item: LostItem | undefined): LostItemFormInput {
     place: item.local,
     occurredOn: item.dataOcorrido.slice(0, DATE_LENGTH),
     description: item.descricao ?? '',
-    // A foto guardada é uma URL, e o campo só sabe lidar com arquivo escolhido
-    // agora: editar começa sem foto e só troca quem escolher outra.
+    // O campo só lida com arquivo escolhido agora, não com a URL guardada.
     photo: null,
   };
 }
 
-/** O schema já entregou os campos aparados e o tipo estreitado. */
 export function toLostItemInput(values: LostItemFormValues): LostItemInput {
   return {
     nome: values.name,

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/index.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useMemo } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { useNotification } from '@app/hooks/useNotification';
+import { LOST_ITEMS_QUERY_KEY } from '@app/pages/LostAndFound/constants';
+import { createLostItem, updateLostItem } from '@app/services/lostAndFound/lostAndFoundService';
+import type { LostItem, LostItemInput } from '@app/services/lostAndFound/types';
+import { Dialog, Typography } from '@design-system';
+
+import { toFormValues, toLostItemInput } from './helpers/mapper';
+import { LostItemFormFields } from './LostItemFormFields';
+import {
+  EMPTY_LOST_ITEM_FORM,
+  lostItemFormSchema,
+  type LostItemFormInput,
+  type LostItemFormValues,
+} from './schema';
+import * as C from './constants';
+import * as S from './styles';
+
+export type LostItemFormDialogProps = Readonly<{
+  open: boolean;
+  onClose: VoidFunction;
+  /** Ausente, o diálogo cadastra um item novo; presente, edita o informado. */
+  item?: LostItem;
+}>;
+
+/** Cadastrar e editar são o mesmo formulário: só mudam os textos e o verbo HTTP. */
+export function LostItemFormDialog({ open, onClose, item }: LostItemFormDialogProps) {
+  const queryClient = useQueryClient();
+  const { notifySuccess } = useNotification();
+
+  const mode = useMemo(() => {
+    if (!item) return C.REGISTER_MODE;
+
+    return C.EDIT_MODE;
+  }, [item]);
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (input: LostItemInput) => {
+      if (!item) return createLostItem(input);
+
+      return updateLostItem(item.id, input);
+    },
+    onSuccess: async () => {
+      notifySuccess(mode.succeeded);
+      onClose();
+      await queryClient.invalidateQueries({ queryKey: [LOST_ITEMS_QUERY_KEY] });
+    },
+    // Sem fechar no erro: refazer o formulário inteiro por causa de uma falha de
+    // rede seria punir quem já digitou tudo.
+    meta: { errorMessage: mode.failed },
+  });
+
+  const form = useForm<LostItemFormInput, unknown, LostItemFormValues>({
+    resolver: zodResolver(lostItemFormSchema),
+    defaultValues: EMPTY_LOST_ITEM_FORM,
+    disabled: isPending,
+  });
+  const { reset } = form;
+
+  // Abrir mostra o item de agora, não o que sobrou da vez anterior.
+  useEffect(() => {
+    if (!open) return;
+
+    reset(toFormValues(item));
+  }, [open, item, reset]);
+
+  const handleSubmit = form.handleSubmit((values) => mutate(toLostItemInput(values)));
+  const SubmitIcon = mode.submitIcon;
+
+  return (
+    <Dialog open={open} onClose={onClose} title={mode.title}>
+      <FormProvider {...form}>
+        <S.LostItemForm component="form" onSubmit={handleSubmit} noValidate>
+          <Dialog.Body>
+            <LostItemFormFields />
+          </Dialog.Body>
+
+          <Dialog.Footer>
+            <S.SubmitButton
+              type="submit"
+              variant="contained"
+              color="error"
+              fullWidth
+              loading={isPending}
+            >
+              <SubmitIcon fontSize="small" />
+              <Typography variant="subtitleBold" color="inherit">
+                {mode.submitLabel}
+              </Typography>
+            </S.SubmitButton>
+          </Dialog.Footer>
+        </S.LostItemForm>
+      </FormProvider>
+    </Dialog>
+  );
+}

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/index.tsx
@@ -23,11 +23,9 @@ import * as S from './styles';
 export type LostItemFormDialogProps = Readonly<{
   open: boolean;
   onClose: VoidFunction;
-  /** Ausente, o diálogo cadastra um item novo; presente, edita o informado. */
   item?: LostItem;
 }>;
 
-/** Cadastrar e editar são o mesmo formulário: só mudam os textos e o verbo HTTP. */
 export function LostItemFormDialog({ open, onClose, item }: LostItemFormDialogProps) {
   const queryClient = useQueryClient();
   const { notifySuccess } = useNotification();
@@ -49,8 +47,7 @@ export function LostItemFormDialog({ open, onClose, item }: LostItemFormDialogPr
       onClose();
       await queryClient.invalidateQueries({ queryKey: [LOST_ITEMS_QUERY_KEY] });
     },
-    // Sem fechar no erro: refazer o formulário inteiro por causa de uma falha de
-    // rede seria punir quem já digitou tudo.
+    // Não fecha no erro: refazer o formulário inteiro puniria quem já digitou.
     meta: { errorMessage: mode.failed },
   });
 
@@ -61,7 +58,6 @@ export function LostItemFormDialog({ open, onClose, item }: LostItemFormDialogPr
   });
   const { reset } = form;
 
-  // Abrir mostra o item de agora, não o que sobrou da vez anterior.
   useEffect(() => {
     if (!open) return;
 

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/schema/index.test.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/schema/index.test.ts
@@ -1,0 +1,120 @@
+import { LostItemKindEnum } from '@app/services/lostAndFound/types';
+import { toApiDate } from '@app/utils/apiDate';
+
+import { LOST_ITEM_FORM_MESSAGES, LOST_ITEM_LIMITS, MAX_PHOTO_BYTES } from '../constants';
+import { lostItemFormSchema, type LostItemFormInput } from '.';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const VALID: LostItemFormInput = {
+  name: 'Garrafa térmica',
+  kind: LostItemKindEnum.FOUND,
+  place: 'Biblioteca',
+  occurredOn: toApiDate(new Date()),
+  description: 'Garrafa azul, com adesivos na tampa.',
+  photo: null,
+};
+
+/** O tamanho é declarado, não ocupado: alocar 5 MB só para reprovar é desperdício. */
+function photoOf(type: string, sizeInBytes: number): File {
+  const photo = new File(['conteúdo'], 'foto', { type });
+  Object.defineProperty(photo, 'size', { value: sizeInBytes });
+
+  return photo;
+}
+
+function firstErrorOf(overrides: Partial<LostItemFormInput>): string | undefined {
+  const result = lostItemFormSchema.safeParse({ ...VALID, ...overrides });
+  if (result.success) return undefined;
+
+  return result.error.issues[0]?.message;
+}
+
+describe('lostItemFormSchema', () => {
+  it('should accept a filled form and narrow the item kind', () => {
+    const result = lostItemFormSchema.safeParse(VALID);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.kind).toBe(LostItemKindEnum.FOUND);
+  });
+
+  it('should trim the name, the place and the description', () => {
+    const result = lostItemFormSchema.safeParse({
+      ...VALID,
+      name: '  Garrafa térmica  ',
+      place: '  Biblioteca  ',
+      description: '  Garrafa azul.  ',
+    });
+
+    expect(result.data?.name).toBe('Garrafa térmica');
+    expect(result.data?.place).toBe('Biblioteca');
+    expect(result.data?.description).toBe('Garrafa azul.');
+  });
+
+  it('should hold the name to the length the api accepts', () => {
+    expect(firstErrorOf({ name: 'ab' })).toBe(LOST_ITEM_FORM_MESSAGES.nameTooShort);
+    expect(firstErrorOf({ name: 'a'.repeat(LOST_ITEM_LIMITS.minName) })).toBeUndefined();
+    expect(firstErrorOf({ name: 'a'.repeat(LOST_ITEM_LIMITS.maxName) })).toBeUndefined();
+    expect(firstErrorOf({ name: 'a'.repeat(LOST_ITEM_LIMITS.maxName + 1) })).toBe(
+      LOST_ITEM_FORM_MESSAGES.nameTooLong,
+    );
+  });
+
+  it('should hold the place to the length the api accepts', () => {
+    expect(firstErrorOf({ place: 'ab' })).toBe(LOST_ITEM_FORM_MESSAGES.placeTooShort);
+    expect(firstErrorOf({ place: 'a'.repeat(LOST_ITEM_LIMITS.minPlace) })).toBeUndefined();
+    expect(firstErrorOf({ place: 'a'.repeat(LOST_ITEM_LIMITS.maxPlace) })).toBeUndefined();
+    expect(firstErrorOf({ place: 'a'.repeat(LOST_ITEM_LIMITS.maxPlace + 1) })).toBe(
+      LOST_ITEM_FORM_MESSAGES.placeTooLong,
+    );
+  });
+
+  it('should require a kind from the api vocabulary', () => {
+    expect(firstErrorOf({ kind: '' })).toBe(LOST_ITEM_FORM_MESSAGES.kindRequired);
+    expect(firstErrorOf({ kind: 'Encontrado' })).toBe(LOST_ITEM_FORM_MESSAGES.kindRequired);
+  });
+
+  it('should require the date of the event', () => {
+    expect(firstErrorOf({ occurredOn: '' })).toBe(LOST_ITEM_FORM_MESSAGES.occurredOnRequired);
+  });
+
+  it('should refuse a day that has not happened yet and accept today', () => {
+    expect(firstErrorOf({ occurredOn: toApiDate(new Date(Date.now() + DAY_MS)) })).toBe(
+      LOST_ITEM_FORM_MESSAGES.occurredOnInFuture,
+    );
+    expect(firstErrorOf({ occurredOn: toApiDate(new Date()) })).toBeUndefined();
+    expect(firstErrorOf({ occurredOn: toApiDate(new Date(Date.now() - DAY_MS)) })).toBeUndefined();
+  });
+
+  it('should accept an empty description but cap a long one', () => {
+    expect(firstErrorOf({ description: '' })).toBeUndefined();
+    expect(
+      firstErrorOf({ description: 'a'.repeat(LOST_ITEM_LIMITS.maxDescription) }),
+    ).toBeUndefined();
+    expect(firstErrorOf({ description: 'a'.repeat(LOST_ITEM_LIMITS.maxDescription + 1) })).toBe(
+      LOST_ITEM_FORM_MESSAGES.descriptionTooLong,
+    );
+  });
+
+  it('should treat the photo as optional', () => {
+    expect(firstErrorOf({ photo: null })).toBeUndefined();
+  });
+
+  it('should accept only the image formats the server will accept', () => {
+    expect(firstErrorOf({ photo: photoOf('image/jpeg', MAX_PHOTO_BYTES) })).toBeUndefined();
+    expect(firstErrorOf({ photo: photoOf('image/png', MAX_PHOTO_BYTES) })).toBeUndefined();
+    expect(firstErrorOf({ photo: photoOf('image/webp', MAX_PHOTO_BYTES) })).toBeUndefined();
+    expect(firstErrorOf({ photo: photoOf('image/gif', MAX_PHOTO_BYTES) })).toBe(
+      LOST_ITEM_FORM_MESSAGES.photoFormatInvalid,
+    );
+    expect(firstErrorOf({ photo: photoOf('application/pdf', MAX_PHOTO_BYTES) })).toBe(
+      LOST_ITEM_FORM_MESSAGES.photoFormatInvalid,
+    );
+  });
+
+  it('should refuse a photo heavier than the limit', () => {
+    expect(firstErrorOf({ photo: photoOf('image/png', MAX_PHOTO_BYTES + 1) })).toBe(
+      LOST_ITEM_FORM_MESSAGES.photoTooLarge,
+    );
+  });
+});

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/schema/index.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/schema/index.ts
@@ -1,0 +1,85 @@
+import { isAfter, isValid, parseISO, startOfDay } from 'date-fns';
+import { z } from 'zod';
+
+import { isLostItemKind } from '@app/pages/LostAndFound/helpers/lostItemKind';
+
+import {
+  ACCEPTED_PHOTO_TYPES,
+  LOST_ITEM_FORM_MESSAGES,
+  LOST_ITEM_LIMITS,
+  MAX_PHOTO_BYTES,
+} from '../constants';
+
+const REQUIRED = 1;
+
+/**
+ * Só se cadastra o que já aconteceu. Campo vazio ou ilegível passa: quem reclama
+ * disso é a regra de obrigatoriedade, e acumular as duas mensagens no mesmo
+ * lugar só confunde quem está preenchendo.
+ */
+function hasAlreadyHappened(value: string): boolean {
+  if (!value) return true;
+
+  const occurred = parseISO(value);
+  if (!isValid(occurred)) return true;
+
+  return !isAfter(startOfDay(occurred), startOfDay(new Date()));
+}
+
+/** A foto é opcional, então não escolher nenhuma é um estado válido. */
+function isAcceptedPhotoFormat(photo: File | null): boolean {
+  if (!photo) return true;
+
+  return ACCEPTED_PHOTO_TYPES.has(photo.type);
+}
+
+function isWithinPhotoSize(photo: File | null): boolean {
+  if (!photo) return true;
+
+  return photo.size <= MAX_PHOTO_BYTES;
+}
+
+export const lostItemFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(LOST_ITEM_LIMITS.minName, LOST_ITEM_FORM_MESSAGES.nameTooShort)
+    .max(LOST_ITEM_LIMITS.maxName, LOST_ITEM_FORM_MESSAGES.nameTooLong),
+  // O predicado estreita a saída: o formulário guarda texto, o schema entrega
+  // `LostItemKindEnum`, e o mapeamento para a requisição não precisa converter.
+  kind: z.string().refine(isLostItemKind, LOST_ITEM_FORM_MESSAGES.kindRequired),
+  place: z
+    .string()
+    .trim()
+    .min(LOST_ITEM_LIMITS.minPlace, LOST_ITEM_FORM_MESSAGES.placeTooShort)
+    .max(LOST_ITEM_LIMITS.maxPlace, LOST_ITEM_FORM_MESSAGES.placeTooLong),
+  occurredOn: z
+    .string()
+    .min(REQUIRED, LOST_ITEM_FORM_MESSAGES.occurredOnRequired)
+    .refine(hasAlreadyHappened, LOST_ITEM_FORM_MESSAGES.occurredOnInFuture),
+  description: z
+    .string()
+    .trim()
+    .max(LOST_ITEM_LIMITS.maxDescription, LOST_ITEM_FORM_MESSAGES.descriptionTooLong),
+  // A validação já é a do servidor: enquanto a #106 não guarda o arquivo, ela é
+  // o que impede o usuário de escolher algo que depois seria recusado.
+  photo: z
+    .instanceof(File)
+    .nullable()
+    .refine(isAcceptedPhotoFormat, LOST_ITEM_FORM_MESSAGES.photoFormatInvalid)
+    .refine(isWithinPhotoSize, LOST_ITEM_FORM_MESSAGES.photoTooLarge),
+});
+
+/** O que os campos guardam: texto, mais o arquivo escolhido. */
+export type LostItemFormInput = z.input<typeof lostItemFormSchema>;
+/** O que sai validado, já com o tipo do item estreitado. */
+export type LostItemFormValues = z.output<typeof lostItemFormSchema>;
+
+export const EMPTY_LOST_ITEM_FORM: LostItemFormInput = {
+  name: '',
+  kind: '',
+  place: '',
+  occurredOn: '',
+  description: '',
+  photo: null,
+};

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/schema/index.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/schema/index.ts
@@ -12,11 +12,7 @@ import {
 
 const REQUIRED = 1;
 
-/**
- * Só se cadastra o que já aconteceu. Campo vazio ou ilegível passa: quem reclama
- * disso é a regra de obrigatoriedade, e acumular as duas mensagens no mesmo
- * lugar só confunde quem está preenchendo.
- */
+/** Campo vazio passa de propósito: quem reclama disso é a obrigatoriedade. */
 function hasAlreadyHappened(value: string): boolean {
   if (!value) return true;
 
@@ -26,7 +22,6 @@ function hasAlreadyHappened(value: string): boolean {
   return !isAfter(startOfDay(occurred), startOfDay(new Date()));
 }
 
-/** A foto é opcional, então não escolher nenhuma é um estado válido. */
 function isAcceptedPhotoFormat(photo: File | null): boolean {
   if (!photo) return true;
 
@@ -45,8 +40,6 @@ export const lostItemFormSchema = z.object({
     .trim()
     .min(LOST_ITEM_LIMITS.minName, LOST_ITEM_FORM_MESSAGES.nameTooShort)
     .max(LOST_ITEM_LIMITS.maxName, LOST_ITEM_FORM_MESSAGES.nameTooLong),
-  // O predicado estreita a saída: o formulário guarda texto, o schema entrega
-  // `LostItemKindEnum`, e o mapeamento para a requisição não precisa converter.
   kind: z.string().refine(isLostItemKind, LOST_ITEM_FORM_MESSAGES.kindRequired),
   place: z
     .string()
@@ -61,8 +54,6 @@ export const lostItemFormSchema = z.object({
     .string()
     .trim()
     .max(LOST_ITEM_LIMITS.maxDescription, LOST_ITEM_FORM_MESSAGES.descriptionTooLong),
-  // A validação já é a do servidor: enquanto a #106 não guarda o arquivo, ela é
-  // o que impede o usuário de escolher algo que depois seria recusado.
   photo: z
     .instanceof(File)
     .nullable()
@@ -70,9 +61,7 @@ export const lostItemFormSchema = z.object({
     .refine(isWithinPhotoSize, LOST_ITEM_FORM_MESSAGES.photoTooLarge),
 });
 
-/** O que os campos guardam: texto, mais o arquivo escolhido. */
 export type LostItemFormInput = z.input<typeof lostItemFormSchema>;
-/** O que sai validado, já com o tipo do item estreitado. */
 export type LostItemFormValues = z.output<typeof lostItemFormSchema>;
 
 export const EMPTY_LOST_ITEM_FORM: LostItemFormInput = {

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/styles.ts
@@ -1,0 +1,31 @@
+import type { FormHTMLAttributes } from 'react';
+
+import {
+  Button,
+  radius,
+  radiusScale,
+  spacing,
+  spacingScale,
+  Stack,
+  styled,
+  type PolymorphicProps,
+} from '@design-system';
+
+const { xs, lg } = spacingScale;
+
+/**
+ * O formulário entra entre o título e o rodapé do esqueleto, no lugar que seria
+ * dos slots. Por isso ele repete o comportamento de filho flexível: é quem cede
+ * altura para o miolo rolar quando a tela é baixa.
+ */
+export const LostItemForm = styled(Stack)<PolymorphicProps<FormHTMLAttributes<HTMLFormElement>>>({
+  flexDirection: 'column',
+  gap: spacing(lg),
+  flexGrow: 1,
+  minHeight: 0,
+});
+
+export const SubmitButton = styled(Button)({
+  gap: spacing(xs),
+  borderRadius: radius(radiusScale.component),
+});

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/styles.ts
@@ -13,11 +13,7 @@ import {
 
 const { xs, lg } = spacingScale;
 
-/**
- * O formulário entra entre o título e o rodapé do esqueleto, no lugar que seria
- * dos slots. Por isso ele repete o comportamento de filho flexível: é quem cede
- * altura para o miolo rolar quando a tela é baixa.
- */
+/** Filho flexível: é ele que cede altura para o miolo rolar na tela baixa. */
 export const LostItemForm = styled(Stack)<PolymorphicProps<FormHTMLAttributes<HTMLFormElement>>>({
   flexDirection: 'column',
   gap: spacing(lg),

--- a/FateConnect/Web/src/pages/LostAndFound/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/index.tsx
@@ -20,7 +20,6 @@ import * as S from './styles';
 
 const SPINNER_SIZE_PX = 60;
 
-/** O mural abre nos itens em aberto; as outras situações vêm pelo filtro. */
 const INITIAL_FILTERS: LostItemFilterValues = { status: LostItemStatusEnum.OPEN };
 
 export function LostAndFound() {
@@ -44,11 +43,9 @@ export function LostAndFound() {
     setIsFormOpen(true);
   }, []);
 
-  // O item fica onde está enquanto o diálogo se fecha: zerar agora trocaria o
-  // título para o de cadastrar bem na frente de quem está vendo a saída.
+  // O item fica até o diálogo fechar: zerar agora trocaria o título na frente de quem olha.
   const handleCloseForm = useCallback(() => setIsFormOpen(false), []);
 
-  // A aba só acende quando foi ela que abriu o diálogo — editar vem do cartão.
   const isRegistering = isFormOpen && !editingItem;
 
   return (

--- a/FateConnect/Web/src/pages/LostAndFound/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/index.tsx
@@ -6,6 +6,7 @@ import { RoutePathEnum } from '@app/routes/paths';
 import { listLostItems } from '@app/services/lostAndFound/lostAndFoundService';
 import {
   LostItemStatusEnum,
+  type LostItem,
   type LostItemFilter as LostItemFilterValues,
 } from '@app/services/lostAndFound/types';
 import { CircularProgress, PageShell, Typography } from '@design-system';
@@ -13,6 +14,7 @@ import { AddIcon, ArrowBackIcon, SearchIcon } from '@design-system/icons';
 
 import { LostItemCard } from './components/LostItemCard';
 import { LostItemFilter } from './components/LostItemFilter';
+import { LostItemFormDialog } from './components/LostItemFormDialog';
 import * as C from './constants';
 import * as S from './styles';
 
@@ -23,6 +25,8 @@ const INITIAL_FILTERS: LostItemFilterValues = { status: LostItemStatusEnum.OPEN 
 
 export function LostAndFound() {
   const [filters, setFilters] = useState<LostItemFilterValues>(INITIAL_FILTERS);
+  const [editingItem, setEditingItem] = useState<LostItem | undefined>(undefined);
+  const [isFormOpen, setIsFormOpen] = useState(false);
 
   const { data: items = [], isPending } = useQuery({
     queryKey: [C.LOST_ITEMS_QUERY_KEY, filters],
@@ -34,6 +38,18 @@ export function LostAndFound() {
     (applied: LostItemFilterValues) => setFilters(applied),
     [],
   );
+
+  const handleRegister = useCallback(() => {
+    setEditingItem(undefined);
+    setIsFormOpen(true);
+  }, []);
+
+  // O item fica onde está enquanto o diálogo se fecha: zerar agora trocaria o
+  // título para o de cadastrar bem na frente de quem está vendo a saída.
+  const handleCloseForm = useCallback(() => setIsFormOpen(false), []);
+
+  // A aba só acende quando foi ela que abriu o diálogo — editar vem do cartão.
+  const isRegistering = isFormOpen && !editingItem;
 
   return (
     <PageShell
@@ -51,12 +67,13 @@ export function LostAndFound() {
           <PageShell.Tab
             label={C.SEARCH_TAB_LABEL}
             icon={<SearchIcon fontSize="small" />}
-            selected
+            selected={!isRegistering}
           />
           <PageShell.Tab
             label={C.REGISTER_TAB_LABEL}
             icon={<AddIcon fontSize="small" />}
-            selected={false}
+            selected={isRegistering}
+            onClick={handleRegister}
           />
         </>
       }
@@ -76,6 +93,8 @@ export function LostAndFound() {
 
         {!isPending && items.map((item) => <LostItemCard key={item.id} item={item} />)}
       </S.LostItemList>
+
+      <LostItemFormDialog open={isFormOpen} onClose={handleCloseForm} item={editingItem} />
     </PageShell>
   );
 }

--- a/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.test.ts
+++ b/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.test.ts
@@ -2,8 +2,16 @@ import { http, HttpResponse } from 'msw';
 
 import { server } from '@app/mocks/server';
 
-import { listLostItems } from './lostAndFoundService';
-import { LostItemKindEnum, LostItemStatusEnum } from './types';
+import { createLostItem, listLostItems, updateLostItem } from './lostAndFoundService';
+import { LostItemKindEnum, LostItemStatusEnum, type LostItemInput } from './types';
+
+const LOST_ITEM_INPUT: LostItemInput = {
+  nome: 'Garrafa térmica',
+  tipo: LostItemKindEnum.FOUND,
+  local: 'Biblioteca',
+  dataOcorrido: '2026-08-20',
+  descricao: 'Garrafa azul, com adesivos na tampa.',
+};
 
 const LOST_AND_FOUND_URL = 'https://api.fateconnect.test/achado';
 
@@ -62,5 +70,36 @@ describe('lostAndFoundService', () => {
     );
 
     await expect(listLostItems()).rejects.toThrow(/não é uma lista/);
+  });
+
+  it('should post the item on creation and return what the api answered', async () => {
+    let body: LostItemInput | null = null;
+    server.use(
+      http.post(LOST_AND_FOUND_URL, async ({ request }) => {
+        body = (await request.json()) as LostItemInput;
+        return HttpResponse.json({ id: 'novo', ...LOST_ITEM_INPUT }, { status: 201 });
+      }),
+    );
+
+    const created = await createLostItem(LOST_ITEM_INPUT);
+
+    expect(body).toEqual(LOST_ITEM_INPUT);
+    expect(created.id).toBe('novo');
+  });
+
+  it('should put the item under its own id on update', async () => {
+    const itemId = 'c4a1f0d2-5b3e-4a6c-9f81-7d2e5b0a3c14';
+    let requestUrl: string | null = null;
+    server.use(
+      http.put(`${LOST_AND_FOUND_URL}/:id`, ({ request }) => {
+        requestUrl = request.url;
+        return HttpResponse.json({ id: itemId, ...LOST_ITEM_INPUT });
+      }),
+    );
+
+    const updated = await updateLostItem(itemId, LOST_ITEM_INPUT);
+
+    expect(requestUrl).toBe(`${LOST_AND_FOUND_URL}/${itemId}`);
+    expect(updated.id).toBe(itemId);
   });
 });

--- a/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.ts
+++ b/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.ts
@@ -6,7 +6,6 @@ const LOST_AND_FOUND_PATH = '/achado';
 const INVALID_LIST_PAYLOAD_MESSAGE =
   'A API de achados e perdidos respondeu algo que não é uma lista.';
 
-/** Tradução dos filtros do front para os nomes de parâmetro da API. */
 function toQueryParams(filters: LostItemFilter = {}): Record<string, string> {
   const params: Record<string, string> = {};
 
@@ -24,9 +23,7 @@ export async function listLostItems(filters?: LostItemFilter): Promise<LostItem[
     params: toQueryParams(filters),
   });
 
-  // O tipo do axios é promessa de contrato, não garantia: sem o endereço da API a
-  // requisição cai no próprio servidor de desenvolvimento, que responde o HTML da
-  // aplicação com status 200. Falhar aqui vira a notificação de erro da tela.
+  // Sem endereço de API a requisição cai no dev server, que responde HTML com 200.
   if (!Array.isArray(data)) throw new Error(INVALID_LIST_PAYLOAD_MESSAGE);
 
   return data;

--- a/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.ts
+++ b/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '../httpClient';
-import type { LostItem, LostItemFilter } from './types';
+import type { LostItem, LostItemFilter, LostItemInput } from './types';
 
 const LOST_AND_FOUND_PATH = '/achado';
 
@@ -28,6 +28,18 @@ export async function listLostItems(filters?: LostItemFilter): Promise<LostItem[
   // requisição cai no próprio servidor de desenvolvimento, que responde o HTML da
   // aplicação com status 200. Falhar aqui vira a notificação de erro da tela.
   if (!Array.isArray(data)) throw new Error(INVALID_LIST_PAYLOAD_MESSAGE);
+
+  return data;
+}
+
+export async function createLostItem(input: LostItemInput): Promise<LostItem> {
+  const { data } = await apiClient.post<LostItem>(LOST_AND_FOUND_PATH, input);
+
+  return data;
+}
+
+export async function updateLostItem(itemId: string, input: LostItemInput): Promise<LostItem> {
+  const { data } = await apiClient.put<LostItem>(`${LOST_AND_FOUND_PATH}/${itemId}`, input);
 
   return data;
 }

--- a/FateConnect/Web/src/services/lostAndFound/types.ts
+++ b/FateConnect/Web/src/services/lostAndFound/types.ts
@@ -16,7 +16,6 @@ export enum CancellationReasonEnum {
   INACTIVITY = 'Inatividade',
 }
 
-/** Entidade como a API devolve (campos em pt-BR). O id é o `Guid` do backend. */
 export type LostItem = {
   id: string;
   nome: string;
@@ -31,17 +30,12 @@ export type LostItem = {
   dataCadastro: string;
 };
 
-/**
- * Corpo de criação e de atualização — a API aceita o mesmo conjunto de campos
- * nos dois verbos. A foto fica de fora: quem devolve a `fotoUrl` é o servidor,
- * e o arquivo escolhido ainda não tem para onde subir.
- */
+/** A foto fica de fora: quem devolve a `fotoUrl` é o servidor. */
 export type LostItemInput = Pick<
   LostItem,
   'nome' | 'tipo' | 'local' | 'dataOcorrido' | 'descricao'
 >;
 
-/** Filtros do front, em inglês; o serviço traduz para os parâmetros da API. */
 export type LostItemFilter = {
   name?: string;
   occurredOn?: string;

--- a/FateConnect/Web/src/services/lostAndFound/types.ts
+++ b/FateConnect/Web/src/services/lostAndFound/types.ts
@@ -31,6 +31,16 @@ export type LostItem = {
   dataCadastro: string;
 };
 
+/**
+ * Corpo de criação e de atualização — a API aceita o mesmo conjunto de campos
+ * nos dois verbos. A foto fica de fora: quem devolve a `fotoUrl` é o servidor,
+ * e o arquivo escolhido ainda não tem para onde subir.
+ */
+export type LostItemInput = Pick<
+  LostItem,
+  'nome' | 'tipo' | 'local' | 'dataOcorrido' | 'descricao'
+>;
+
 /** Filtros do front, em inglês; o serviço traduz para os parâmetros da API. */
 export type LostItemFilter = {
   name?: string;


### PR DESCRIPTION
## Objetivo

Cadastrar e editar um item de achados e perdidos, sem sair da lista. Um diálogo só serve os dois casos — sem item é cadastro, com item é edição —, como caronas já faz com o formulário de oferta.

## Alterações

- **A aba "Cadastrar Item" passou a abrir o diálogo** sobre a própria lista, sem trocar de endereço, e o destaque volta para a aba de busca quando ele fecha.
- **Seis campos:** nome do item, tipo, local, data do ocorrido, descrição e foto. O schema recusa data futura — item achado ou perdido só pode ter ocorrido até hoje — e valida o tamanho e o formato da foto.
- **Campo de foto** com prévia da imagem escolhida e ação de remover.
- **Criar e atualizar passam pelo serviço**, invalidando o cache da lista e avisando em caso de sucesso e de erro. O diálogo **não fecha quando a requisição falha**, para o que foi digitado não se perder.

### Decisões que vale registrar

- **A prévia da foto é local e vive enquanto a página estiver aberta.** A #106 ainda não guarda o arquivo, então não há URL de servidor para exibir; a validação de formato e tamanho já é a regra que o servidor vai repetir.
- **O corpo enviado não inclui a foto.** O endereço da imagem é gerado pelo servidor e o upload ainda não existe do outro lado — mandar o campo agora seria inventar contrato.
- **Editar começa com o campo de foto vazio**, mesmo num item que já tem imagem. O campo lida com arquivo, não com endereço; mostrar a foto guardada sugeriria um "remover a foto do servidor" que o contrato não sabe expressar.
- **O tipo do diálogo foi para `@types/`**, e não para um `types.ts` na raiz da pasta como o diálogo de caronas faz. A regra de estrutura do repo diz que na raiz ficam só `index`, teste e `styles` — as telas de menu e de cadastro já seguem assim. Fica a divergência com o diálogo irmão, caso valha unificar depois.
- **O lápis do cartão ainda não abre este diálogo.** O botão é da #125 e a fiação entre os dois é uma linha na tela; ela entra quando as duas estiverem na `develop`.

### Gate

ESLint exit 0 sobre `src` inteiro, `tsc --noEmit` exit 0, **371 testes** em 57 arquivos, cobertura de 99,3% nas linhas.

Os testes foram verificados por mutação, três vezes: fazendo o schema aceitar data futura, fazendo a validação de tamanho da foto passar sempre, e trocando o verbo de atualização por criação. A suíte reprovou nos três casos — inclusive em dois arquivos diferentes nos dois últimos — e o código foi restaurado.

## Issue

- #124

Closes #124

## Evidências

<img width="1290" height="831" alt="image" src="https://github.com/user-attachments/assets/550369b4-1a84-4df8-b27b-1efe5ce9db91" />
<img width="1290" height="831" alt="image" src="https://github.com/user-attachments/assets/ef9e52dc-3220-41fa-825a-797bad1dfd1a" />
