### PR TITLE
feat(138): separate the card info items and remember the theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Avisa no painel de filtros de caronas que ele recolhe e quando há filtro valendo (#131) [Frontend]
 - Fixa os recuos e vãos das telas, que acompanhavam a largura da janela e cresciam sem limite em monitor grande, e antecipa a divisão entre apresentação e login na tela inicial (#148) [Frontend]
 - Alinha o espaçamento dos cartões de carona e de achados e perdidos, que separavam as informações e a descrição com medidas diferentes (#148) [Frontend]
+- Aproxima as informações dos cartões de carona e de achados e perdidos, separadas agora por uma barra vertical em vez do vão que as fazia parecer colunas distintas (#149) [Frontend]
+- Passa a abrir a aplicação no tema escolhido na última visita, em vez de voltar ao claro a cada recarga (#149) [Frontend]
 
 ### Fixed
 

--- a/FateConnect/Web/design-system/ThemeProvider/ThemeProvider.test.tsx
+++ b/FateConnect/Web/design-system/ThemeProvider/ThemeProvider.test.tsx
@@ -1,6 +1,12 @@
 import Typography from '@mui/material/Typography';
 
-import { render, screen } from '@app/test/testing-library';
+import { render, screen, userEvent } from '@app/test/testing-library';
+
+import { ThemeToggleButton } from '../components/ThemeToggleButton';
+import { themeModeStorage } from './storage/themeModeStorage';
+
+const SWITCH_TO_DARK = 'Ativar tema escuro';
+const SWITCH_TO_LIGHT = 'Ativar tema claro';
 
 describe('ThemeProvider', () => {
   it('should provide the theme to components in the tree', () => {
@@ -10,5 +16,21 @@ describe('ThemeProvider', () => {
 
     expect(element).toBeInTheDocument();
     expect(getComputedStyle(element).fontSize).toBe('1.3rem');
+  });
+
+  it('should open in the mode chosen on the last visit', () => {
+    themeModeStorage.save('dark');
+
+    render(<ThemeToggleButton />);
+
+    expect(screen.getByRole('button', { name: SWITCH_TO_LIGHT })).toBeInTheDocument();
+  });
+
+  it('should remember the mode the reader switches to', async () => {
+    render(<ThemeToggleButton />);
+
+    await userEvent.click(screen.getByRole('button', { name: SWITCH_TO_DARK }));
+
+    expect(themeModeStorage.read()).toBe('dark');
   });
 });

--- a/FateConnect/Web/design-system/ThemeProvider/index.tsx
+++ b/FateConnect/Web/design-system/ThemeProvider/index.tsx
@@ -5,24 +5,35 @@ import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import { GlobalStyles } from '../GlobalStyles';
 import { createAppTheme, type ThemeMode } from '../theme';
 import { ThemeModeContext } from './context/ThemeModeContext';
+import { themeModeStorage } from './storage/themeModeStorage';
 
 type ThemeProviderProps = Readonly<{
   children: ReactNode;
   defaultMode?: ThemeMode;
 }>;
 
+function oppositeMode(mode: ThemeMode): ThemeMode {
+  if (mode === 'light') return 'dark';
+  return 'light';
+}
+
 export function ThemeProvider({ children, defaultMode = 'light' }: ThemeProviderProps) {
-  const [mode, setMode] = useState<ThemeMode>(defaultMode);
+  const [mode, setMode] = useState<ThemeMode>(() => themeModeStorage.read() ?? defaultMode);
 
   const toggleMode = useCallback(() => {
-    setMode((atual) => (atual === 'light' ? 'dark' : 'light'));
+    setMode((current) => {
+      const chosen = oppositeMode(current);
+      themeModeStorage.save(chosen);
+
+      return chosen;
+    });
   }, []);
 
   const theme = useMemo(() => createAppTheme(mode), [mode]);
-  const contexto = useMemo(() => ({ mode, toggleMode }), [mode, toggleMode]);
+  const themeMode = useMemo(() => ({ mode, toggleMode }), [mode, toggleMode]);
 
   return (
-    <ThemeModeContext.Provider value={contexto}>
+    <ThemeModeContext.Provider value={themeMode}>
       <MuiThemeProvider theme={theme}>
         <CssBaseline />
         <GlobalStyles />

--- a/FateConnect/Web/design-system/ThemeProvider/storage/themeModeStorage.test.ts
+++ b/FateConnect/Web/design-system/ThemeProvider/storage/themeModeStorage.test.ts
@@ -1,0 +1,23 @@
+import { themeModeStorage } from './themeModeStorage';
+
+describe('themeModeStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('should read back the mode it saved', () => {
+    themeModeStorage.save('dark');
+
+    expect(themeModeStorage.read()).toBe('dark');
+  });
+
+  it('should report no choice when nothing was saved', () => {
+    expect(themeModeStorage.read()).toBeNull();
+  });
+
+  it('should ignore a stored value that is not a theme mode', () => {
+    window.localStorage.setItem('theme_mode', 'sepia');
+
+    expect(themeModeStorage.read()).toBeNull();
+  });
+});

--- a/FateConnect/Web/design-system/ThemeProvider/storage/themeModeStorage.ts
+++ b/FateConnect/Web/design-system/ThemeProvider/storage/themeModeStorage.ts
@@ -1,0 +1,28 @@
+import type { ThemeMode } from '@ds-root/theme';
+
+const THEME_MODE_KEY = 'theme_mode';
+
+const THEME_MODES: ReadonlySet<string> = new Set<ThemeMode>(['light', 'dark']);
+
+function isThemeMode(value: string | null): value is ThemeMode {
+  if (value === null) return false;
+
+  return THEME_MODES.has(value);
+}
+
+/**
+ * Único ponto que fala com o armazenamento do navegador sobre o tema, na mesma
+ * convenção do armazenamento de sessão da aplicação.
+ */
+export const themeModeStorage = {
+  read(): ThemeMode | null {
+    const stored = window.localStorage.getItem(THEME_MODE_KEY);
+    if (isThemeMode(stored)) return stored;
+
+    return null;
+  },
+
+  save(mode: ThemeMode): void {
+    window.localStorage.setItem(THEME_MODE_KEY, mode);
+  },
+};

--- a/FateConnect/Web/design-system/components/ListCard/ListCard.test.tsx
+++ b/FateConnect/Web/design-system/components/ListCard/ListCard.test.tsx
@@ -5,6 +5,8 @@ import { ListCard, type ListCardProps } from '.';
 const TITLE = 'Item de teste';
 const OWN_LABEL = 'Meu item';
 const MEDIA_TEXT = 'foto';
+const FIRST_INFO = 'Biblioteca';
+const SECOND_INFO = '11/08/2026';
 
 const DEFAULT_PROPS: ListCardProps = { children: TITLE };
 
@@ -33,6 +35,19 @@ describe('ListCard', () => {
     renderComponent({ ...DEFAULT_PROPS, ownLabel: OWN_LABEL });
 
     expect(screen.queryByText(OWN_LABEL)).not.toBeInTheDocument();
+  });
+
+  it('should separate the info items without anything the screen reader would read', () => {
+    renderComponent({
+      children: (
+        <ListCard.InfoRow>
+          <ListCard.InfoItem>{FIRST_INFO}</ListCard.InfoItem>
+          <ListCard.InfoItem>{SECOND_INFO}</ListCard.InfoItem>
+        </ListCard.InfoRow>
+      ),
+    });
+
+    expect(screen.getByRole('article')).toHaveTextContent(`${FIRST_INFO}${SECOND_INFO}`);
   });
 
   it('should keep the own flag out of the markup', () => {

--- a/FateConnect/Web/design-system/components/ListCard/styles.ts
+++ b/FateConnect/Web/design-system/components/ListCard/styles.ts
@@ -5,9 +5,10 @@ import { PolymorphicStack } from '@ds-root/polymorphic';
 import { styled } from '@ds-root/styled';
 import { iconSizeTokens, radiusScale, shadowTokens, spacingScale } from '@ds-root/tokens';
 
-const { xxs, sm, md, xl } = spacingScale;
+const { xxs, sm, md } = spacingScale;
 
 const OWN_STRIPE_PX = 4;
+const HAIRLINE = '1px';
 const ACTION_BUTTON_SIZE_PX = 32;
 /** O glifo da biblioteca de origem ocupa 70% do botão. */
 const ACTION_ICON_SCALE = 0.7;
@@ -72,16 +73,32 @@ export const ActionButtons = styled(Stack)(({ theme }) => ({
 export const InfoRow = styled(Stack)(({ theme }) => ({
   flexDirection: 'row',
   flexWrap: 'wrap',
-  columnGap: theme.space(xl),
+  columnGap: theme.space(md),
   rowGap: theme.space(xxs),
   marginBottom: theme.space(sm),
+  // Cada item desenha a barra à sua esquerda, dentro do vão. É este recorte que
+  // apaga a do primeiro item de cada linha — inclusive a da linha que quebrou.
+  overflow: 'hidden',
   color: theme.palette.text.secondary,
 }));
 
 export const InfoItem = styled(Stack)(({ theme }) => ({
+  position: 'relative',
   flexDirection: 'row',
   alignItems: 'center',
   gap: theme.space(xxs),
+
+  // Desenhada como fundo, e não como caractere, para o leitor de tela ler a
+  // informação e não a separação.
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: `calc(${theme.space(md)} / -2)`,
+    width: HAIRLINE,
+    backgroundColor: theme.palette.divider,
+  },
 
   '& svg': {
     color: theme.palette.secondary.main,


### PR DESCRIPTION
## Objetivo

Atender a issue #138: as informações dos cartões — local, data e tipo em achados e perdidos; data, hora e vagas em caronas — ficavam a 32px umas das outras e liam como colunas de coisas diferentes. Agora ficam próximas e separadas por uma barra vertical, como uma frase.

Aproveitando a janela do PR, entra também a persistência da escolha de tema, que não sobrevivia à recarga da página. São dois assuntos independentes, em commits separados.

## Alterações

### Barra entre as informações do cartão (#138)

A #148 já havia unificado a casca dos dois cartões no `ListCard` do design system, então a mudança fica inteira em `InfoRow`/`InfoItem`: **nenhum arquivo de tela foi tocado**. O vão passa de 32px para 16px e ganha uma barra de 1px no meio, na cor de divisor do tema.

A issue deixava em aberto se a mudança valia para o cartão de caronas — a ressalva existia porque o vão dele (`5vw`) vinha da migração do front anterior. Aquele valor já não existia: a #148 o havia substituído. A decisão foi aplicar aos dois.

**O mecanismo é o ponto não óbvio da revisão.** A barra é um `::before` absoluto na metade esquerda do vão de cada item, e o `overflow: hidden` da linha recorta a barra do primeiro item de **cada** linha. É isso que cumpre "sem barra sobrando na ponta quando a linha quebra no estreito" sem uma linha de JS. Desenhada como fundo (`content: ""`), não existe caractere para o leitor de tela anunciar.

Medições no navegador, código real, nos dois temas, em 375px e 1440px:

| Medida | Resultado |
| --- | --- |
| Barra | 1px × 20px, `#D9D9D9` no claro e `rgba(255,255,255,0.12)` no escuro |
| Contraste sobre o cartão | 1,41:1 no claro e 1,44:1 no escuro — mesmo peso visual nos dois |
| Cartão de "Biblioteca" em 375px | quebrava em duas linhas com o vão antigo; agora cabe em uma |
| Cartão de "Laboratório de redes" em 375px | continua quebrando, e a barra do item que abre a segunda linha cai em −8px e é recortada |
| Recorte de texto pelo `overflow` | nenhum (`scrollHeight == clientHeight`) |
| Transbordo de página em 1440px | nenhum |

O teste novo foi verificado nos dois sentidos. Ele pega o caso realista — trocar o pseudo-elemento por um `<span aria-hidden>|</span>`, que voltaria ao `textContent`: falha com essa sonda aplicada, passa sem ela. Ele **não** pega um `content: "|"` no próprio pseudo-elemento, porque o jsdom não resolve pseudo-elemento; isso também foi verificado, e essa metade quem cobre é a medição no navegador, não o teste.

### Tema escolhido sobrevive à recarga

`themeModeStorage`, em `ThemeProvider/storage/`, passa a guardar a escolha — na mesma convenção do `tokenStorage` já existente, de um único ponto falando com o `localStorage`, e com type guard descartando valor inválido em vez de cast. O `ThemeProvider` lê no inicializador do `useState` e grava no toggle.

Verificado no navegador: escolhi o escuro, recarreguei, voltou escuro (`body` em `rgb(18,18,18)`, cartão em `rgb(30,30,30)`). Os dois testes novos falham sem a funcionalidade e passam com ela.

No mesmo arquivo, boy-scout: saiu o ternário do `toggleMode` e os identificadores em português viraram inglês. Sem varredura nos vizinhos.

**Uma ponta que fica aberta de propósito:** ainda há um lampejo claro ao recarregar em modo escuro. O `<html>` é transparente e o fundo só chega quando o React monta. Fechar isso exigiria um script inline no `index.html` duplicando a chave do armazenamento e a cor do tema fora de quem é dono das duas — o oposto do que o `themeModeStorage` existe para evitar. Fica como candidato a issue separada.

### Gates

`eslint` 0 · `tsc` 0 · `vitest` 421/421 em 65 arquivos, cobertura 98,4% · `vite build` 0.

## Issue

- #138

Closes #138

## Evidências

<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/e3867f84-9f8e-4958-84dd-bff377773aa6" />
<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/828f20af-4a86-44c6-b490-27e8a76b5243" />
<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/9c7bba0b-d7c4-4c15-87d7-a658f13b9bee" />
<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/3ad49b2c-a6d3-43c0-8349-ab5a1fe743af" />


<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/2cc495a1-2e16-4660-b7e5-75f574c4fb1b" />
