### PR TITLE
feat(171): add the pagination control and the list card skeleton

### DIFF
--- a/FateConnect/Web/design-system/components/ListCardSkeleton/ListCardSkeleton.test.tsx
+++ b/FateConnect/Web/design-system/components/ListCardSkeleton/ListCardSkeleton.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@app/test/testing-library';
+
+import { ListCardSkeleton } from '.';
+
+const GHOST_CARD_COUNT = 3;
+
+const renderComponent = () => render(<ListCardSkeleton />);
+
+describe('ListCardSkeleton', () => {
+  it('should stand in for the list while it loads', () => {
+    renderComponent();
+
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('article')).toHaveLength(GHOST_CARD_COUNT);
+  });
+
+  it('should leave nothing for the screen reader to announce', () => {
+    renderComponent();
+
+    expect(screen.getByRole('status')).toHaveTextContent('');
+  });
+});

--- a/FateConnect/Web/design-system/components/ListCardSkeleton/constants/index.ts
+++ b/FateConnect/Web/design-system/components/ListCardSkeleton/constants/index.ts
@@ -1,0 +1,6 @@
+const GHOST_CARD_COUNT = 3;
+
+export const GHOST_CARD_KEYS: readonly number[] = Array.from(
+  { length: GHOST_CARD_COUNT },
+  (_, index) => index,
+);

--- a/FateConnect/Web/design-system/components/ListCardSkeleton/index.tsx
+++ b/FateConnect/Web/design-system/components/ListCardSkeleton/index.tsx
@@ -1,0 +1,32 @@
+import { ListCard } from '@ds-root/components/ListCard';
+
+import { GHOST_CARD_KEYS } from './constants';
+import * as S from './styles';
+
+export function ListCardSkeleton() {
+  return (
+    <S.SkeletonList role="status" aria-busy>
+      {GHOST_CARD_KEYS.map((key) => (
+        <ListCard key={key}>
+          <ListCard.Header>
+            <S.GhostTitle />
+          </ListCard.Header>
+
+          <ListCard.InfoRow>
+            <ListCard.InfoItem>
+              <S.GhostInfo />
+            </ListCard.InfoItem>
+
+            <ListCard.InfoItem>
+              <S.GhostInfo />
+            </ListCard.InfoItem>
+          </ListCard.InfoRow>
+
+          <ListCard.Description>
+            <S.GhostDescription />
+          </ListCard.Description>
+        </ListCard>
+      ))}
+    </S.SkeletonList>
+  );
+}

--- a/FateConnect/Web/design-system/components/ListCardSkeleton/styles.ts
+++ b/FateConnect/Web/design-system/components/ListCardSkeleton/styles.ts
@@ -1,0 +1,27 @@
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+
+import { styled } from '@ds-root/styled';
+
+const TITLE_WIDTH_PX = 176;
+const TITLE_HEIGHT_PX = 20;
+const INFO_WIDTH_PX = 96;
+const LINE_HEIGHT_PX = 14;
+const DESCRIPTION_WIDTH = '70%';
+
+export const SkeletonList = styled(Stack)({ flexDirection: 'column', width: '100%' });
+
+export const GhostTitle = styled(Skeleton)({
+  width: `${TITLE_WIDTH_PX}px`,
+  height: `${TITLE_HEIGHT_PX}px`,
+});
+
+export const GhostInfo = styled(Skeleton)({
+  width: `${INFO_WIDTH_PX}px`,
+  height: `${LINE_HEIGHT_PX}px`,
+});
+
+export const GhostDescription = styled(Skeleton)({
+  width: DESCRIPTION_WIDTH,
+  height: `${LINE_HEIGHT_PX}px`,
+});

