### PR TITLE
fix(153): update the deployment code before validating the environment

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -15,6 +15,29 @@ case "$ENVIRONMENT" in
   *) echo "Uso: ./deploy.sh hml|prod" >&2; exit 1 ;;
 esac
 
+# A atualização vem antes de tudo que possa falhar. Depois da validação, um
+# defeito nas linhas de cima travaria a publicação para sempre: o script
+# quebrado nunca alcança o `git pull` que traria a própria correção, e só um
+# acesso manual à máquina destrava.
+if [ -z "${DEPLOY_SELF_UPDATED:-}" ]; then
+  echo "==> Atualizando o código a partir da branch $BRANCH"
+  # Avisar e seguir não adianta: o `git checkout` abaixo aborta sozinho e a
+  # mensagem dele não diz o que fazer. Melhor parar aqui, explicando.
+  if [ -n "$(git -C .. status --porcelain)" ]; then
+    echo "ERRO: há alterações não commitadas nesta cópia do repositório." >&2
+    echo "Veja o que é com:  git -C '$(cd .. && pwd)' status" >&2
+    exit 1
+  fi
+  git -C .. fetch --prune
+  git -C .. checkout "$BRANCH"
+  git -C .. pull --ff-only
+
+  # `exec`, e não seguir em frente: o bash lê o script incrementalmente, então
+  # continuar executando o arquivo que o `pull` acabou de reescrever é
+  # imprevisível. A guarda impede que a cópia nova atualize outra vez.
+  DEPLOY_SELF_UPDATED=1 exec "$0" "$@"
+fi
+
 ENV_FILE=".env.$ENVIRONMENT"
 PROJECT="fateconnect-$ENVIRONMENT"
 WEB_ROOT="/var/www/fateconnect/$ENVIRONMENT"
@@ -47,18 +70,6 @@ if [ ! -f "$WEB_ROOT/index.html" ]; then
   echo "  ./build-front.sh $ENVIRONMENT" >&2
   exit 1
 fi
-
-echo "==> Atualizando o código a partir da branch $BRANCH"
-# Avisar e seguir não adianta: o `git checkout` abaixo aborta sozinho e a
-# mensagem dele não diz o que fazer. Melhor parar aqui, explicando.
-if [ -n "$(git -C .. status --porcelain)" ]; then
-  echo "ERRO: há alterações não commitadas nesta cópia do repositório." >&2
-  echo "Veja o que é com:  git -C '$(cd .. && pwd)' status" >&2
-  exit 1
-fi
-git -C .. fetch --prune
-git -C .. checkout "$BRANCH"
-git -C .. pull --ff-only
 
 echo "==> Construindo as APIs de $ENVIRONMENT ($PUBLIC_URL)"
 docker compose -p "$PROJECT" --env-file "$ENV_FILE" build


### PR DESCRIPTION
## Objetivo

Tirar do `deploy.sh` a dependência circular que travou o primeiro deploy real de homologação: ele **se validava antes de se atualizar**, então qualquer defeito na primeira metade do script tornava a publicação impossível de consertar pela pipeline — o `git pull` que traria a correção morava numa parte que o script quebrado nunca alcançava.

O defeito pontual que expôs isso (`valor: unbound variable`) já foi corrigido no #152. Este PR trata a causa que o tornou permanente.

## Alterações

- a atualização do código (`fetch` / `checkout` / `pull`, mais a checagem de árvore limpa) sai do meio do script e passa a ser a **primeira** coisa depois de descobrir a branch do ambiente;
- o script re-executa a cópia recém-baixada com `exec`, protegido por uma guarda que impede a segunda cópia de atualizar de novo.

O `exec` não é enfeite: o bash lê o script **incrementalmente**, então continuar executando o arquivo que o `pull` acabou de reescrever é imprevisível. Re-executar elimina isso.

A alternativa considerada — o workflow dar o `git pull` por SSH antes de chamar o script — foi descartada porque quebraria o `./deploy.sh hml` manual que o runbook documenta.

## Como foi provado

Montei um repositório de teste com um clone atrasado e defeituoso e uma origem já corrigida, reproduzindo o cenário real, e **executei** o script — `bash -n` não pega nada disso, porque a falha é semântica.

| Critério da issue | Resultado |
| --- | --- |
| atualiza antes de carregar e validar o `.env` | o clone puxou a correção e só então validou |
| re-executa uma vez, sem laço | `==> Atualizando` aparece 1 vez; sai no ponto esperado |
| uso manual intacto | `./deploy.sh` sem argumento e com argumento inválido seguem rejeitados |
| defeito na segunda metade se cura sozinho | 3 ocorrências antes → 0 depois |

Contraste no mesmo cenário, com a ordem que está hoje na `develop`: morre em `unbound variable`, o clone **não** avança e o defeito permanece — reproduzindo a falha de produção.

## Issue

- #153

Closes #153

## Evidências