### PR TITLE
ci(168): analyze the main branch in sonar

### DIFF
--- a/.github/workflows/sonar-main.yml
+++ b/.github/workflows/sonar-main.yml
@@ -1,0 +1,65 @@
+name: Sonar main
+
+# A `main` precisa ser analisada para o Sonar ter linha de base: é contra ela
+# que ele calcula o "código novo" de cada PR. O `check.yml` só dispara em
+# `pull_request`, então até aqui nenhuma análise da branch principal existia — e
+# o painel do projeto avisava isso.
+on:
+  push:
+    branches:
+      - main
+  # Disparo manual porque o push na `main` só acontece em release: sem ele, uma
+  # análise fora de ciclo — depois de mexer na configuração do Sonar, por
+  # exemplo — esperaria semanas pela próxima versão.
+  workflow_dispatch:
+
+# Duas análises da mesma branch em sequência não podem correr juntas: a segunda
+# publicaria um resultado calculado sobre um estado que já mudou.
+concurrency:
+  group: sonar-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Workflow próprio, e não um job no `release.yml`: lá os jobs são sobre
+  # publicar, e análise falha por motivos diferentes de tag e deploy.
+  sonar:
+    name: Analyze the main branch
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: FateConnect/Web
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Mesmo motivo do `check.yml`: sem histórico completo o Sonar não sabe
+          # quem mudou o quê e perde a noção de código novo.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: FateConnect/Web/.nvmrc
+          cache: yarn
+          cache-dependency-path: FateConnect/Web/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # O scan consome o lcov e o `sonar-report.xml` que esta suíte produz —
+      # sem rodá-la, `sonar.testExecutionReportPaths` aponta para um arquivo que
+      # não existe e o scan falha.
+      - name: Tests and coverage
+        run: yarn test:ci
+
+      # Mesma configuração do PR, pelo `sonar-project.properties`. O
+      # `sonar.qualitygate.wait` de lá vale aqui também: na `main` ele não
+      # bloqueia nada, mas deixa o run vermelho quando algo escapou do gate do
+      # PR — que é o único jeito de descobrir que escapou.
+      - name: Sonar
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        with:
+          projectBaseDir: FateConnect/Web
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Objetivo

O painel do SonarCloud avisava que **a `main` nunca foi analisada**. A causa não era um passo esquecido: **nenhum workflow rodava o Sonar em `push`**. O `check.yml` é o único que tem o passo, e dispara só em `pull_request`; o `release.yml` tem tag, publicação e back-merge — nenhum de análise.

Isso não é cosmético. O SonarCloud usa a branch principal como **linha de base do "código novo"** — é contra ela que o quality gate de cada PR mede. Sem análise da `main`, a comparação fica degradada.

## Alterações

Um workflow novo, `analyze.yml`, disparado no push da `main`: checkout, dependências, suíte com cobertura e o scan.

**Por que workflow próprio e não um job no `release.yml`:** os jobs de lá são sobre publicar. Análise falha por motivos diferentes de tag e deploy, e juntá-las faria um estragar o sinal do outro.

⚠️ **`fetch-depth: 0` não é detalhe.** Sem histórico completo o Sonar não atribui autoria nem calcula código novo — o `check.yml` já faz isso pelo mesmo motivo, e o comentário dele explica.

**A suíte roda antes do scan** porque é ela que produz o `lcov` e o `sonar-report.xml`. Sem isso o `sonar.testExecutionReportPaths` aponta para um arquivo inexistente e o scan falha.

**Nenhuma configuração foi duplicada:** o scan usa o mesmo `sonar-project.properties` do PR.

## O disparo manual

O gatilho de `push` na `main` só acontece em release — o aviso ficaria no painel até a próxima versão. O `workflow_dispatch` permite rodar uma vez agora e limpar, e serve também para reanalisar depois de mexer na configuração do Sonar.

## Uma decisão registrada

O `sonar.qualitygate.wait=true` vive no `sonar-project.properties`, compartilhado. Na `main` isso deixa o run **vermelho** se o gate reprovar, depois do merge, sem poder bloquear nada.

Mantido de propósito: todo PR já passa pelo gate antes, então reprovação na `main` significa que algo escapou — e o run vermelho é o único jeito de descobrir. Desligar só nesse workflow é possível se o ruído incomodar.

## Fora de escopo

Analisar a `develop`. Os PRs já são analisados como PR, e tratá-la como branch de longa duração no Sonar é configuração à parte que não resolve este aviso.

## Como conferir

⚠️ O gatilho é `push` na `main`, então **este PR não exercita o workflow**. A prova vem depois do merge, disparando o `workflow_dispatch` — e o critério é o painel do SonarCloud deixar de dizer que a `main` não foi analisada.

O YAML foi validado por parser, e o secret `SONAR_TOKEN` já existe no repositório, fora de ambiente — então está disponível para um workflow disparado por push.

## Issue

- #168

Closes #168

## Evidências