### PR TITLE
fix(140): keep the style-only props out of the markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige ofertar e editar carona, que falhavam quando a hora vinha sem os segundos (#99) [Backend]
 - Corrige a atualização de carona, que apagava a descrição quando o campo não era reenviado (#101) [Backend]
 - Corrige a página branca quando a aplicação quebra por inteiro: agora aparece a mesma tela de erro das rotas, com o caminho de volta ao início (#141) [Frontend]
+- Corrige o HTML das telas, que trazia atributos inválidos vindos de propriedades usadas só para estilo (#145) [Frontend]
 
 ## [0.2.0] - 2026-08-20
 

--- a/FateConnect/Web/design-system/components/FilterPanel/FilterPanel.test.tsx
+++ b/FateConnect/Web/design-system/components/FilterPanel/FilterPanel.test.tsx
@@ -58,4 +58,10 @@ describe('FilterPanel', () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
+
+  it('should keep the column count out of the markup', () => {
+    renderComponent();
+
+    expect(screen.getByText('campo').closest('[columns]')).toBeNull();
+  });
 });

--- a/FateConnect/Web/design-system/components/FilterPanel/styles.ts
+++ b/FateConnect/Web/design-system/components/FilterPanel/styles.ts
@@ -71,7 +71,9 @@ export const PanelForm = styled(Stack)<PolymorphicProps<FormHTMLAttributes<HTMLF
 });
 
 /** Quem arranja a linha decide quantas células cabem nela. */
-export const FieldsRow = styled(Stack)<PolymorphicProps & { columns: number }>(({ columns }) => ({
+export const FieldsRow = styled(Stack, {
+  shouldForwardProp: (prop) => prop !== 'columns',
+})<PolymorphicProps & { columns: number }>(({ columns }) => ({
   flexDirection: 'row',
   flexWrap: 'wrap',
   alignItems: 'flex-start',

--- a/FateConnect/Web/design-system/components/InitialsAvatar/InitialsAvatar.test.tsx
+++ b/FateConnect/Web/design-system/components/InitialsAvatar/InitialsAvatar.test.tsx
@@ -33,4 +33,10 @@ describe('InitialsAvatar', () => {
       backgroundColor: 'rgb(207, 46, 46)',
     });
   });
+
+  it('should keep the size out of the markup', () => {
+    renderComponent({ ...DEFAULT_PROPS, size: 'large' });
+
+    expect(screen.getByRole('img', { name: 'Maria Silva' })).not.toHaveAttribute('size');
+  });
 });

--- a/FateConnect/Web/design-system/components/InitialsAvatar/styles.ts
+++ b/FateConnect/Web/design-system/components/InitialsAvatar/styles.ts
@@ -17,7 +17,14 @@ const DIAMETER_PX: Record<InitialsAvatarSize, number> = {
   large: spacingScale.xxl,
 };
 
-export const InitialsCircle = styled(Avatar)<{ size: InitialsAvatarSize }>(({ theme, size }) => {
+/**
+ * `size` é só para o estilo. Hoje ele não aparece no DOM por acidente: o React
+ * descarta o atributo `size` quando o valor não é numérico, e a escala usa
+ * palavras. Trocar `small`/`large` por número faria o atributo voltar.
+ */
+export const InitialsCircle = styled(Avatar, {
+  shouldForwardProp: (prop) => prop !== 'size',
+})<{ size: InitialsAvatarSize }>(({ theme, size }) => {
   const bodyBySize = {
     small: theme.typography.captionBold,
     large: theme.typography.subtitleBold,

--- a/FateConnect/Web/design-system/components/StatusTag/StatusTag.test.tsx
+++ b/FateConnect/Web/design-system/components/StatusTag/StatusTag.test.tsx
@@ -55,4 +55,10 @@ describe('StatusTag', () => {
 
     expect(getComputedStyle(tagBox()).backgroundColor).toBe('rgba(0, 0, 0, 0)');
   });
+
+  it('should keep the tone out of the markup', () => {
+    renderComponent({ ...DEFAULT_PROPS, tone: 'muted' });
+
+    expect(tagBox()).not.toHaveAttribute('tone');
+  });
 });

--- a/FateConnect/Web/design-system/components/StatusTag/styles.ts
+++ b/FateConnect/Web/design-system/components/StatusTag/styles.ts
@@ -13,15 +13,15 @@ const { xxs, sm } = spacingScale;
 
 const TAG_RADIUS_PX = 12;
 
-export const TagRoot = styled(Box)<PolymorphicProps & { tone: StatusTagTone }>(
-  ({ theme, tone }) => ({
-    // Elemento em linha: a caixa acompanha a altura do texto. A entrelinha
-    // neutra evita que ela cresça quando o pai é um contêiner flex.
-    display: 'inline',
-    lineHeight: 1,
-    padding: spacing(xxs, sm),
-    borderRadius: `${TAG_RADIUS_PX}px`,
-    background: statusTagSurface(theme, tone),
-    color: onStatusTagSurface(theme, tone),
-  }),
-);
+export const TagRoot = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'tone',
+})<PolymorphicProps & { tone: StatusTagTone }>(({ theme, tone }) => ({
+  // Elemento em linha: a caixa acompanha a altura do texto. A entrelinha
+  // neutra evita que ela cresça quando o pai é um contêiner flex.
+  display: 'inline',
+  lineHeight: 1,
+  padding: spacing(xxs, sm),
+  borderRadius: `${TAG_RADIUS_PX}px`,
+  background: statusTagSurface(theme, tone),
+  color: onStatusTagSurface(theme, tone),
+}));


### PR DESCRIPTION
## Objetivo

Barrar as propriedades que servem só ao estilo antes de chegarem ao elemento renderizado. Três `styled` do design system as encaminhavam, e elas saíam escritas no HTML como atributo inválido. O React só avisa no console quando o valor é booleano — foi o caso do `own` no cartão de achados e perdidos, resolvido com a mesma linha —, então estes passavam calados.

## Alterações

Um `shouldForwardProp` em cada, seguindo o precedente do `own`:

| Componente | Prop barrada | Saía no HTML como |
| --- | --- | --- |
| `StatusTag` → `TagRoot` | `tone` | `tone="muted"` |
| `FilterPanel` → `FieldsRow` | `columns` | `columns="3"` |
| `InitialsAvatar` → `InitialsCircle` | `size` | — (ver abaixo) |

### O terceiro caso, que o escopo pedia para procurar

O `size` **não** aparece no HTML hoje — e por acidente, não por correção. Medido com sonda descartável:

| Valor | Atributo no DOM |
| --- | --- |
| `size="large"` | nenhum |
| `size="3"` | `size="3"` |

O React descarta o atributo `size` quando o valor não é numérico, e a escala do componente usa palavras. Uma prop inventada (`madeUpProp`) vaza tanto por `styled(Avatar)` quanto por `styled(Box)`, o que mostra que o filtro não é do Material: é do React e é específico do `size`. Trocar `small`/`large` por número traria o atributo de volta, com a correção parecendo desnecessária. É por isso que este é o único dos três com comentário — a ausência dele engana quem lê.

### Varredura

Procurei todo `styled(...)` com prop própria. Além dos três, apareceram `ChannelRowProps` e `CardProps`: os dois carregam atributos reais de `<a>`, de `<button>` e do router — `href`, `target`, `rel`, `type`, `onClick`, `to` —, e encaminhar está correto. Os casos com `FormHTMLAttributes` e `ButtonHTMLAttributes` também. Nenhum outro ficou de fora.

### Testes

Três asserções, escritas **antes** da correção. Duas falharam de saída, `tone` e `columns`, e a do `size` passou — foi isso que me levou a medir em vez de presumir vazamento. Vale saber ao revisar: a do `size` passa antes e depois, então ela registra o critério de aceite mas não é rede de proteção da correção. Ali quem protege é o comentário.

### Changelog

Entrada em `Fixed`, porque o HTML entregue mudou:

> Corrige o HTML das telas, que trazia atributos inválidos vindos de propriedades usadas só para estilo

### Gates

| Gate | Resultado |
| --- | --- |
| `eslint .` | 0 |
| `tsc --noEmit` | 0 |
| `vitest run --coverage` | 406/406 em 62 arquivos — 98,46% stmts, 92,05% branches, 97,87% funcs, 99,48% lines |

## Issue

- #140

Closes #140

## Evidências

<!-- reservado -->
