### PR TITLE
chore(release): cut version 0.4.1

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -27,7 +27,9 @@ O comentário que passou no teste acima ainda escolhe a forma errada. Acima de u
 
 O comentário que passou nos dois testes acima ainda mente com o tempo: ele foi escrito quando a regra nasceu, e a **regra ao lado mudou depois**. Ninguém releu.
 
-⛔ **Ao adicionar regra, seletor ou ramo perto de um comentário existente, releia o comentário vizinho.** É barato e é o único momento em que a divergência é visível.
+⛔ **Ao adicionar regra, seletor, ramo — ou outro comentário — perto de um comentário existente, releia o comentário vizinho.** É barato e é o único momento em que a divergência é visível.
+
+**Comentário ao lado de comentário é o caso mais fácil de pular**, porque o gesto não parece uma mudança de código: você está justamente escrevendo a explicação, então parece que a explicação já está sendo cuidada. Aconteceu em 2026-08-27 no `sonar-main.yml`: escrevi um bloco novo explicando por que a análise precisa declarar a versão, encostado num bloco que dizia que o run só fica vermelho *"quando algo escapou do gate do PR"* — a frase que acabara de se mostrar falsa, e a razão de eu ter procurado um culpado inexistente. Passei por cima dela para escrever ao lado. Quem apontou foi o Victor.
 
 Aconteceu três vezes no mesmo arquivo, em 2026-08-25, no `eslint.config.js` — e quem achou a primeira foi o Victor:
 

--- a/.claude/rules/fateconnect-locale-code.md
+++ b/.claude/rules/fateconnect-locale-code.md
@@ -12,6 +12,7 @@ Separar o que é **experiência do usuário (pt-BR)** do que é **base de códig
 
 - **Copy de produto:** texto de tela, notificação, diálogo, placeholder, `aria-label` quando é mensagem ao usuário, e o erro de bootstrap em `main.tsx`.
 - **URLs visíveis:** segmentos de rota e fragmentos de âncora (`inicio`, `cadastro`, `menu`, `achados-perdidos`, `caronas`, `buscar`, `ofertar`, `servicos`, `contato`, `login`). Trocar um segmento quebra link salvo — só com decisão de produto.
+- **Query string — o nome e o valor.** ⛔ **A regra não para no caminho:** `?meus=true` é errado pela mesma razão que uma rota `/lost-and-found` seria. Booleano é `sim` e `nao`; conjunto fechado usa o **rótulo** da interface, em minúscula e sem acento (`?tipo=solidaria`), nunca o valor que o backend serializa — ver `.claude/rules/product-copy.md`. Leitura tolerante a maiúscula, e valor irreconhecível cai no padrão em vez de quebrar a tela.
 - **`index.html`:** `lang="pt-BR"`, alinhado à interface.
 - **Comentário e JSDoc:** português, citando nome de API em inglês quando necessário.
 

--- a/.claude/rules/product-copy.md
+++ b/.claude/rules/product-copy.md
@@ -34,6 +34,14 @@ O mesmo objeto ou estado se chama igual em **toda** a tela — etiqueta, botão,
 
 ⛔ Aconteceu em achados e perdidos: etiqueta "Concluído", diálogo "Confirmar Conclusão", botão "Concluir" e aviso "Item resolvido" — dois nomes para um estado. Ficou **Resolvido** em todos, inclusive no valor que o contrato serializa.
 
+### O valor que o contrato serializa não é o rótulo
+
+⛔ **Antes de escrever um valor de enum em texto que alguém lê — copy, URL, corpo de issue —, confira o mapa de rótulo.** Os dois nem sempre coincidem: `Filantropica` aparece na tela como **Solidária**, e `Igualitaria` como **Igualitária**, com acento. O mapa mora ao lado da tela, em `src/pages/Rides/helpers/rideType.ts`.
+
+Aconteceu ao especificar a paginação: escrevi `?tipo=filantropica` chamando aquilo de "o termo em pt-BR do produto". Não era — era a serialização do backend, e a palavra que a interface usa é outra. Eu tinha lido o `types.ts`; o valor estava certo e o **papel** dele, errado.
+
+Coincidir é o caso feliz, não a regra: em achados e perdidos `lostItemKind.ts` diz que "o valor canônico já é o rótulo", e é por isso que lá não há armadilha.
+
 ## Erro: o problema e a saída
 
 Diz o que aconteceu e o que fazer: `Erro ao carregar os itens. Tente novamente.`

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -21,7 +21,7 @@ Saber isto muda o que você precisa fazer à mão. O `release.yml` dispara em to
 | `publish` | constrói e publica em produção, pelo mesmo `publish.yml` da homologação |
 | `back-merge` | traz a `main` de volta para a `develop` |
 
