### PR TITLE
fix(171): give the pagination items the card look from the prototype

### DIFF
--- a/FateConnect/Web/design-system/components/Pagination/styles.ts
+++ b/FateConnect/Web/design-system/components/Pagination/styles.ts
@@ -1,11 +1,19 @@
 import MuiPagination from '@mui/material/Pagination';
 
 import { styled } from '@ds-root/styled';
-import { radiusScale, spacingScale } from '@ds-root/tokens';
+import { radiusScale, shadowTokens, spacingScale } from '@ds-root/tokens';
 
 const { none, xxs } = spacingScale;
 
 const ITEM_SIZE_PX = 36;
+
+/**
+ * Os pontos das reticências repousam na linha de base e os dígitos sobem a
+ * partir dela, então centralizar as duas caixas deixa a tinta em alturas
+ * diferentes. Este é metade da diferença entre as duas alturas de tinta, em
+ * `em` para acompanhar o tamanho da fonte.
+ */
+const ELLIPSIS_INK_OFFSET = '0.3em';
 
 export const PaginationNav = styled(MuiPagination)(({ theme }) => ({
   '& .MuiPagination-ul': { justifyContent: 'center' },
@@ -16,6 +24,20 @@ export const PaginationNav = styled(MuiPagination)(({ theme }) => ({
     margin: theme.space(none, xxs),
     borderRadius: theme.radius(radiusScale.md),
     color: theme.palette.text.primary,
+  },
+
+  // As reticências ficam de fora: no protótipo elas repousam sobre o fundo da
+  // página, e só os itens em que se clica são cartão.
+  '& .MuiPaginationItem-page, & .MuiPaginationItem-previousNext': {
+    backgroundColor: theme.palette.background.paper,
+    boxShadow: shadowTokens.component,
+  },
+
+  '& .MuiPaginationItem-ellipsis': {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transform: `translateY(-${ELLIPSIS_INK_OFFSET})`,
   },
 
   // Sem repetir a classe do item, este seletor empata com o do MUI e perde no


### PR DESCRIPTION
## Objetivo

O controle de paginação entregue no #178 saiu diferente do protótipo: as páginas **não selecionadas** deveriam ser quadrados brancos com sombra e estavam transparentes — só a selecionada tinha fundo. As setas de anterior e próxima, idem.

A branch reusa o ID da #171 por ser correção do que aquela issue entregou; ela já está fechada, então não há `Closes` aqui.

## Por que passou

O estilo definia tamanho, raio e cor de texto, e **nenhum `backgroundColor`**. Nenhum gate pega isso, e a conferência que fiz no #178 mediu **cores pontuais** em vez de comparar o controle inteiro com o desenho.

## Alterações

- `.MuiPaginationItem-page` e `.MuiPaginationItem-previousNext` ganham fundo `background.paper` e a sombra de `shadowTokens.component`.
- `.MuiPaginationItem-ellipsis` fica **de fora do fundo, de propósito**: no protótipo as reticências repousam sobre o fundo da página, sem cartão.
- As reticências ganham centralização e um deslocamento vertical.

### O deslocamento das reticências, e por que ele é contraintuitivo

Rendeu **três medições**, e as duas primeiras me enganaram:

| Medi | Disse | Estava |
| --- | --- | --- |
| Retângulo do elemento | alinhado | errado — o glifo subia 8px |
| Caixa de linha, via `Range` | 0px de diferença | errado — os pontos ficavam baixos |
| **Tinta, via `measureText`** | 0px | certo |

O `Range` parece medição de glifo mas ainda é caixa: ele devolve a **linha**, não a tinta. Medindo com `actualBoundingBoxAscent`, o dígito tem centro de tinta **5.0px acima** da linha de base e as reticências **0.8px** — porque dígito sobe a partir da base e ponto repousa nela. **Centralizar caixa nunca igualaria as duas.**

O deslocamento de `0.3em` é **metade da diferença entre as duas alturas de tinta** — derivado, não escolhido —, em unidade relativa para acompanhar o tamanho da fonte.

## As reticências não eram defeito

Também estranhamos não tê-las visto. Verifiquei antes de concordar: o teste unitário **já afirmava** a sequência `12345…10` com 10 páginas, e passava. O comportamento sempre esteve certo.

⛔ **O que faltou foi olhar.** A demo do #178 usou 47 itens com página de 10 — exatamente **5 páginas**, e cinco páginas não conseguem produzir reticências. Dado de teste incapaz de revelar o comportamento que se queria ver. Com 97 itens (10 páginas) a sequência apareceu igual à do protótipo.

## Sem teste novo, e sem changelog

O que mudou é fundo, sombra e deslocamento de tinta. O repositório não testa estilo computado em teste de unidade — a exceção é o `contrast.test.ts`, que já cobre o par relevante. Um teste afirmando `backgroundColor: white` só repetiria a folha de estilo; o que protege isso é **rodar na aplicação**, que é a regra escrita no #179.

Sem entrada de changelog: o componente ainda não tem consumidor, e nenhuma tela renderiza a paginação. Isso chega na #173 e na #174.

## Prova

Medido no app rodando contra um stub de 97 caronas, com 10 páginas:

- sequência `‹ 1 2 3 4 5 … 10 ›`, igual ao protótipo;
- setas e números não selecionados em `rgb(255, 255, 255)` com sombra; a selecionada em `rgb(207, 46, 46)` com texto branco; reticências transparentes e sem sombra;
- centro da tinta do dígito e das reticências no mesmo `y` — diferença **0px**.

## Gates

`eslint` 0 · `tsc` 0 · `vitest` 438/438 em 66 arquivos.

## Issue

- #171

## Evidências

<img width="1287" height="948" alt="image" src="https://github.com/user-attachments/assets/6421c772-7934-4687-8eb9-7ff35ee30ed0" />
<img width="1287" height="948" alt="image" src="https://github.com/user-attachments/assets/04341d4f-6f49-4d62-82e6-de490ec91418" />
