### PR TITLE
feat(137): require a tooltip on every icon button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Adiciona as ações de quem cadastrou o item de achados e perdidos — concluir, reabrir e excluir, com confirmação onde ela protege (#132) [Frontend]
 - Adiciona o contato de quem cadastrou o item de achados e perdidos, com e-mail copiável e conversa no WhatsApp (#134) [Frontend]
 - Adiciona o monitoramento de erros e de navegação no Sentry, com gravação de sessão mascarada e sem enviar corpo de requisição nem dado de usuário (#141) [Frontend]
+- Adiciona o rótulo dos botões de ícone, que passam a dizer o que fazem ao ponteiro e ao leitor de tela (#146) [Frontend]
 
 ### Changed
 

--- a/FateConnect/Web/design-system/components/Header/index.tsx
+++ b/FateConnect/Web/design-system/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import MenuIcon from '@mui/icons-material/Menu';
-import IconButton from '@mui/material/IconButton';
+
+import { IconButton } from '@ds-root/components/IconButton';
 
 import * as S from './styles';
 
@@ -31,7 +32,7 @@ export function Header({ logo, navigation, actions, onMenuClick, menuButtonLabel
           {actions}
 
           <S.MenuButtonSlot component="span">
-            <IconButton color="inherit" aria-label={menuButtonLabel} onClick={onMenuClick}>
+            <IconButton color="inherit" label={menuButtonLabel} onClick={onMenuClick}>
               <MenuIcon />
             </IconButton>
           </S.MenuButtonSlot>

--- a/FateConnect/Web/design-system/components/IconButton/IconButton.test.tsx
+++ b/FateConnect/Web/design-system/components/IconButton/IconButton.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, userEvent } from '@app/test/testing-library';
+import { EditIcon } from '@ds-root/icons';
+
+import { IconButton, type IconButtonProps } from '.';
+
+const LABEL = 'Editar a carona';
+
+const DEFAULT_PROPS: IconButtonProps = { label: LABEL, children: <EditIcon /> };
+
+const renderComponent = (props = DEFAULT_PROPS) => render(<IconButton {...props} />);
+
+function tooltipTarget(): HTMLElement {
+  const target = screen.getByRole('button').parentElement;
+  if (!target) throw new Error('O botão renderizou sem o invólucro do tooltip.');
+
+  return target;
+}
+
+describe('IconButton', () => {
+  it('should name the button by the label it receives', () => {
+    renderComponent();
+
+    expect(screen.getByRole('button')).toHaveAccessibleName(LABEL);
+    expect(screen.getAllByLabelText(LABEL)).toHaveLength(1);
+  });
+
+  it('should show the label as a tooltip on hover', async () => {
+    renderComponent();
+
+    await userEvent.hover(screen.getByRole('button'));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(LABEL);
+  });
+
+  it('should call onClick when the button is clicked', async () => {
+    const onClick = vi.fn();
+    renderComponent({ ...DEFAULT_PROPS, onClick });
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  // O botão desabilitado não recebe evento de ponteiro; quem o recebe é o invólucro.
+  it('should still show the tooltip while the button is disabled', async () => {
+    renderComponent({ ...DEFAULT_PROPS, disabled: true });
+
+    await userEvent.hover(tooltipTarget());
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(LABEL);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/FateConnect/Web/design-system/components/IconButton/index.tsx
+++ b/FateConnect/Web/design-system/components/IconButton/index.tsx
@@ -1,0 +1,31 @@
+import MuiIconButton, {
+  type IconButtonProps as MuiIconButtonProps,
+} from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+
+import * as S from './styles';
+
+export type IconButtonProps = Readonly<
+  Omit<MuiIconButtonProps, 'aria-label' | 'title'> & {
+    /** O que a ação faz: vira tooltip e nome acessível do botão. */
+    label: string;
+  }
+>;
+
+/**
+ * Botão de ícone com rótulo obrigatório. Um ícone sozinho não diz o que faz, e
+ * o mesmo texto atende quem passa o ponteiro e quem usa leitor de tela.
+ */
+export function IconButton({ label, children, ...buttonProps }: IconButtonProps) {
+  return (
+    <Tooltip title={label}>
+      {/* O Tooltip estampa o próprio `aria-label` no filho; anulá-lo aqui evita
+          que o rótulo nomeie o invólucro além do botão. */}
+      <S.TooltipTarget component="span" aria-label={undefined}>
+        <MuiIconButton {...buttonProps} aria-label={label}>
+          {children}
+        </MuiIconButton>
+      </S.TooltipTarget>
+    </Tooltip>
+  );
+}

--- a/FateConnect/Web/design-system/components/IconButton/styles.ts
+++ b/FateConnect/Web/design-system/components/IconButton/styles.ts
@@ -1,0 +1,10 @@
+import Stack from '@mui/material/Stack';
+
+import { styled, type PolymorphicProps } from '@ds-root/styled';
+
+/**
+ * Invólucro do botão: o Material não dispara evento de ponteiro em elemento
+ * desabilitado, então sem este intermediário o tooltip do botão desabilitado
+ * nunca apareceria.
+ */
+export const TooltipTarget = styled(Stack)<PolymorphicProps>({ display: 'inline-flex' });

--- a/FateConnect/Web/design-system/components/Input/Input.test.tsx
+++ b/FateConnect/Web/design-system/components/Input/Input.test.tsx
@@ -2,7 +2,7 @@ import { createRef } from 'react';
 
 import { act, render, screen, userEvent, within } from '@app/test/testing-library';
 
-import { TIME_PICKER_LABEL } from './constants';
+import { DATE_PICKER_LABEL, TIME_PICKER_LABEL } from './constants';
 import { Input, type InputProps } from '.';
 
 const DEFAULT_PROPS: InputProps = { label: 'Destino' };
@@ -131,7 +131,7 @@ describe('Input.Select', () => {
     const pickedDay = new Date(2026, 7, 10);
     render(<Input.Date label="Data" value={pickedDay} maxDate={pickedDay} onChange={vi.fn()} />);
 
-    await userEvent.click(screen.getByRole('button', { name: /Escolha uma data/i }));
+    await userEvent.click(screen.getByRole('button', { name: DATE_PICKER_LABEL }));
 
     const calendar = within(await screen.findByRole('grid'));
     expect(calendar.getByRole('gridcell', { name: '10' })).toBeEnabled();

--- a/FateConnect/Web/design-system/components/Input/components/DateInput/index.tsx
+++ b/FateConnect/Web/design-system/components/Input/components/DateInput/index.tsx
@@ -1,6 +1,8 @@
 import type { FocusEvent, ReactNode } from 'react';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
+import { DatePickerButton } from '@ds-root/components/Input/components/DatePickerButton';
+
 export type DateInputProps = Readonly<{
   label: ReactNode;
   value: Date | null;
@@ -35,6 +37,7 @@ export function DateInput({
       onChange={onChange}
       disabled={disabled}
       maxDate={maxDate}
+      slots={{ openPickerButton: DatePickerButton }}
       slotProps={{
         textField: {
           required,

--- a/FateConnect/Web/design-system/components/Input/components/DatePickerButton/index.tsx
+++ b/FateConnect/Web/design-system/components/Input/components/DatePickerButton/index.tsx
@@ -1,0 +1,15 @@
+import type { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton';
+
+import { IconButton } from '@ds-root/components/IconButton';
+import { DATE_PICKER_LABEL } from '@ds-root/components/Input/constants';
+
+export type DatePickerButtonProps = Readonly<Omit<MuiIconButtonProps, 'aria-label' | 'title'>>;
+
+/**
+ * O `DatePicker` desenha o próprio botão de abrir, e o rótulo dele viria da
+ * tradução do Material, sem tooltip. Este componente ocupa o slot para o botão
+ * obedecer à mesma regra dos outros: rótulo nosso, visível ao ponteiro.
+ */
+export function DatePickerButton(buttonProps: DatePickerButtonProps) {
+  return <IconButton {...buttonProps} label={DATE_PICKER_LABEL} />;
+}

--- a/FateConnect/Web/design-system/components/Input/components/TimePickerButton/index.tsx
+++ b/FateConnect/Web/design-system/components/Input/components/TimePickerButton/index.tsx
@@ -1,5 +1,4 @@
-import IconButton from '@mui/material/IconButton';
-
+import { IconButton } from '@ds-root/components/IconButton';
 import { TIME_PICKER_LABEL } from '@ds-root/components/Input/constants';
 import { ScheduleIcon } from '@ds-root/icons';
 
@@ -7,7 +6,7 @@ export type TimePickerButtonProps = Readonly<{ onOpen: VoidFunction }>;
 
 export function TimePickerButton({ onOpen }: TimePickerButtonProps) {
   return (
-    <IconButton type="button" aria-label={TIME_PICKER_LABEL} onClick={onOpen}>
+    <IconButton type="button" label={TIME_PICKER_LABEL} onClick={onOpen}>
       <ScheduleIcon />
     </IconButton>
   );

--- a/FateConnect/Web/design-system/components/Input/constants/index.ts
+++ b/FateConnect/Web/design-system/components/Input/constants/index.ts
@@ -1,1 +1,2 @@
+export const DATE_PICKER_LABEL = 'Abrir calendário';
 export const TIME_PICKER_LABEL = 'Abrir seletor de horário';

--- a/FateConnect/Web/design-system/components/ThemeToggleButton/ThemeToggleButton.test.tsx
+++ b/FateConnect/Web/design-system/components/ThemeToggleButton/ThemeToggleButton.test.tsx
@@ -2,11 +2,11 @@ import { render, screen, userEvent } from '@app/test/testing-library';
 
 import { ThemeToggleButton } from '.';
 
-const PARA_ESCURO = 'Ativar tema escuro';
-const PARA_CLARO = 'Ativar tema claro';
+const SWITCH_TO_DARK = 'Ativar tema escuro';
+const SWITCH_TO_LIGHT = 'Ativar tema claro';
 
 /** Lê a cor de fundo aplicada pelo tema ao corpo do documento. */
-function fundoDoDocumento() {
+function documentBackground() {
   return getComputedStyle(document.body).backgroundColor;
 }
 
@@ -14,7 +14,7 @@ describe('ThemeToggleButton', () => {
   it('should offer the dark theme while the light one is active', () => {
     render(<ThemeToggleButton />);
 
-    expect(screen.getByRole('button', { name: PARA_ESCURO })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: SWITCH_TO_DARK })).toBeInTheDocument();
   });
 
   it('should show an icon that reflects the active mode', async () => {
@@ -23,28 +23,28 @@ describe('ThemeToggleButton', () => {
     // Modo claro: sol. O ícone mostra o modo atual, não o destino do clique.
     expect(screen.getByTestId('LightModeIcon')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: PARA_ESCURO }));
+    await userEvent.click(screen.getByRole('button', { name: SWITCH_TO_DARK }));
 
     expect(screen.getByTestId('DarkModeIcon')).toBeInTheDocument();
   });
 
   it('should switch the theme and flip its own label when clicked', async () => {
     render(<ThemeToggleButton />);
-    const fundoClaro = fundoDoDocumento();
+    const lightBackground = documentBackground();
 
-    await userEvent.click(screen.getByRole('button', { name: PARA_ESCURO }));
+    await userEvent.click(screen.getByRole('button', { name: SWITCH_TO_DARK }));
 
-    expect(screen.getByRole('button', { name: PARA_CLARO })).toBeInTheDocument();
-    expect(fundoDoDocumento()).not.toBe(fundoClaro);
+    expect(screen.getByRole('button', { name: SWITCH_TO_LIGHT })).toBeInTheDocument();
+    expect(documentBackground()).not.toBe(lightBackground);
   });
 
   it('should return to the light theme on a second click', async () => {
     render(<ThemeToggleButton />);
-    const fundoClaro = fundoDoDocumento();
+    const lightBackground = documentBackground();
 
-    await userEvent.click(screen.getByRole('button', { name: PARA_ESCURO }));
-    await userEvent.click(screen.getByRole('button', { name: PARA_CLARO }));
+    await userEvent.click(screen.getByRole('button', { name: SWITCH_TO_DARK }));
+    await userEvent.click(screen.getByRole('button', { name: SWITCH_TO_LIGHT }));
 
-    expect(fundoDoDocumento()).toBe(fundoClaro);
+    expect(documentBackground()).toBe(lightBackground);
   });
 });

--- a/FateConnect/Web/design-system/components/ThemeToggleButton/index.tsx
+++ b/FateConnect/Web/design-system/components/ThemeToggleButton/index.tsx
@@ -1,24 +1,23 @@
-import IconButton from '@mui/material/IconButton';
-
+import { IconButton } from '@ds-root/components/IconButton';
 import { DarkModeIcon, LightModeIcon } from '@ds-root/icons';
 import { useThemeMode } from '@ds-root/ThemeProvider/context/ThemeModeContext';
 
-const LABEL_PARA_ESCURO = 'Ativar tema escuro';
-const LABEL_PARA_CLARO = 'Ativar tema claro';
+const SWITCH_TO_DARK_LABEL = 'Ativar tema escuro';
+const SWITCH_TO_LIGHT_LABEL = 'Ativar tema claro';
 
 /** Alterna entre o tema claro e o escuro. */
 export function ThemeToggleButton() {
   const { mode, toggleMode } = useThemeMode();
-  const estaClaro = mode === 'light';
+  const isLightMode = mode === 'light';
 
   return (
     <IconButton
       color="inherit"
-      aria-label={estaClaro ? LABEL_PARA_ESCURO : LABEL_PARA_CLARO}
+      label={isLightMode ? SWITCH_TO_DARK_LABEL : SWITCH_TO_LIGHT_LABEL}
       onClick={toggleMode}
     >
       {/* O ícone mostra o modo atual; o rótulo descreve a ação do clique. */}
-      {estaClaro ? <LightModeIcon /> : <DarkModeIcon />}
+      {isLightMode ? <LightModeIcon /> : <DarkModeIcon />}
     </IconButton>
   );
 }

--- a/FateConnect/Web/design-system/index.ts
+++ b/FateConnect/Web/design-system/index.ts
@@ -18,6 +18,8 @@ export { InitialsAvatar } from './components/InitialsAvatar';
 export { Dialog } from './components/Dialog';
 export { FilterPanel } from './components/FilterPanel';
 export type { FilterPanelProps } from './components/FilterPanel';
+export { IconButton } from './components/IconButton';
+export type { IconButtonProps } from './components/IconButton';
 export { Input } from './components/Input';
 export type { InputProps } from './components/Input';
 export type { SelectOption } from './components/Input/components/SelectInput/types';

--- a/FateConnect/Web/design-system/ui.ts
+++ b/FateConnect/Web/design-system/ui.ts
@@ -14,14 +14,12 @@ export { default as Checkbox } from '@mui/material/Checkbox';
 export { default as CircularProgress } from '@mui/material/CircularProgress';
 export { default as Drawer } from '@mui/material/Drawer';
 export { default as FormControlLabel } from '@mui/material/FormControlLabel';
-export { default as IconButton } from '@mui/material/IconButton';
 export { default as List } from '@mui/material/List';
 export { default as ListItemButton } from '@mui/material/ListItemButton';
 export { default as ListItemText } from '@mui/material/ListItemText';
 export { default as Popover } from '@mui/material/Popover';
 export { default as Stack } from '@mui/material/Stack';
 export { default as Toolbar } from '@mui/material/Toolbar';
-export { default as Tooltip } from '@mui/material/Tooltip';
 export { default as Typography } from '@mui/material/Typography';
 
 export type { BoxProps } from '@mui/material/Box';

--- a/FateConnect/Web/src/components/ContactButton/index.tsx
+++ b/FateConnect/Web/src/components/ContactButton/index.tsx
@@ -40,7 +40,7 @@ export function ContactButton({ contact, message }: ContactButtonProps) {
 
   return (
     <>
-      <IconButton type="button" aria-label={C.CONTACT_LABEL} onClick={handleOpen}>
+      <IconButton type="button" label={C.CONTACT_LABEL} onClick={handleOpen}>
         <ContactPageIcon />
       </IconButton>
 

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -104,7 +104,7 @@ export function LandingLoginCard() {
           endAdornment={
             <IconButton
               type="button"
-              aria-label={C.PASSWORD_TOGGLE_LABEL}
+              label={C.PASSWORD_TOGGLE_LABEL}
               aria-pressed={!passwordHidden}
               onClick={handleTogglePassword}
             >

--- a/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
@@ -233,7 +233,7 @@ describe('LostAndFound', () => {
     renderComponent();
     await screen.findByText(C.EMPTY_LIST_MESSAGE);
 
-    await userEvent.click(screen.getByRole('button', { name: /Escolha uma data/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir calendário' }));
 
     const calendar = within(await screen.findByRole('grid'));
     expect(calendar.getByRole('gridcell', { name: '10' })).toBeEnabled();

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemCard/LostItemActions/LostItemOwnerActions/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemCard/LostItemActions/LostItemOwnerActions/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { IconButton, Tooltip } from '@design-system';
+import { IconButton } from '@design-system';
 import { DeleteIcon, EditIcon } from '@design-system/icons';
 
 import { LostItemConfirmAction } from '@app/pages/LostAndFound/components/LostItemCard/LostItemConfirmAction';
@@ -24,11 +24,9 @@ export function LostItemOwnerActions({ item, onEdit, onCancel }: LostItemOwnerAc
 
   return (
     <>
-      <Tooltip title={C.LOST_ITEM_ACTION_LABELS.edit}>
-        <IconButton type="button" aria-label={C.LOST_ITEM_ACTION_LABELS.edit} onClick={handleEdit}>
-          <EditIcon />
-        </IconButton>
-      </Tooltip>
+      <IconButton type="button" label={C.LOST_ITEM_ACTION_LABELS.edit} onClick={handleEdit}>
+        <EditIcon />
+      </IconButton>
 
       <LostItemConfirmAction
         label={C.LOST_ITEM_ACTION_LABELS.delete}

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemCard/LostItemConfirmAction/LostItemConfirmTrigger/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemCard/LostItemConfirmAction/LostItemConfirmTrigger/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Button, IconButton, Tooltip } from '@design-system';
+import { Button, IconButton } from '@design-system';
 
 type LostItemConfirmTriggerProps = Readonly<{
   label: string;
@@ -24,10 +24,8 @@ export function LostItemConfirmTrigger({
   }
 
   return (
-    <Tooltip title={label}>
-      <IconButton type="button" aria-label={label} onClick={onClick}>
-        {icon}
-      </IconButton>
-    </Tooltip>
+    <IconButton type="button" label={label} onClick={onClick}>
+      {icon}
+    </IconButton>
   );
 }

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/RideDeleteConfirmation/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/RideDeleteConfirmation/index.tsx
@@ -29,7 +29,7 @@ export function RideDeleteConfirmation({ ride, onDelete }: RideDeleteConfirmatio
 
   return (
     <>
-      <IconButton type="button" aria-label={RIDE_CARD_LABELS.delete} onClick={handleAsk}>
+      <IconButton type="button" label={RIDE_CARD_LABELS.delete} onClick={handleAsk}>
         <DeleteIcon />
       </IconButton>
 

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
@@ -40,7 +40,7 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
           <S.ActionButtons>
             <RideDriverContact destination={ride.destino} />
 
-            <IconButton type="button" aria-label={C.RIDE_CARD_LABELS.edit} onClick={handleEdit}>
+            <IconButton type="button" label={C.RIDE_CARD_LABELS.edit} onClick={handleEdit}>
               <EditIcon />
             </IconButton>
 

--- a/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
@@ -91,7 +91,7 @@ export function AccountSection() {
           endAdornment={
             <IconButton
               type="button"
-              aria-label={PASSWORD_TOGGLE_LABEL}
+              label={PASSWORD_TOGGLE_LABEL}
               aria-pressed={!passwordHidden}
               onClick={handleTogglePassword}
             >

--- a/FateConnect/Web/src/pages/Signup/components/BirthDateField/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/BirthDateField/index.tsx
@@ -74,7 +74,7 @@ export function BirthDateField() {
         shrinkLabel={isBirthDateFilled}
         maxLength={MASKED_DATE_LENGTH}
         endAdornment={
-          <IconButton type="button" aria-label={CALENDAR_TOGGLE_LABEL} onClick={handleOpenCalendar}>
+          <IconButton type="button" label={CALENDAR_TOGGLE_LABEL} onClick={handleOpenCalendar}>
             <CalendarTodayIcon fontSize="small" />
           </IconButton>
         }


### PR DESCRIPTION
## Objetivo

Um ícone sozinho não diz o que faz. O barril reexportava o `IconButton` do Material direto, então nada obrigava um rótulo visível: dos 11 botões de ícone do produto, **2** tinham tooltip. O que levantou o assunto foi o botão de contato do cartão de achados e perdidos, que abre um diálogo e só se descobre clicando.

Agora existe um `IconButton` no design system que **exige** o rótulo, e é ele que a aplicação inteira usa.

## Alterações

**O componente** — `design-system/components/IconButton/`. Recebe `label: string` obrigatório e envolve o botão do Material em `Tooltip`. O mesmo texto alimenta o tooltip e o `aria-label`, então a duplicação que existia em todos os pontos de uso desapareceu — o diff é **negativo em linhas**.

O tipo é `Omit<MuiIconButtonProps, 'aria-label' | 'title'> & { label: string }`: as duas props que o componente passa a possuir saem do contrato, e o resto do Material continua disponível.

**A obrigação é aplicada, não combinada.** A reexportação crua saiu do `ui.ts` — sem isso o botão sem rótulo continuaria importável. Verificado nos dois sentidos: remover o `label` de um uso dá `TS2741`, e importar `@mui/material/IconButton` em `src/` reprova no `no-restricted-imports`.

**Os 12 pontos de uso.** Os 11 da issue — 8 na aplicação e 3 dentro do próprio design system, que importavam do Material direto e não eram alcançados pela remoção do barril. Onde já havia um `Tooltip` por fora, ele saiu por ficar redundante.

**Mais um, encontrado ao medir:** o botão de abrir o calendário dos campos de data era desenhado pelo próprio `DatePicker`, com o rótulo vindo da tradução da biblioteca e sem tooltip. Ele agora ocupa o slot `openPickerButton` com um `DatePickerButton` nosso, o que alcança os **quatro** consumidores de `Input.Date` — filtro e formulário de caronas, filtro e formulário de achados e perdidos.

Passar `slotProps={{ openPickerButton: { label } }}` **não compila**: o contrato do slot é o `IconButtonProps` do Material, que não tem `label`. Como cast está fora de questão neste repo, a saída foi o componente dedicado — o mesmo padrão que o `TimePickerButton` já usava. O critério de aceite da issue funcionando contra mim.

De brinde, uma divergência de copy morreu: o mesmo botão dizia "Escolha uma data" nos campos de data e "Abrir calendário" no cadastro. Agora diz "Abrir calendário" nos dois.

**Botão desabilitado** — o Material não dispara evento de ponteiro em elemento desabilitado, então o tooltip nunca apareceria. Resolvido **uma vez**, no componente: o botão vive dentro de um `span` `inline-flex`. Não há botão de ícone desabilitado hoje; o invólucro é incondicional de propósito, porque um ramo `disabled ? invólucro : sem invólucro` seria um ramo sem teste contra um limite de 90% de cobertura de ramos.

Uma consequência não óbvia, e a razão do `aria-label={undefined}` no invólucro: o `Tooltip` do Material estampa o próprio `aria-label` no filho, que com invólucro é o `span`, não o botão. Sem anular, **dois** elementos passam a carregar o nome acessível. Há teste travando isso, então uma atualização do Material que mude a ordem de mescla de props falha alto em vez de duplicar em silêncio.

**Identificadores em inglês** — `LABEL_PARA_ESCURO` → `SWITCH_TO_DARK_LABEL`, `LABEL_PARA_CLARO` → `SWITCH_TO_LIGHT_LABEL`, `estaClaro` → `isLightMode`, e os do teste. A copy exibida continua em pt-BR. O arquivo era tocado aqui de todo jeito.

### Prova de que nada se moveu

O invólucro é um elemento novo em volta de 12 botões, e nenhum gate vê layout. Medido no navegador com `getComputedStyle`/`getBoundingClientRect`, `develop` contra esta branch, mesmo viewport e mesma sessão:

| Botão | Antes | Depois |
| --- | --- | --- |
| Tema | `[1259, 12, 40, 40]` | `[1259, 12, 40, 40]` |
| Menu (estreito) | `[305, 12, 40, 40]` | `[305, 12, 40, 40]` |
| Olho da senha | `[832, 343, 40, 40]` | `[832, 343, 40, 40]` |
| Calendário do cadastro | `[1185, 273, 36, 36]` | `[1185, 273, 36, 36]` |
| Calendário do filtro | `[308, 343, 40, 40]` | `[308, 343, 40, 40]` |
| Ações do cartão | `1227 / 1259 / 1291` | `1227 / 1259 / 1291` |

A fileira de ações do cabeçalho mede `[1259, 80]` nos dois, com a mesma ordem. O botão de menu segue escondido no desktop e visível no estreito, nos dois. O calendário do filtro abre e ancora dentro da viewport. O tooltip aparece com o texto certo e **um único** elemento carrega o nome acessível.

### Gates

Rodados no estado **integrado**, depois do rebase na `develop` com a #140 dentro:

| Gate | Resultado |
| --- | --- |
| `eslint .` | 0 |
| `tsc --noEmit` | 0 |
| `vitest run --coverage` | 410/410 em 63 arquivos — 98,47% stmts, 92,05% branches |

Nenhum teste existente precisou ser afrouxado. Dois foram atualizados por procurarem `/Escolha uma data/i`, o rótulo antigo da biblioteca: no design system pela constante, como ele já fazia com `TIME_PICKER_LABEL`; na aplicação pelo texto visível, para não abrir precedente de teste de app alcançando o interno do design system.

Quatro testes novos no componente: nome acessível vindo do `label` (com a asserção de que ele nomeia **um** elemento), texto do tooltip ao passar o ponteiro, o `onClick`, e o tooltip aparecendo com o botão desabilitado.

## Em aberto

A issue previa e continua aberto: **toque não tem hover**, e o tooltip do Material só aparece depois de um toque longo. Se rótulo visível resolve melhor no estreito é decisão de produto — nenhum comportamento responsivo foi inventado, e a mudança, se vier, cabe dentro deste único componente.

## Issue

- #137

Closes #137

## Evidências

<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/377d0e27-a691-4c32-bf92-38a7a6ff3ffb" />
<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/34bb179a-5cd3-441b-adc5-dee44ebe22de" />
<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/69e30afd-b0a3-4b82-a198-12297c5a14b9" />