-⚠️ O `publish` para em **espera de aprovação**: o ambiente `prod` tem *Required reviewers*. A tag e o back-merge não esperam por ele — são jobs independentes de propósito.
+⚠️ **Mergear é publicar** — o `publish` sobe para produção sozinho, sem portão de aprovação. O que for conferir, confira antes do merge.
 
 ## 1. Ver se há o que publicar, e o quê
 
@@ -107,5 +107,4 @@ E confira que a `develop` recebeu o back-merge: `git rev-list --count origin/dev
 | Sintoma | Causa |
 | --- | --- |
 | O PR para a `main` é reprovado no passo `Version` | a versão da raiz já tem tag — faltou o bump |
-| A tag saiu, mas nada foi publicado | normal enquanto ninguém aprova o ambiente `prod` |
 | Um bump ficou para trás e ninguém notou | só a versão da raiz é lida; as outras não quebram nada ao divergir |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # É o ambiente do GitHub que separa as variáveis e os segredos dos dois
-    # destinos, e é onde se exige aprovação antes de produção.
+    # destinos.
     environment:
       name: ${{ inputs.environment }}
       url: ${{ vars.PUBLIC_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,7 @@ jobs:
   #
   # Os passos estão em `publish.yml`, compartilhados com homologação, para que
   # os dois ambientes subam pelo mesmo caminho. As variáveis e os segredos vêm
-  # do ambiente `prod` do GitHub, que é também onde se exige aprovação antes de
-  # publicar.
+  # do ambiente `prod` do GitHub.
   #
   # Independente do job da tag, como o back-merge: falha ao criar a tag não tem
   # por que impedir a publicação, e vice-versa.

--- a/.github/workflows/sonar-main.yml
+++ b/.github/workflows/sonar-main.yml
@@ -53,13 +53,30 @@ jobs:
       - name: Tests and coverage
         run: yarn test:ci
 
+      # A definição de código novo do projeto é `previous_version`, então sem
+      # versão declarada não há fronteira: as sete condições do gate são todas
+      # sobre código novo, nenhuma métrica `new_*` é calculada, e o veredito sai
+      # `NONE` — que o `sonar.qualitygate.wait` reprova como se fosse falha.
+      #
+      # Vem daqui e não do `sonar-project.properties` porque o número mora no
+      # `package.json` da raiz, fora do `projectBaseDir`.
+      - name: Project version
+        id: version
+        run: echo "value=$(jq -r .version "$GITHUB_WORKSPACE/package.json")" >> "$GITHUB_OUTPUT"
+
       # Mesma configuração do PR, pelo `sonar-project.properties`. O
       # `sonar.qualitygate.wait` de lá vale aqui também: na `main` ele não
-      # bloqueia nada, mas deixa o run vermelho quando algo escapou do gate do
-      # PR — que é o único jeito de descobrir que escapou.
+      # bloqueia merge nenhum, mas deixa o run vermelho quando o gate não sai
+      # `OK` — seja porque algo escapou do gate do PR, seja porque não houve
+      # código novo para avaliar.
+      #
+      # A versão só é declarada aqui: é a história de versões da `main` que
+      # forma a linha de base. Análise de PR usa o próprio diff como código
+      # novo e nunca consulta a versão.
       - name: Sonar
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         with:
           projectBaseDir: FateConnect/Web
+          args: -Dsonar.projectVersion=${{ steps.version.outputs.value }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-27
+
+### Fixed
+
+- Corrige a análise de qualidade da branch principal, que reprovava sem ter código novo para avaliar (#182) [Frontend]
+
 ## [0.4.0] - 2026-08-27
 
 ### Added

--- a/FateConnect/Web/package.json
+++ b/FateConnect/Web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fateconnect-web",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "engines": {
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"

--- a/FateConnect/Web/sonar-project.properties
+++ b/FateConnect/Web/sonar-project.properties
@@ -15,6 +15,11 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.testExecutionReportPaths=coverage/sonar-report.xml
 sonar.sourceEncoding=UTF-8
 
-# Reprova o job de CI quando o quality gate reprova. Sem isto o scan publica o
-# resultado no Sonar e sai verde, e o limite de duplicação não bloqueia nada.
+# Reprova o job de CI com qualquer veredito diferente de `OK`. Isso inclui
+# `NONE`, que não é reprovação e sim ausência de veredito — quando não há código
+# novo, nenhuma condição do gate é avaliada. O scanner escreve "FAILED" nos dois
+# casos, então o log não distingue "violou uma regra" de "não teve o que medir".
+#
+# Sem isto o scan publica o resultado no Sonar e sai verde, e o limite de
+# duplicação não bloqueia nada.
 sonar.qualitygate.wait=true

--- a/FateConnect/Web/src/providers/QueryProvider.tsx
+++ b/FateConnect/Web/src/providers/QueryProvider.tsx
@@ -6,7 +6,7 @@ import { useNotification } from '@app/hooks/useNotification';
 import { createQueryClient } from './queryClient';
 
 /** Precisa ficar dentro do provider de notificação: consome o notificador. */
-export function QueryProvider({ children }: { children: ReactNode }) {
+export function QueryProvider({ children }: Readonly<{ children: ReactNode }>) {
   const { notifyError } = useNotification();
   const [queryClient] = useState(() => createQueryClient(notifyError));
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -158,8 +158,9 @@ acusar.
 
 ### O que configurar no GitHub
 
-Em **Settings → Environments**, crie `hml` e `prod`. Em produção, marque
-*Required reviewers*: assim o push na `main` fica parado até alguém aprovar.
+Em **Settings → Environments**, crie `hml` e `prod`. É o ambiente que separa as
+variáveis e os segredos de cada destino; o push na `main` publica em produção
+direto.
 
 **Variables**, em cada ambiente:
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "fateconnect",
   "private": true,
-  "version": "0.4.0"
+  "version": "0.4.1"
 }


### PR DESCRIPTION
## Objetivo

Uma release de correção, e o alvo dela é a própria esteira. Desde que a `main` passou a ser analisada, **todo run da análise de qualidade sai vermelho** — e a 0.4.0 foi a primeira a mostrar isso.

### O diagnóstico

Vale escrever porque é contraintuitivo. São cinco elos, todos medidos:

1. A definição de código novo do projeto é **`previous_version`**.
2. **Nenhuma análise declarava versão** — a única análise da `main` gravou `projectVersion: "not provided"`.
3. Sem versão anterior não há fronteira de código novo. O gate tem **sete** condições e as sete são sobre código novo: nenhuma métrica `new_*` chegou a ser calculada.
4. Sem métrica, o veredito não é reprovação — é **`NONE`**, ausência de veredito.
5. O `sonar.qualitygate.wait` reprova o job com **qualquer coisa diferente de `OK`**. O scanner escreve "FAILED" nos dois casos, então o log não distingue "violou uma regra" de "não teve o que medir" — foi essa palavra que me fez procurar um culpado que não existia.

## Alterações

- **O workflow da análise da `main` passa a declarar `sonar.projectVersion`**, lido do `package.json` da raiz. Vem do workflow e não do `sonar-project.properties` porque o número mora fora do `projectBaseDir`. Só na `main`: é a história de versões dela que forma a linha de base — análise de PR usa o próprio diff e nunca consulta a versão.
- **O único issue aberto do projeto foi corrigido.** O `QueryProvider` era o único de 56 componentes do front sem `Readonly` nas props. É tipagem, sem efeito em runtime.
- **Quatro arquivos deixam de mentir sobre o portão de aprovação.** A revisão obrigatória do ambiente de produção foi desligada, então a publicação sobe sozinha no merge — mas os comentários e o guia de deploy ainda mandavam configurar revisor obrigatório. Confirmado na API antes de escrever: o ambiente `prod` está com `protection_rules: []`.
- **Dois comentários sobre o quality gate** passam a dizer que o job reprova com qualquer veredito diferente de `OK`, incluindo `NONE`.
- **Três regras do harness:** valor serializado não é rótulo, query string em pt-BR, e reler o comentário vizinho ao escrever um comentário ao lado dele.

### Bumps

| Arquivo | Mudança |
| --- | --- |
| `package.json` da raiz | 0.4.0 → **0.4.1** — é esta que vira a tag `v0.4.1` |
| `FateConnect/Web/package.json` | 0.9.0 → 0.9.1 |

As duas APIs .NET não sobem: diff vazio nas duas.

E vale dizer — **o próprio número é parte do conserto.** É ele que dá à definição `previous_version` a fronteira que faltava.

## Previsão do gate

O que dá para medir antes:

- Código novo em escopo do Sonar (`sonar.sources=src,design-system`) é a linha alterada no `QueryProvider`, e ela está **coberta**: 3 de 3 linhas, função executada 226 vezes. Cobertura de **100%**, contra o mínimo de 90 do gate.
- Zero violações críticas, zero duplicação, zero hotspots. Ratings **A**.

⚠️ **O risco que sobra:** se o Sonar não tratar `not provided` como versão distinta de `0.4.1`, a fronteira não nasce e o veredito volta `NONE`. Não dá para saber antes de rodar — a análise da `main` executa a definição que está **na** `main`, e a `main` ainda não tem este ajuste.

## Gates

ESLint 0 erros, `tsc` 0 erros, suíte inteira verde com cobertura de **98.51%** em statements e **99.36%** em linhas.

## O que acontece no merge

O `release.yml` roda três jobs independentes: a tag anotada `v0.4.1`, a publicação em produção e o back-merge da `main` na `develop`.

A publicação **não espera aprovação** — sobe sozinha.

## Evidências
