### PR TITLE
feat(139): put the card tag and actions together and gate the owner ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Alinha o espaçamento dos cartões de carona e de achados e perdidos, que separavam as informações e a descrição com medidas diferentes (#148) [Frontend]
 - Aproxima as informações dos cartões de carona e de achados e perdidos, separadas agora por uma barra vertical em vez do vão que as fazia parecer colunas distintas (#149) [Frontend]
 - Passa a abrir a aplicação no tema escolhido na última visita, em vez de voltar ao claro a cada recarga (#149) [Frontend]
+- Junta a etiqueta e as ações no topo do cartão de carona e de achados e perdidos também no celular, onde a etiqueta descia sozinha para o rodapé (#150) [Frontend]
+- Passa a marcar a carona de quem a ofertou e a oferecer editar e excluir só nela; enquanto a API não disser de quem é cada carona, nenhuma é reconhecida como sua (#150) [Frontend]
 
 ### Fixed
 
@@ -41,6 +43,8 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige a página branca quando a aplicação quebra por inteiro: agora aparece a mesma tela de erro das rotas, com o caminho de volta ao início (#141) [Frontend]
 - Corrige o HTML das telas, que trazia atributos inválidos vindos de propriedades usadas só para estilo (#145) [Frontend]
 - Corrige a largura de 768px, em que o topo já estava no modo estreito enquanto o cadastro ainda usava a grade larga (#148) [Frontend]
+- Corrige o canto superior direito do cartão, que parava antes da borda em lugar diferente a cada cartão da lista, e o título comprido, que corria por cima da etiqueta e dos ícones (#150) [Frontend]
+- Corrige o diálogo de contato, que encostava o conteúdo à esquerda enquanto o título ficava centralizado (#150) [Frontend]
 
 ## [0.2.0] - 2026-08-20
 

--- a/FateConnect/Web/design-system/components/ListCard/ListCardActions/index.tsx
+++ b/FateConnect/Web/design-system/components/ListCard/ListCardActions/index.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+import { ACTIONS_ATTRIBUTE } from '../constants';
+import * as S from './styles';
+
+export type ListCardActionsProps = Readonly<{ children: ReactNode }>;
+
+/**
+ * Etiqueta e ações do cabeçalho do cartão. O atributo é como o cartão as
+ * alcança para prendê-las ao canto quando a mídia empurra o cabeçalho para
+ * baixo.
+ */
+export function ListCardActions({ children }: ListCardActionsProps) {
+  return <S.ActionsRow {...{ [ACTIONS_ATTRIBUTE]: '' }}>{children}</S.ActionsRow>;
+}

--- a/FateConnect/Web/design-system/components/ListCard/ListCardActions/styles.ts
+++ b/FateConnect/Web/design-system/components/ListCard/ListCardActions/styles.ts
@@ -1,0 +1,13 @@
+import Stack from '@mui/material/Stack';
+
+import { styled } from '@ds-root/styled';
+import { spacingScale } from '@ds-root/tokens';
+
+const { sm } = spacingScale;
+
+export const ActionsRow = styled(Stack)(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  flexShrink: 0,
+  gap: theme.space(sm),
+}));

--- a/FateConnect/Web/design-system/components/ListCard/constants.ts
+++ b/FateConnect/Web/design-system/components/ListCard/constants.ts
@@ -1,0 +1,2 @@
+/** Marca as ações do cabeçalho para o cartão poder prendê-las ao canto. */
+export const ACTIONS_ATTRIBUTE = 'data-list-card-actions';

--- a/FateConnect/Web/design-system/components/ListCard/index.tsx
+++ b/FateConnect/Web/design-system/components/ListCard/index.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 
 import { HiddenField } from '@ds-root/components/HiddenField';
 
+import { ListCardActions } from './ListCardActions';
 import * as S from './styles';
 
 export type ListCardProps = Readonly<{
@@ -22,7 +23,7 @@ export type ListCardProps = Readonly<{
  */
 function ListCard({ own = false, ownLabel, media, children }: ListCardProps) {
   return (
-    <S.CardRoot component="article" own={own}>
+    <S.CardRoot component="article" own={own} hasMedia={media !== undefined}>
       {own && ownLabel && <HiddenField component="span">{ownLabel}</HiddenField>}
 
       {media}
@@ -33,7 +34,7 @@ function ListCard({ own = false, ownLabel, media, children }: ListCardProps) {
 }
 
 ListCard.Header = S.HeaderRow;
-ListCard.Actions = S.HeaderActions;
+ListCard.Actions = ListCardActions;
 ListCard.ActionButtons = S.ActionButtons;
 ListCard.InfoRow = S.InfoRow;
 ListCard.InfoItem = S.InfoItem;

--- a/FateConnect/Web/design-system/components/ListCard/index.tsx
+++ b/FateConnect/Web/design-system/components/ListCard/index.tsx
@@ -38,7 +38,5 @@ ListCard.ActionButtons = S.ActionButtons;
 ListCard.InfoRow = S.InfoRow;
 ListCard.InfoItem = S.InfoItem;
 ListCard.Description = S.Description;
-ListCard.WideOnlyTag = S.WideOnlyTag;
-ListCard.CompactOnlyTag = S.CompactOnlyTag;
 
 export { ListCard };

--- a/FateConnect/Web/design-system/components/ListCard/styles.ts
+++ b/FateConnect/Web/design-system/components/ListCard/styles.ts
@@ -5,6 +5,8 @@ import { PolymorphicStack } from '@ds-root/polymorphic';
 import { styled } from '@ds-root/styled';
 import { iconSizeTokens, radiusScale, shadowTokens, spacingScale } from '@ds-root/tokens';
 
+import { ACTIONS_ATTRIBUTE } from './constants';
+
 const { xxs, sm, md } = spacingScale;
 
 const OWN_STRIPE_PX = 4;
@@ -13,11 +15,14 @@ const ACTION_BUTTON_SIZE_PX = 32;
 /** O glifo da biblioteca de origem ocupa 70% do botão. */
 const ACTION_ICON_SCALE = 0.7;
 
+const STYLE_ONLY_PROPS: ReadonlySet<string> = new Set(['own', 'hasMedia']);
+
 /** A faixa na borda é o que diz, sem etiqueta, que o registro é de quem olha. */
 export const CardRoot = styled(PolymorphicStack, {
-  // `own` é só para o estilo: sem isto o Stack a repassa e o React reclama do atributo.
-  shouldForwardProp: (prop) => prop !== 'own',
-})<{ own: boolean }>(({ theme, own }) => ({
+  // São só para o estilo: sem isto o Stack as repassa e o React reclama do atributo.
+  shouldForwardProp: (prop) => !STYLE_ONLY_PROPS.has(String(prop)),
+})<{ own: boolean; hasMedia: boolean }>(({ theme, own, hasMedia }) => ({
+  position: 'relative',
   flexDirection: 'row',
   alignItems: 'flex-start',
   gap: theme.space(md),
@@ -30,7 +35,20 @@ export const CardRoot = styled(PolymorphicStack, {
   background: theme.palette.background.paper,
   color: theme.palette.text.primary,
 
-  [theme.breakpoints.down('md')]: { flexDirection: 'column' },
+  [theme.breakpoints.down('md')]: {
+    flexDirection: 'column',
+
+    // Com a mídia no topo, o cabeçalho desce com ela e a etiqueta sairia do
+    // canto. Tirá-la do fluxo é o que a mantém lá — e só há espaço para isso
+    // porque a mídia é uma miniatura, deixando a faixa à direita dela vazia.
+    ...(hasMedia && {
+      [`& [${ACTIONS_ATTRIBUTE}]`]: {
+        position: 'absolute',
+        top: theme.space(md),
+        right: theme.space(md),
+      },
+    }),
+  },
 }));
 
 export const CardBody = styled(Stack)(({ theme }) => ({
@@ -55,13 +73,6 @@ export const HeaderRow = styled(Stack)(({ theme }) => ({
   // estreito: o `minWidth` é o que deixa a caixa encolher, e a quebra é o que
   // impede uma palavra sem espaço de correr por cima delas.
   '& > :first-of-type': { minWidth: 0, overflowWrap: 'anywhere' },
-}));
-
-export const HeaderActions = styled(Stack)(({ theme }) => ({
-  flexDirection: 'row',
-  alignItems: 'center',
-  flexShrink: 0,
-  gap: theme.space(sm),
 }));
 
 export const ActionButtons = styled(Stack)(({ theme }) => ({

--- a/FateConnect/Web/design-system/components/ListCard/styles.ts
+++ b/FateConnect/Web/design-system/components/ListCard/styles.ts
@@ -33,18 +33,28 @@ export const CardRoot = styled(PolymorphicStack, {
   [theme.breakpoints.down('md')]: { flexDirection: 'column' },
 }));
 
-export const CardBody = styled(Stack)({
+export const CardBody = styled(Stack)(({ theme }) => ({
   flexDirection: 'column',
   flexGrow: 1,
   minWidth: 0,
-});
+
+  // No estreito o cartão vira coluna, e aí o `flex-start` do topo encolheria o
+  // corpo até o conteúdo: o cabeçalho pararia antes da borda, em lugar
+  // diferente a cada cartão.
+  [theme.breakpoints.down('md')]: { width: '100%' },
+}));
 
 export const HeaderRow = styled(Stack)(({ theme }) => ({
   flexDirection: 'row',
   justifyContent: 'space-between',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   gap: theme.space(sm),
   marginBottom: theme.space(sm),
+
+  // Sem os dois o título empurra a etiqueta e as ações para fora do cartão no
+  // estreito: o `minWidth` é o que deixa a caixa encolher, e a quebra é o que
+  // impede uma palavra sem espaço de correr por cima delas.
+  '& > :first-of-type': { minWidth: 0, overflowWrap: 'anywhere' },
 }));
 
 export const HeaderActions = styled(Stack)(({ theme }) => ({
@@ -109,21 +119,4 @@ export const InfoItem = styled(Stack)(({ theme }) => ({
 export const Description = styled(Box)(({ theme }) => ({
   marginBottom: theme.space(sm),
   color: theme.palette.text.secondary,
-}));
-
-/** A etiqueta acompanha o cabeçalho no desktop e desce para o rodapé no estreito. */
-export const WideOnlyTag = styled(Box)(({ theme }) => ({
-  display: 'block',
-
-  [theme.breakpoints.down('md')]: { display: 'none' },
-}));
-
-export const CompactOnlyTag = styled(Box)(({ theme }) => ({
-  display: 'none',
-
-  [theme.breakpoints.down('md')]: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    paddingTop: theme.space(sm),
-  },
 }));

--- a/FateConnect/Web/src/components/ContactButton/ContactDetails/index.tsx
+++ b/FateConnect/Web/src/components/ContactButton/ContactDetails/index.tsx
@@ -24,8 +24,8 @@ export type ContactDetailsProps = Readonly<{
 
 /**
  * Vias de contato de uma pessoa: identidade de um lado, canais clicáveis do
- * outro, empilhados e centralizados no estreito. Não sabe onde está sendo
- * mostrado — cabe dentro de um diálogo, de um cartão ou de um painel.
+ * outro, centralizados no espaço que receberem e empilhados no estreito. Não
+ * sabe onde está sendo mostrado — cabe num diálogo, num cartão ou num painel.
  */
 export function ContactDetails({
   name,

--- a/FateConnect/Web/src/components/ContactButton/ContactDetails/styles.ts
+++ b/FateConnect/Web/src/components/ContactButton/ContactDetails/styles.ts
@@ -5,6 +5,7 @@ const { xs, md, xl } = spacingScale;
 export const DetailsRow = styled(Stack)(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'center',
+  justifyContent: 'center',
   gap: theme.space(xl),
 
   [theme.breakpoints.down('md')]: {

--- a/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
@@ -314,7 +314,7 @@ describe('LostAndFound', () => {
     await filterByStatus(STATUS_TAG_LABEL.cancelled);
 
     expect(await screen.findByText(LOST_ITEM.nome)).toBeInTheDocument();
-    expect(card().getAllByText(STATUS_TAG_LABEL.cancelled)).not.toHaveLength(0);
+    expect(card().getAllByText(STATUS_TAG_LABEL.cancelled)).toHaveLength(1);
     expect(card().getByText(CANCELLATION_NOTE.owner)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: REOPEN_LABEL }));
@@ -332,7 +332,7 @@ describe('LostAndFound', () => {
     await filterByStatus(STATUS_TAG_LABEL.resolved);
 
     expect(await screen.findByText(LOST_ITEM.nome)).toBeInTheDocument();
-    expect(card().getAllByText(STATUS_TAG_LABEL.resolved)).not.toHaveLength(0);
+    expect(card().getAllByText(STATUS_TAG_LABEL.resolved)).toHaveLength(1);
   });
 
   it('should keep the owner actions off the card of someone else', async () => {
@@ -409,7 +409,7 @@ describe('LostAndFound', () => {
 
     // O diálogo sai por transição: some da árvore depois do clique, não nele.
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-    expect(card().getAllByText(STATUS_TAG_LABEL.open)).not.toHaveLength(0);
+    expect(card().getAllByText(STATUS_TAG_LABEL.open)).toHaveLength(1);
   });
 
   it('should reopen the item without asking anything first', async () => {

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemCard/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemCard/index.tsx
@@ -39,9 +39,7 @@ export function LostItemCard({ item, onEdit, onResolve, onCancel, onReopen }: Lo
         <Typography variant="subtitleBold">{item.nome}</Typography>
 
         <ListCard.Actions>
-          <ListCard.WideOnlyTag>
-            <StatusTag tone={statusTone}>{statusLabel}</StatusTag>
-          </ListCard.WideOnlyTag>
+          <StatusTag tone={statusTone}>{statusLabel}</StatusTag>
 
           <LostItemActions item={item} onEdit={onEdit} onCancel={onCancel} />
         </ListCard.Actions>
@@ -87,10 +85,6 @@ export function LostItemCard({ item, onEdit, onResolve, onCancel, onReopen }: Lo
       )}
 
       <LostItemStatusAction item={item} onResolve={onResolve} onReopen={onReopen} />
-
-      <ListCard.CompactOnlyTag>
-        <StatusTag tone={statusTone}>{statusLabel}</StatusTag>
-      </ListCard.CompactOnlyTag>
     </ListCard>
   );
 }

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -141,9 +141,7 @@ describe('Rides', () => {
     expect(screen.getByText('22/05/2026')).toBeInTheDocument();
     expect(screen.getByText('07:30')).toBeInTheDocument();
     expect(screen.getByText(C.seatsLabel(RIDE.qtdVagas))).toBeInTheDocument();
-    // A etiqueta existe duas vezes: uma no cabeçalho e outra no rodapé do
-    // cartão, alternadas por media query — que o jsdom não avalia.
-    expect(screen.getAllByText('Solidária')).toHaveLength(2);
+    expect(screen.getAllByText('Solidária')).toHaveLength(1);
   });
 
   it('should tell the user when no ride matches', async () => {
@@ -329,6 +327,23 @@ describe('Rides', () => {
     await screen.findByText(RIDE.destino);
 
     expect(screen.queryByRole('button', { name: CONTACT_LABEL })).not.toBeInTheDocument();
+  });
+
+  it('should announce the ride of the logged user, which the border stripe only shows', async () => {
+    tokenStorage.save('token', RIDE_DRIVER.name);
+    listReturning([RIDE]);
+    renderComponent();
+    await screen.findByText(RIDE.destino);
+
+    expect(screen.getByText(C.OWN_RIDE_LABEL)).toBeInTheDocument();
+  });
+
+  it('should keep that announcement off a ride offered by someone else', async () => {
+    listReturning([RIDE]);
+    renderComponent();
+    await screen.findByText(RIDE.destino);
+
+    expect(screen.queryByText(C.OWN_RIDE_LABEL)).not.toBeInTheDocument();
   });
 
   it('should open the edit dialog filled with the ride, without lighting the offer tab', async () => {

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -46,6 +46,11 @@ function listReturning(rides: Ride[], onRequest?: (url: URL) => void) {
   );
 }
 
+/** Editar e excluir só existem para quem ofertou; os casos deles partem daqui. */
+function loggedAsTheDriver() {
+  tokenStorage.save('token', RIDE_DRIVER.name);
+}
+
 function renderComponent() {
   const router = createMemoryRouter(
     [
@@ -201,6 +206,7 @@ describe('Rides', () => {
 
   it('should ask for confirmation before deleting and keep the ride when it is refused', async () => {
     listReturning([RIDE]);
+    loggedAsTheDriver();
     renderComponent();
     await screen.findByText(RIDE.destino);
 
@@ -217,6 +223,7 @@ describe('Rides', () => {
   });
 
   it('should delete the ride once the removal is confirmed', async () => {
+    loggedAsTheDriver();
     let deleted = false;
     server.use(
       http.get(RIDES_URL, () => HttpResponse.json(deleted ? [] : [RIDE])),
@@ -239,6 +246,7 @@ describe('Rides', () => {
 
   it('should report a failure to delete', async () => {
     listReturning([RIDE]);
+    loggedAsTheDriver();
     server.use(http.delete(`${RIDES_URL}/:rideId`, () => new HttpResponse(null, { status: 500 })));
     renderComponent();
     await screen.findByText(RIDE.destino);
@@ -329,6 +337,18 @@ describe('Rides', () => {
     expect(screen.queryByRole('button', { name: CONTACT_LABEL })).not.toBeInTheDocument();
   });
 
+  it('should keep the owner actions off a ride offered by someone else', async () => {
+    listReturning([RIDE]);
+    renderComponent();
+    await screen.findByText(RIDE.destino);
+
+    expect(screen.queryByRole('button', { name: C.RIDE_CARD_LABELS.edit })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: C.RIDE_CARD_LABELS.delete }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: CONTACT_LABEL })).toBeInTheDocument();
+  });
+
   it('should announce the ride of the logged user, which the border stripe only shows', async () => {
     tokenStorage.save('token', RIDE_DRIVER.name);
     listReturning([RIDE]);
@@ -348,6 +368,7 @@ describe('Rides', () => {
 
   it('should open the edit dialog filled with the ride, without lighting the offer tab', async () => {
     listReturning([RIDE]);
+    loggedAsTheDriver();
     renderComponent();
     await screen.findByText(RIDE.destino);
 

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/RideOwnerActions/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/RideOwnerActions/index.tsx
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import { IconButton } from '@design-system';
+import { EditIcon } from '@design-system/icons';
+
+import { RIDE_CARD_LABELS } from '@app/pages/Rides/constants';
+import { isOwnRide, RIDE_DRIVER } from '@app/pages/Rides/helpers/rideDriver';
+import type { Ride } from '@app/services/rides/types';
+
+import { RideDeleteConfirmation } from '../RideDeleteConfirmation';
+
+type RideOwnerActionsProps = Readonly<{
+  ride: Ride;
+  onEdit: (ride: Ride) => void;
+  onDelete: (ride: Ride) => void;
+}>;
+
+/**
+ * Editar e excluir só existem para quem ofertou a carona. Esconder o botão é
+ * conveniência, não regra: quem impede de verdade é a API, e ela ainda não sabe
+ * de quem é a carona.
+ */
+export function RideOwnerActions({ ride, onEdit, onDelete }: RideOwnerActionsProps) {
+  const handleEdit = useCallback(() => onEdit(ride), [onEdit, ride]);
+
+  if (!isOwnRide(RIDE_DRIVER)) return null;
+
+  return (
+    <>
+      <IconButton type="button" label={RIDE_CARD_LABELS.edit} onClick={handleEdit}>
+        <EditIcon />
+      </IconButton>
+
+      <RideDeleteConfirmation ride={ride} onDelete={onDelete} />
+    </>
+  );
+}

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
@@ -1,6 +1,5 @@
-import { useCallback } from 'react';
-import { IconButton, ListCard, StatusTag, Typography } from '@design-system';
-import { AccessTimeIcon, CalendarTodayIcon, EditIcon, GroupsIcon } from '@design-system/icons';
+import { ListCard, StatusTag, Typography } from '@design-system';
+import { AccessTimeIcon, CalendarTodayIcon, GroupsIcon } from '@design-system/icons';
 import { format, parseISO } from 'date-fns';
 
 import * as C from '@app/pages/Rides/constants';
@@ -8,8 +7,8 @@ import { isOwnRide, RIDE_DRIVER } from '@app/pages/Rides/helpers/rideDriver';
 import { rideTypeDisplayLabel, rideTypeTone } from '@app/pages/Rides/helpers/rideType';
 import type { Ride } from '@app/services/rides/types';
 
-import { RideDeleteConfirmation } from './RideDeleteConfirmation';
 import { RideDriverContact } from './RideDriverContact';
+import { RideOwnerActions } from './RideOwnerActions';
 
 const DATE_FORMAT = 'dd/MM/yyyy';
 /** A API devolve `HH:mm:ss`; o cartão mostra só horas e minutos. */
@@ -22,8 +21,6 @@ type RideCardProps = Readonly<{
 }>;
 
 export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
-  const handleEdit = useCallback(() => onEdit(ride), [onEdit, ride]);
-
   const typeLabel = rideTypeDisplayLabel(ride.tipoCarona);
   const tone = rideTypeTone(ride.tipoCarona);
 
@@ -38,11 +35,7 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
           <ListCard.ActionButtons>
             <RideDriverContact destination={ride.destino} />
 
-            <IconButton type="button" label={C.RIDE_CARD_LABELS.edit} onClick={handleEdit}>
-              <EditIcon />
-            </IconButton>
-
-            <RideDeleteConfirmation ride={ride} onDelete={onDelete} />
+            <RideOwnerActions ride={ride} onEdit={onEdit} onDelete={onDelete} />
           </ListCard.ActionButtons>
         </ListCard.Actions>
       </ListCard.Header>

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
@@ -4,6 +4,7 @@ import { AccessTimeIcon, CalendarTodayIcon, EditIcon, GroupsIcon } from '@design
 import { format, parseISO } from 'date-fns';
 
 import * as C from '@app/pages/Rides/constants';
+import { isOwnRide, RIDE_DRIVER } from '@app/pages/Rides/helpers/rideDriver';
 import { rideTypeDisplayLabel, rideTypeTone } from '@app/pages/Rides/helpers/rideType';
 import type { Ride } from '@app/services/rides/types';
 
@@ -27,14 +28,12 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
   const tone = rideTypeTone(ride.tipoCarona);
 
   return (
-    <ListCard>
+    <ListCard own={isOwnRide(RIDE_DRIVER)} ownLabel={C.OWN_RIDE_LABEL}>
       <ListCard.Header>
         <Typography variant="subtitleBold">{ride.destino}</Typography>
 
         <ListCard.Actions>
-          <ListCard.WideOnlyTag>
-            <StatusTag tone={tone}>{typeLabel}</StatusTag>
-          </ListCard.WideOnlyTag>
+          <StatusTag tone={tone}>{typeLabel}</StatusTag>
 
           <ListCard.ActionButtons>
             <RideDriverContact destination={ride.destino} />
@@ -76,10 +75,6 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
           {ride.descricao}
         </Typography>
       </ListCard.Description>
-
-      <ListCard.CompactOnlyTag>
-        <StatusTag tone={tone}>{typeLabel}</StatusTag>
-      </ListCard.CompactOnlyTag>
     </ListCard>
   );
 }

--- a/FateConnect/Web/src/pages/Rides/constants/index.ts
+++ b/FateConnect/Web/src/pages/Rides/constants/index.ts
@@ -16,6 +16,9 @@ export const RIDE_LIST_MESSAGES = {
 
 export const RIDE_CARD_LABELS = { edit: 'Editar', delete: 'Excluir' };
 
+/** A faixa na borda não fala com leitor de tela; este texto é quem conta. */
+export const OWN_RIDE_LABEL = 'Minha carona';
+
 const SINGLE_SEAT = 1;
 
 export function seatsLabel(seats: number): string {


### PR DESCRIPTION


## Objetivo

Atender a issue #139. No estreito, a etiqueta de situação descia sozinha para o canto inferior direito enquanto as ações ficavam na linha do título — o cartão passava a ter duas âncoras de leitura. Agora etiqueta e ações ficam juntas no topo direito nas duas larguras, e a etiqueta é renderizada uma vez só.

Aproveitando a janela do PR, entraram mais duas coisas pedidas durante a tarefa, em commits separados: editar e excluir passam a existir só para quem ofertou a carona, e o diálogo de contato deixa de encostar o conteúdo à esquerda.

## Alterações

### Etiqueta e ações no topo do cartão (#139)

O par `WideOnlyTag`/`CompactOnlyTag` saiu. Ele renderizava a etiqueta **duas vezes no DOM** e alternava por media query; agora existe uma renderização só, dentro das ações do cabeçalho. Como os dois cartões dividem o `ListCard` desde a #148, a mudança vale para caronas e para achados e perdidos sem tocar nas telas.

Junto veio a faixa vermelha na borda esquerda marcando a carona de quem olha — achados e perdidos já a tinha, e agora os dois têm, cada um com o seu texto oculto para leitor de tela.

⚠️ **A faixa não acende para ninguém ainda.** O motorista é fictício e igual para toda carona, então "esta carona é minha" nunca dá verdadeiro. Quem desbloqueia é a **#105**; o código entra agora e acende sozinho, no mesmo arranjo que achados e perdidos mantém esperando a #106. A issue já previa isso.

### Editar e excluir só para quem ofertou

Espelha o que achados e perdidos já fazia: um componente dedicado que devolve `null` quando a carona não é de quem olha, irmão do contato dentro das ações.

⚠️ **Duas ressalvas.** Pelo mesmo motivo da faixa, hoje isto faz editar e excluir sumirem de **todas** as caronas para **todo mundo**, até a #105 chegar. E esconder o botão **não é regra**: a API não recusa editar nem excluir carona de terceiro — isso está no escopo da #105, e ficou escrito no JSDoc do componente para ninguém ler o botão escondido como proteção.

### Diálogo de contato centralizado

O conteúdo encostava à esquerda no desktop enquanto o título ficava centralizado. A causa é que a fileira declarava o alinhamento **transversal** e nunca o principal, caindo no `flex-start` padrão — o próprio JSDoc do componente só prometia centralização "no estreito". Medido antes: **0px de folga à esquerda, 139px à direita**. Depois: **70px de cada lado**. Vale para os diálogos de contato dos dois módulos, que dividem o componente.

### Dois defeitos anteriores, que esta mudança desenterrou

| Defeito | Antes | Depois |
| --- | --- | --- |
| No estreito o corpo do cartão encolhia até o conteúdo, então o topo direito parava em lugar diferente a cada cartão | borda do corpo em 335 num cartão e 326 no outro, com os dois cartões terminando em 351 | 291 nos dois, recuo de 16px |
| Título comprido sem espaços corria por cima da etiqueta e dos ícones | texto vazando 137px | quebra em 3 linhas, sem invadir |

O primeiro existia antes deste PR, mas ficava escondido enquanto o topo direito tinha só os ícones; com a etiqueta lá, a borda direita ficava visivelmente irregular entre cartões da mesma lista.

### Medições

Nas duas páginas, em 375px e 1440px, sempre depois de recarga forçada:

- recuo das ações até a borda do cartão: **16px, igual em todos os cartões**, nas duas larguras;
- ações no topo do cabeçalho: deslocamento 0;
- etiqueta no DOM: **uma vez**;
- três casos de título — curto, frase longa e palavra sem espaço: todos quebram sem invadir a etiqueta nem os ícones, sem transbordo;
- faixa da carona própria, com o nome do login casando: `4px solid rgb(207, 46, 46)`, texto oculto no DOM e botão de contato ausente.

### Testes

O caso que **afirmava a duplicação** da etiqueta virou a asserção do critério de aceite — de "existe duas vezes" para "existe uma vez" —, e o comentário que descrevia o comportamento antigo saiu junto. Em achados e perdidos, três asserções usavam `not.toHaveLength(0)`, uma hedge que só existia por causa da renderização dupla; viraram contagem exata. Quatro casos de editar e excluir passaram a entrar logados como o motorista, por um helper nomeado. Entraram três casos novos: dois para a faixa e um para as ações escondidas.

Os dois primeiros commits dividem `RideCard/index.tsx` e `Rides.test.tsx`. Para o primeiro ficar revertível sozinho, reconstruí o estado intermediário e verifiquei que ele passa isolado (`tsc` 0, 423/423); no fim, `md5` confirma que a árvore final é idêntica ao snapshot tirado antes de dividir.

### Gates

`eslint` 0 · `tsc` 0 · `vitest` 424/424 em 65 arquivos, cobertura 98,4% · `vite build` 0.

## Issue

- #139

Closes #139

## Evidências

<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/51be476a-af41-454c-98fb-a5babf6de5c9" />
<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/2b1d0291-f2aa-42d0-820a-d8e12f4d007f" />
<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/02ef2f57-9943-42db-b6da-7a8d92be1651" />
<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/195e65eb-d2c8-4935-b0a8-7c88de1aca5b" />

<img width="1291" height="947" alt="image" src="https://github.com/user-attachments/assets/8a61b0cc-9775-4bd8-b33d-1fd977059d6a" />

⚠️ A faixa e as ações só-do-dono **não se demonstram navegando**: enquanto a #105 não chegar, é preciso casar o nome do login com o do motorista fictício para vê-las.
