### PR TITLE
fix(157): use a single red on the application actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Passa a abrir a aplicação no tema escolhido na última visita, em vez de voltar ao claro a cada recarga (#149) [Frontend]
 - Junta a etiqueta e as ações no topo do cartão de carona e de achados e perdidos também no celular, onde a etiqueta descia sozinha para o rodapé (#150) [Frontend]
 - Passa a marcar a carona de quem a ofertou e a oferecer editar e excluir só nela; enquanto a API não disser de quem é cada carona, nenhuma é reconhecida como sua (#150) [Frontend]
+- Padroniza o vermelho das ações, que alternava entre dois tons e destoava dentro da mesma tela, principalmente no tema escuro (#158) [Frontend]
 
 ### Fixed
 

--- a/FateConnect/Web/design-system/components/FilterPanel/index.tsx
+++ b/FateConnect/Web/design-system/components/FilterPanel/index.tsx
@@ -34,7 +34,7 @@ function FilterPanel({
     <S.PanelRoot defaultExpanded disableGutters>
       <S.PanelHeader expandIcon={<ChevronRightIcon />}>
         <FilterAltIcon />
-        <S.ActiveFilterBadge variant="dot" color="error" invisible={!active}>
+        <S.ActiveFilterBadge variant="dot" color="secondary" invisible={!active}>
           <Typography variant="subtitleBold" color="inherit">
             {title}
           </Typography>
@@ -47,7 +47,7 @@ function FilterPanel({
             {children}
 
             <FilterPanelField>
-              <S.SubmitButton type="submit" variant="contained" color="error" fullWidth>
+              <S.SubmitButton type="submit" variant="contained" color="secondary" fullWidth>
                 <SearchIcon fontSize="small" />
                 <Typography variant="subtitleBold" color="inherit">
                   {submitLabel}

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -115,7 +115,7 @@ export function LandingLoginCard() {
         />
 
         <S.SubmitRow>
-          <Button type="submit" variant="contained" color="error" loading={isPending}>
+          <Button type="submit" variant="contained" color="secondary" loading={isPending}>
             {C.SUBMIT_LABEL}
           </Button>
         </S.SubmitRow>

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/LostItemFormFields/LostItemPhotoField/index.tsx
@@ -77,7 +77,7 @@ export function LostItemPhotoField() {
           {photo && (
             <S.PhotoActionButton
               variant="outlined"
-              color="error"
+              color="secondary"
               onClick={handleRemove}
               disabled={disabled}
             >

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/index.tsx
@@ -79,7 +79,7 @@ export function LostItemFormDialog({ open, onClose, item }: LostItemFormDialogPr
             <S.SubmitButton
               type="submit"
               variant="contained"
-              color="error"
+              color="secondary"
               fullWidth
               loading={isPending}
             >

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/index.tsx
@@ -78,7 +78,7 @@ export function RideFormDialog({ open, onClose, ride }: RideFormDialogProps) {
             <S.SubmitButton
               type="submit"
               variant="contained"
-              color="error"
+              color="secondary"
               fullWidth
               loading={isPending}
             >

--- a/FateConnect/Web/src/pages/Signup/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/index.tsx
@@ -82,7 +82,7 @@ export function Signup() {
             <ConsentSection />
 
             <S.SubmitContainer>
-              <Button type="submit" variant="contained" color="error" loading={isPending}>
+              <Button type="submit" variant="contained" color="secondary" loading={isPending}>
                 {C.SUBMIT_LABEL}
               </Button>
 


### PR DESCRIPTION
## Objetivo

A aplicação usava **dois vermelhos** e a diferença aparecia dentro da mesma tela — no mural de achados, a aba "Buscar item" num tom e o botão "Filtrar" no outro. No tema escuro o contraste entre os dois ficava evidente. Agora a ação tem uma cor só: o opaco.

| Token | Claro | Escuro |
| --- | --- | --- |
| `secondary` (opaco) | `#CF2E2E` | `#D84E4E` |
| `error` (vibrante) | `#E81C0D` | `#F44336` |

## Alterações

Sete usos de `error` que eram **ação, não erro**, passaram para `secondary`: os botões de entrar e de cadastrar, os botões de enviar dos dois diálogos, o "Filtrar", o ponto de filtro ativo e o "Remover" do campo de foto.

⛔ **Os tokens não foram fundidos.** O `error` continua no tema com o tom de hoje, reservado a erro de verdade: o texto do campo de foto e a validação de campo, que passa pelo `Input` do design system e depende do token. Fundir deixaria a mensagem de validação exatamente da cor do botão de ação principal.

O oitavo consumidor — o texto de erro do campo de foto — ficou intocado de propósito.

## Como foi conferido

- varredura no repositório inteiro: nenhum `color="error"` sobra como cor de ação;
- a paleta e os tokens não foram tocados (`git diff` vazio em `design-system/theme/` e `design-system/tokens/`);
- gates rodados de novo fora da worktree do agente: ESLint sobre os 6 arquivos e `tsc --noEmit` em exit 0, e **424 testes em 65 arquivos** passando, `contrast.test.ts` incluído.

## Um ramo que ficou sem consumidor, e por que não saiu

`design-system/theme/components.ts` fixa o fundo do botão preenchido no hover para `secondary` **e** `error`. Com a troca, nenhum botão preenchido usa `error` nesta aplicação — mas o design system é consumido como biblioteca e `error` continua sendo uma cor legal, então a regra se aplicaria corretamente a um consumidor futuro. Não é código morto; é regra sem uso local.

## Suposição registrada

Depois desta troca o `error` sobra só como texto. Ele passa onde é usado hoje — 4.56:1 sobre o branco do diálogo no tema claro e 4.53:1 sobre a superfície elevada no escuro. Sobre o cinza da página daria 4.07:1 e reprovaria AA, mas esse caso não ocorre: todo texto de erro vive dentro de diálogo ou campo. Fica o registro caso algum formulário passe a viver direto sobre o fundo da página.

⚠️ O `CHANGELOG.md` vai conflitar com o do #156 quando um dos dois mergear — os dois tocam o `Unreleased`.

## Issue

- #157

Closes #157

## Evidências