--- a/FateConnect/Web/design-system/components/Pagination/Pagination.test.tsx
+++ b/FateConnect/Web/design-system/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, userEvent } from '@app/test/testing-library';
+
+import { Pagination, type PaginationProps } from '.';
+
+const PAGE_COUNT = 10;
+const FIRST_PAGE = 1;
+const SINGLE_PAGE_COUNT = 1;
+const THIRD_PAGE = 3;
+const THIRD_PAGE_LABEL = 'Ir para a página 3';
+const VISIBLE_PAGES = '12345…10';
+
+const DEFAULT_PROPS: PaginationProps = { count: PAGE_COUNT, page: FIRST_PAGE, onChange: vi.fn() };
+
+const renderComponent = (props = DEFAULT_PROPS) => render(<Pagination {...props} />);
+
+describe('Pagination', () => {
+  it('should render the pages up to the gap and keep the last one visible', () => {
+    renderComponent();
+
+    expect(screen.getByRole('navigation')).toHaveTextContent(VISIBLE_PAGES);
+  });
+
+  it('should hand the chosen page to whoever owns the list', async () => {
+    const onChange = vi.fn();
+    renderComponent({ ...DEFAULT_PROPS, onChange });
+
+    await userEvent.click(screen.getByRole('button', { name: THIRD_PAGE_LABEL }));
+
+    expect(onChange).toHaveBeenCalledWith(THIRD_PAGE);
+  });
+
+  it('should render nothing when there is a single page', () => {
+    renderComponent({ ...DEFAULT_PROPS, count: SINGLE_PAGE_COUNT });
+
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+});

--- a/FateConnect/Web/design-system/components/Pagination/index.tsx
+++ b/FateConnect/Web/design-system/components/Pagination/index.tsx
@@ -1,0 +1,22 @@
+import { useCallback, type ChangeEvent } from 'react';
+
+import * as S from './styles';
+
+export type PaginationProps = Readonly<{
+  /** Total de páginas. Com uma só o controle não se desenha. */
+  count: number;
+  /** Página atual, contada a partir de 1. */
+  page: number;
+  onChange: (page: number) => void;
+}>;
+
+export function Pagination({ count, page, onChange }: PaginationProps) {
+  const handleChange = useCallback(
+    (_event: ChangeEvent<unknown>, nextPage: number) => onChange(nextPage),
+    [onChange],
+  );
+
+  if (count <= 1) return null;
+
+  return <S.PaginationNav count={count} page={page} onChange={handleChange} />;
+}

--- a/FateConnect/Web/design-system/components/Pagination/styles.ts
+++ b/FateConnect/Web/design-system/components/Pagination/styles.ts
@@ -1,0 +1,28 @@
+import MuiPagination from '@mui/material/Pagination';
+
+import { styled } from '@ds-root/styled';
+import { radiusScale, spacingScale } from '@ds-root/tokens';
+
+const { none, xxs } = spacingScale;
+
+const ITEM_SIZE_PX = 36;
+
+export const PaginationNav = styled(MuiPagination)(({ theme }) => ({
+  '& .MuiPagination-ul': { justifyContent: 'center' },
+
+  '& .MuiPaginationItem-root': {
+    minWidth: `${ITEM_SIZE_PX}px`,
+    height: `${ITEM_SIZE_PX}px`,
+    margin: theme.space(none, xxs),
+    borderRadius: theme.radius(radiusScale.md),
+    color: theme.palette.text.primary,
+  },
+
+  // Sem repetir a classe do item, este seletor empata com o do MUI e perde no
+  // desempate por ordem: o fundo do item selecionado volta ao cinza da biblioteca.
+  // O `:hover` repete porque o MUI o repinta com um tom que ele deriva sozinho.
+  '& .MuiPaginationItem-root.Mui-selected, & .MuiPaginationItem-root.Mui-selected:hover': {
+    backgroundColor: theme.palette.secondary.main,
+    color: theme.palette.secondary.contrastText,
+  },
+}));

--- a/FateConnect/Web/design-system/index.ts
+++ b/FateConnect/Web/design-system/index.ts
@@ -31,6 +31,8 @@ export { PageMessage } from './components/PageMessage';
 export type { PageMessageProps } from './components/PageMessage';
 export { PageShell } from './components/PageShell';
 export type { PageShellProps } from './components/PageShell';
+export { Pagination } from './components/Pagination';
+export type { PaginationProps } from './components/Pagination';
 export { StatusTag } from './components/StatusTag';
 export type { StatusTagProps } from './components/StatusTag';
 export type { StatusTagTone } from './theme/types';

--- a/FateConnect/Web/design-system/index.ts
+++ b/FateConnect/Web/design-system/index.ts
@@ -26,6 +26,7 @@ export type { InputProps } from './components/Input';
 export type { SelectOption } from './components/Input/components/SelectInput/types';
 export { ListCard } from './components/ListCard';
 export type { ListCardProps } from './components/ListCard';
+export { ListCardSkeleton } from './components/ListCardSkeleton';
 export { NotificationProvider } from './components/NotificationProvider';
 export { PageMessage } from './components/PageMessage';
 export type { PageMessageProps } from './components/PageMessage';

--- a/FateConnect/Web/design-system/theme/components.ts
+++ b/FateConnect/Web/design-system/theme/components.ts
@@ -124,6 +124,17 @@ export const components: Components<Theme> = {
   // deixava de valer para o que a tela desenhava.
   MuiPaper: { styleOverrides: { root: { backgroundImage: 'none' } } },
   MuiDialog: { styleOverrides: { paper: { borderRadius: radius(radiusScale.lg) } } },
+  // O esqueleto pisca por gradiente, não pela opacidade do `pulse` padrão: a 40%
+  // de opacidade a cor pintada deixa de ser a que `contrast.test.ts` mede.
+  MuiSkeleton: {
+    defaultProps: { variant: 'rectangular', animation: 'wave' },
+    styleOverrides: {
+      root: ({ theme }) => ({
+        backgroundColor: theme.palette.skeleton,
+        borderRadius: radius(radiusScale.sm),
+      }),
+    },
+  },
   MuiAppBar: {
     defaultProps: { elevation: 0 },
     styleOverrides: {

--- a/FateConnect/Web/design-system/theme/contrast.test.ts
+++ b/FateConnect/Web/design-system/theme/contrast.test.ts
@@ -58,6 +58,7 @@ function nonTextColours(theme: Theme): [string, string][] {
   return [
     ['the field outline', theme.palette.inputOutline],
     ['the button fill', theme.palette.secondary.main],
+    ['the loading skeleton', theme.palette.skeleton],
   ];
 }
 

--- a/FateConnect/Web/design-system/theme/createAppTheme.ts
+++ b/FateConnect/Web/design-system/theme/createAppTheme.ts
@@ -37,6 +37,7 @@ declare module '@mui/material/styles' {
     brandText: string;
     chrome: ChromeColors;
     inputOutline: string;
+    skeleton: string;
     statusTag: Record<StatusTagTone, SurfacePair>;
     notification: Record<NotificationVariant, SurfacePair>;
   }
@@ -45,6 +46,7 @@ declare module '@mui/material/styles' {
     brandText: string;
     chrome: ChromeColors;
     inputOutline: string;
+    skeleton: string;
     statusTag: Record<StatusTagTone, SurfacePair>;
     notification: Record<NotificationVariant, SurfacePair>;
   }

--- a/FateConnect/Web/design-system/theme/palettes.ts
+++ b/FateConnect/Web/design-system/theme/palettes.ts
@@ -56,6 +56,7 @@ export const lightPalette: PaletteOptions = {
    * (23% contra 38%), o que deixaria todo formulário mais lavado que hoje.
    */
   inputOutline: colorTokens.inputOutline,
+  skeleton: colorTokens.skeleton,
   statusTag: {
     neutral: { surface: NO_SURFACE, content: INHERITED_CONTENT },
     muted: { surface: colorTokens.mutedBackground, content: colorTokens.mutedText },
@@ -120,6 +121,7 @@ export const darkPalette: PaletteOptions = {
   },
   /** 38% de branco é a ênfase desabilitada do sistema de cor do Material Design. */
   inputOutline: darkColorTokens.onSurfaceDisabled,
+  skeleton: darkColorTokens.skeleton,
   // No escuro o par da etiqueta e o do aviso invertem de claridade, não de papel.
   statusTag: {
     neutral: { surface: NO_SURFACE, content: INHERITED_CONTENT },

--- a/FateConnect/Web/design-system/tokens/palette.ts
+++ b/FateConnect/Web/design-system/tokens/palette.ts
@@ -43,6 +43,14 @@ export const colorTokens = {
   mutedText: '#383D41',
   mutedBackground: '#E2E3E5',
 
+  /**
+   * Bloco-fantasma do esqueleto de carregamento. O cinza de esqueleto usual
+   * fica perto de 1.2:1 e some para quem enxerga pouco; este é o tom mais claro
+   * da família neutra que ainda alcança os 3:1 da WCAG 1.4.11 sobre os dois
+   * fundos claros.
+   */
+  skeleton: '#848C92',
+
   /** Divisor sobre superfície neutra. */
   divider: '#D9D9D9',
   /** Divisor sobre o cromo colorido, onde a linha precisa ser clara. */
@@ -117,6 +125,9 @@ export const darkColorTokens = {
   dangerTagText: '#EF9A9A',
   mutedTagBackground: '#37393B',
   mutedTagText: '#CFD8DC',
+
+  /** Bloco-fantasma: 33% de branco já achatado sobre a superfície elevada. */
+  skeleton: '#696969',
 
   onSurfaceHigh: 'rgba(255, 255, 255, 0.87)',
   onSurfaceMedium: 'rgba(255, 255, 255, 0.60)',


### PR DESCRIPTION
## Objetivo

As duas peças de interface que a lista paginada precisa e que não existiam no repositório. Saem juntas porque nenhuma serve para nada sozinha e as duas atendem os mesmos dois consumidores — caronas e achados e perdidos —, o mesmo motivo que põe o `ListCard` no design system.

## Alterações

- **`design-system/components/Pagination/`** — envolve o `Pagination` do MUI, que já entrega as reticências, a primeira e a última página, as setas, a navegação por teclado e os rótulos de leitor de tela. **Não se desenha quando há uma página só.** Exportado pelo barrel como componente próprio; o `ui.ts` não reexporta o do MUI cru, que é o que permite trocar depois sem varrer o app.
- **`design-system/components/ListCardSkeleton/`** — estado de carregamento no formato do `ListCard`, com três cartões-fantasma. Reusa o próprio `ListCard` em vez de redesenhar o cromo do cartão.
- **Slot novo na paleta, `skeleton`**, declarado nos dois temas e medido no `contrast.test.ts` como elemento não textual. O teste foi de **47 para 51 casos**.

### O esqueleto anima por gradiente, não pelo `pulse`

O `pulse` padrão do MUI baixa a opacidade a 40%, e aí a cor efetivamente pintada deixa de ser a que o `contrast.test.ts` mede. É a mesma família da armadilha do `Paper` com elevação que o tema já registra.

## Defeitos achados na conferência

### O seletor perdia para o do MUI, e isso só apareceu rodando a aplicação

⛔ `& .Mui-selected` tem a **mesma especificidade** do seletor do MUI e perdia no desempate por ordem de fonte. A cor do texto aplicava — o MUI não disputa essa propriedade — mas o fundo voltava ao cinza da biblioteca. O resultado era o número da página atual em **branco sobre cinza claro**, quase ilegível.

Isso passava por **ESLint, `tsc`, 436 testes e o próprio teste de contraste**, porque nenhum deles renderiza o componente dentro da aplicação. Corrigido repetindo a classe do item no seletor.

### O commit da paginação não compilava sozinho

O barrel já exportava o `ListCardSkeleton`, cuja pasta só chegava no commit seguinte. Cada commit passou a levar apenas a sua própria linha no barrel.

### O tom do esqueleto estava mais escuro do que precisava

O número que manda não é o contraste sobre o cartão branco (3.76) e sim **o menor dos dois** — 3.35 sobre o fundo cinza da página. O tom foi para o mais claro que ainda passa nas duas superfícies:

| Tema | Antes | Agora | Pior caso |
| --- | --- | --- | --- |
| Claro | `#7C858B` | `#848C92` | 3.35 → **3.04** |
| Escuro | `#747474` | `#696969` | 3.57 → **3.04** |

Não ficou em 3.00 exato de propósito: ponto flutuante e qualquer ajuste futuro de superfície derrubariam o teste.

## Prova na aplicação

Medido com `getComputedStyle` no app rodando, contra um stub de 47 caronas:

- **Paginação:** `‹ 1 2 3 4 5 ›`, rótulos de leitor de tela em pt-BR, página atual em `#CF2E2E` com texto branco a **5.14:1**.
- **Esqueleto:** três cartões-fantasma de quatro blocos, `#848C92` a **3.42:1** sobre o cartão branco, animação `wave`, container com `role="status"` e `aria-busy`.
- **Mutação:** trocando o token do esqueleto para o `#E0E0E0` convencional, os dois casos do `contrast.test.ts` **reprovam**; com o valor real, passam. A guarda é de verdade, não passa por acaso.

## Fora de escopo

Trocar o `CircularProgress` das telas pelo esqueleto, como a issue diz — isso é das sub-issues de cada tela (#173 e #174).

Consequência: os dois componentes entram **sem consumidor**, e é por isso que **não há entrada de changelog**. Nenhuma tela renderiza nenhum dos dois, então não há comportamento novo para quem usa.

## Gates

`eslint` 0 · `tsc` 0 · `vitest` 436/436 em 65 arquivos · contraste 51/51.

## Issue

- #171

Closes #171

## Evidências

<img width="1290" height="950" alt="image" src="https://github.com/user-attachments/assets/313d0c4b-ff77-433c-9256-ff8cb722909c" />
<img width="1290" height="950" alt="image" src="https://github.com/user-attachments/assets/a86f29df-e7af-41b8-b3eb-26c4354d0bfb" />
<img width="1290" height="950" alt="image" src="https://github.com/user-attachments/assets/f8a096f7-d207-4261-a562-a9e11f64d3ea" />
<img width="1290" height="950" alt="image" src="https://github.com/user-attachments/assets/e91aa6ab-8e8a-4b63-afae-febbc90b5e5b" />
