### PR TITLE
docs: add the community health files and the release commit rule

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -87,6 +87,12 @@ dotnet build -v q --nologo
 
 `## [Unreleased]` vira `## [X.Y.Z] - AAAA-MM-DD`, e um `## [Unreleased]` **vazio** nasce por cima. Não há links de comparação no rodapé deste arquivo — não invente.
 
+### Um commit só
+
+⛔ **O bump e o corte do CHANGELOG saem no mesmo commit.** Os dois passos acima são um assunto — *cortar a versão X.Y.Z* — e a release é onde o histórico tem que ser mínimo: quem revisa quer ver o número mudando, não a sequência que o produziu.
+
+Quando a branch de release levar correção junto — esteira, configuração —, ela é **um** commit e o corte é o outro. Dois é o teto.
+
 ## 5. Abrir o PR
 
 Branch `release/X.Y.Z` a partir da `develop`, PR **para a `main`** pela skill `pr-creator`.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,53 @@
+name: Defeito
+description: Algo que já existe não está funcionando como deveria.
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⛔ **Falha de segurança não entra aqui.** Use o [relato privado](https://github.com/victorfob/FateConnect/security/advisories/new).
+
+  - type: textarea
+    id: o-que-acontece
+    attributes:
+      label: O que acontece
+      description: O comportamento observado, em uma ou duas frases.
+    validations:
+      required: true
+
+  - type: textarea
+    id: o-que-deveria
+    attributes:
+      label: O que deveria acontecer
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducao
+    attributes:
+      label: Como reproduzir
+      description: O caminho até o defeito. Diga também com que dado — muitas vezes ele é a diferença entre ver e não ver.
+      placeholder: |
+        1. Abra …
+        2. Preencha … com …
+        3. Clique em …
+    validations:
+      required: true
+
+  - type: dropdown
+    id: onde
+    attributes:
+      label: Onde
+      options:
+        - Front-end (Web)
+        - API de contas (FateConnect.Api)
+        - API de caronas (Carona)
+        - Não sei
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidencia
+    attributes:
+      label: Evidência
+      description: Captura de tela, mensagem de erro ou saída do console. Remova dado pessoal antes de anexar.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Vulnerabilidade de segurança
+    url: https://github.com/victorfob/FateConnect/security/advisories/new
+    about: Não relate falha de segurança em issue pública — use o canal privado.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,35 @@
+name: Funcionalidade
+description: Algo que o projeto ainda não faz.
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: problema
+    attributes:
+      label: O problema
+      description: O que a pessoa não consegue fazer hoje. Descreva a necessidade, não a solução — a solução vem depois, na especificação.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposta
+    attributes:
+      label: Proposta
+      description: Como você imagina resolver. Tudo bem não ter resposta fechada.
+
+  - type: dropdown
+    id: onde
+    attributes:
+      label: Onde
+      options:
+        - Front-end (Web)
+        - API de contas (FateConnect.Api)
+        - API de caronas (Carona)
+        - Ainda não está claro
+    validations:
+      required: true
+
+  - type: textarea
+    id: referencia
+    attributes:
+      label: Referência
+      description: Protótipo, captura de outra aplicação, ou o texto que descreve como deve ficar.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Objetivo
+
+<!-- O que esta branch resolve, e por quê. Uma pessoa que não acompanhou a conversa precisa entender só com isto. -->
+
+## Alterações
+
+<!-- O que mudou de concreto. Descreva o efeito, não o arquivo. -->
+
+## Issue
+
+<!-- O número da issue que originou a mudança. Ex.: - #48 -->
+
+## Evidências
+
+<!--
+Captura, medição ou saída de comando que prova que funciona.
+Mudança visual pede captura; mudança de comportamento pede o teste ou o valor medido.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Código de Conduta
+
+## O compromisso
+
+Este é um espaço de aprendizado. Quem participa — abrindo issue, revisando código, comentando — deve poder fazê-lo sem hostilidade, independentemente de nível de experiência, idade, deficiência, aparência, identidade de gênero, orientação sexual, raça, etnia, nacionalidade ou religião.
+
+Erro de quem está aprendendo não é falta de conduta. Tratar alguém mal por causa dele, sim.
+
+## O que se espera
+
+- Criticar o código, a decisão ou o argumento — nunca a pessoa.
+- Aceitar review como o que ele é: leitura atenta do trabalho, não julgamento de quem o fez.
+- Explicar o porquê ao discordar. "Isso está errado" fecha a conversa; "isso quebra no caso X" a abre.
+- Assumir o erro quando ele for seu, corrigir, e seguir.
+
+## O que não se aceita
+
+- Ofensa, deboche ou insinuação de natureza sexual.
+- Ataque pessoal, provocação ou perseguição, dentro ou fora do repositório.
+- Publicar dado privado de alguém — endereço, e-mail, telefone — sem autorização explícita.
+- Insistir em comportamento já apontado como inadequado.
+
+## Alcance
+
+Vale em tudo que pertence ao projeto: issues, pull requests, commits, comentários de review e documentação. Vale também quando alguém representa o projeto em outro lugar.
+
+## Relatos
+
+Comportamento que viole este documento pode ser relatado pelo **[formulário privado de relato do repositório](https://github.com/victorfob/FateConnect/security/advisories/new)**, que chega apenas a quem mantém o projeto.
+
+Não use issue pública para relatar: ela expõe quem relata e quem é relatado, e não dá para desfazer.
+
+Quem mantém o projeto se compromete a responder, apurar e preservar a privacidade de quem relata. As respostas possíveis vão de um pedido de correção até o bloqueio permanente da pessoa no repositório, conforme a gravidade e a reincidência.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Como contribuir
+
+Obrigado pelo interesse. Este é um projeto acadêmico, e o fluxo aqui é simples — mas tem convenções próprias, e vale ler estas duas páginas antes de abrir a primeira mudança.
+
+O **[README](README.md)** é a referência completa: estrutura das pastas, regras de idioma, versionamento, integração contínua. Este arquivo é o caminho curto de quem vai contribuir, e não repete o que está lá.
+
+## Antes de escrever código
+
+**Abra uma issue primeiro.** O número dela alimenta o nome da branch, o título e o corpo do PR — sem ele, o rastro se perde. Se a mudança já tem issue, comente nela dizendo que vai pegar, para ninguém trabalhar em dobro.
+
+Issues são escritas em **pt-BR**: elas são documento de planejamento, não código.
+
+## Ambiente
+
+O front vive em `FateConnect/Web` e usa a versão do Node declarada no `.nvmrc`, com Yarn 1.x:
+
+```bash
+cd FateConnect/Web && nvm use && yarn && yarn dev
+```
+
+Os hooks locais **não vêm habilitados no clone** — o repositório usa `core.hooksPath` em vez de um gerenciador de hooks, para não desligar os hooks do Git LFS. Habilite uma vez:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+O `pre-push` roda só os testes relacionados aos arquivos enviados. A suíte inteira com cobertura fica no CI.
+
+## Branch e commit
+
+Branch sai da **`develop`**, nomeada `<tipo>/<número-da-issue>` — `feat/56`, `fix/171`, `chore/48`. Sem issue, um slug descritivo.
+
+Mensagem de commit em **inglês**, no imperativo, seguindo [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add the pagination control
+fix: correct the email field validation
+docs: update the setup guide
+```
+
+**Uma mudança lógica por commit** — mas agrupar é metade da regra. Se dois commits descrevem o mesmo assunto para quem lê o histórico, são um só. Dividir demais custa tanto quanto juntar tudo.
+
+## Pull Request
+
+PR aponta para a **`develop`**. Título em **inglês**, no formato `tipo(número-da-issue): descrição curta`. A **descrição** é o único texto do fluxo git em pt-BR, e segue o modelo que aparece ao abrir o PR: objetivo, alterações, issue e evidências.
+
+Antes de pedir review, rode os mesmos portões que o CI roda:
+
+```bash
+cd FateConnect/Web && yarn lint && yarn typecheck && yarn test:ci
+```
+
+Erro reprova. Warning não.
+
+## Mudança que o usuário percebe entra no CHANGELOG
+
+Tela nova, comportamento diferente, defeito corrigido — vai para a seção `## [Unreleased]` do [CHANGELOG.md](CHANGELOG.md), como **uma** entrada que descreve o efeito, terminando no número do PR.
+
+O que não muda comportamento — refactor interno, ajuste de teste, configuração de lint — fica só no histórico de commit.
+
+## Código
+
+Os padrões do front estão em `.claude/rules/`, e valem para quem escreve à mão tanto quanto para um agente de código: comentário só quando for estritamente essencial, nada de estilo inline, tipos e componentes em arquivos próprios, teste consultando por papel de acessibilidade.
+
+Antes de criar componente, hook ou utilitário, **procure o que já existe** — buscando pelo comportamento, não pelo nome. Se achar algo parecido mas não igual, proponha unificar em vez de criar a segunda cópia.
+
+## Segurança
+
+Encontrou uma vulnerabilidade? **Não abra issue.** O caminho está em [SECURITY.md](SECURITY.md).
+
+## Convivência
+
+Participar daqui implica seguir o [Código de Conduta](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Victor Brayner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ FateConnect/
 deploy/               publicação em homologação e produção → deploy/README.md
 ESII/  ESIII/  LBD/   documentos das disciplinas, versionados por entrega
 CHANGELOG.md          histórico de mudanças no formato Keep a Changelog
+CONTRIBUTING.md       como propor uma mudança
+CODE_OF_CONDUCT.md    o que se espera de quem participa
+SECURITY.md           como relatar vulnerabilidade
+LICENSE               MIT
 package.json          a versão do projeto, e nada mais
 ```
 
@@ -24,6 +28,10 @@ package.json          a versão do projeto, e nada mais
 - Código e estrutura — identificadores, arquivos, pastas: **inglês**
 - Mensagem de commit, nome de branch e **título** de PR em inglês. A **descrição** do PR é o único texto do fluxo git em pt-BR
 - Issues em pt-BR: são documento de planejamento lido pelo time
+
+## Como contribuir
+
+O caminho de quem vai propor uma mudança está em **[CONTRIBUTING.md](CONTRIBUTING.md)**; o que se espera de quem participa, no **[Código de Conduta](CODE_OF_CONDUCT.md)**. Vulnerabilidade **não** vai para issue pública — o canal está em **[SECURITY.md](SECURITY.md)**.
 
 ## Fluxo de trabalho
 
@@ -47,18 +55,23 @@ A validação consulta as tags no **remoto**. Consultar localmente aprovaria qua
 
 ## Integração contínua
 
-| Workflow      | Quando                                       | O que faz                                                          |
-| ------------- | -------------------------------------------- | ------------------------------------------------------------------ |
-| `check.yml`   | PR que toca `FateConnect/Web/**` ou a versão | valida a versão, tipos, lint, testes e build do front              |
-| `release.yml` | push na `main`                               | cria a tag da versão publicada e devolve a `main` para a `develop` |
+| Workflow          | Quando                                        | O que faz                                                                   |
+| ----------------- | --------------------------------------------- | --------------------------------------------------------------------------- |
+| `check.yml`       | PR que toca `FateConnect/Web/**` ou a versão  | valida a versão, tipos, lint, testes, build e a análise do Sonar            |
+| `deploy.yml`      | push na `develop`                             | publica em homologação                                                      |
+| `release.yml`     | push na `main`                                | cria a tag, publica em produção e devolve a `main` para a `develop`         |
+| `sonar-main.yml`  | push na `main`                                | analisa a `main`, que é a linha de base do código novo de cada PR           |
+| `publish.yml`     | chamado pelos dois de publicação              | constrói o front e sobe um ambiente — os passos que homologação e produção compartilham |
 
 O `check.yml` não roda em PR que não mexe no front: mudança de back-end não tem por que pagar a suíte de front. O `package.json` da raiz entra no filtro por causa da validação de versão — mudança de versão não pode escapar dela.
 
-Os dois passos da release moram no mesmo workflow porque acontecem no mesmo evento: o push que a `main` recebe quando a release entra. Eles não dependem um do outro — falha ao marcar a tag não impede a sincronização, e vice-versa.
+Os três jobs da release moram no mesmo workflow porque acontecem no mesmo evento: o push que a `main` recebe quando a release entra. Eles não dependem uns dos outros — falha ao marcar a tag não impede a publicação nem a sincronização, e vice-versa.
 
 O job de back-merge do `release.yml` empurra **direto na `develop`**, sem PR: a ruleset da `develop` concede bypass a uma **deploy key** de escrita, que o workflow usa no checkout, e a da `main` não concede a ninguém — a release continua exigindo PR e review. Bypass para o app GitHub Actions resolveria sem chave nenhuma, mas ele exige repositório de organização: em conta pessoal a API recusa o ator. O caminho comum é fast-forward, porque a `develop` normalmente não andou desde o corte da release. Quando andou, o job faz o merge de verdade; se conflitar, ele para e reporta, porque escolher qual lado vale é decisão humana.
 
-Não há envio de cobertura para o GitHub: o Code Quality exige repositório de organização em plano Team ou Enterprise Cloud, e este é de conta pessoal. Quem reprova por cobertura é o limite do Vitest, dentro do `test:ci`.
+Quem reprova por cobertura é o **quality gate do Sonar**, que mede o código novo do PR, somado ao limite do Vitest dentro do `test:ci`. Não há envio para o Code Quality do GitHub: ele exige repositório de organização em plano Team ou Enterprise Cloud, e este é de conta pessoal.
+
+A análise da `main` existe para dar ao Sonar a **linha de base** — é contra ela que o código novo de cada PR é calculado. Ela declara a versão do `package.json` da raiz porque a definição de código novo do projeto é *previous_version*: sem versão declarada não há fronteira, nenhuma métrica de código novo é calculada, e o gate reprova por não ter o que avaliar.
 
 ## Configuração do agente de código
 
@@ -70,7 +83,7 @@ A pasta **`.claude/`** guarda o contexto que um agente de código carrega ao tra
 | `rules/*.md`        | Padrão que vale para uma área do código                               | pelo `paths:` do arquivo — ao abrir um arquivo que casa                |
 | `skills/*/SKILL.md` | Procedimento sob demanda, com passos                                  | quando a tarefa casa com a `description`, ou pelo nome (`/pr-creator`) |
 
-As skills de hoje: **`pr-creator`** (abrir e atualizar PR), **`write-commit`** (mensagem de commit e agrupamento em commits), **`changelog-writer`** (entrada do `CHANGELOG.md`) e **`fateconnect-create-component`** (criar componente no front).
+As skills de hoje: **`spec-issue`** (especificar uma issue e dividir em sub-issues), **`pr-creator`** (abrir e atualizar PR), **`resolve-pr-comments`** (triar e responder review), **`write-commit`** (mensagem de commit e agrupamento em commits), **`changelog-writer`** (entrada do `CHANGELOG.md`), **`create-release`** (cortar uma versão e publicar), **`ux-writing`** (texto de interface) e **`fateconnect-create-component`** (criar componente no front).
 
 ### Como mexer nela
 
@@ -79,3 +92,7 @@ As skills de hoje: **`pr-creator`** (abrir e atualizar PR), **`write-commit`** (
 - **É conteúdo público.** Vale a mesma restrição do resto do repositório: nada de nome de empregador, repositório interno, pacote privado ou ferramenta corporativa. Quando a orientação vier de fonte interna, registre só a decisão e a justificativa.
 
 O raciocínio completo — quando uma correção merece virar regra, e onde cada coisa mora — está em `.claude/rules/harness-evolution.md`.
+
+## Licença
+
+[MIT](LICENSE). O aviso de copyright acompanha qualquer cópia ou trecho reaproveitado.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Política de Segurança
+
+## Versões cobertas
+
+O projeto está em desenvolvimento e não mantém versões antigas. Correções de segurança entram na versão em desenvolvimento e saem na release seguinte.
+
+| Versão | Coberta |
+| ------ | ------- |
+| última release | sim |
+| anteriores | não |
+
+## Como relatar uma vulnerabilidade
+
+⛔ **Não abra issue pública para vulnerabilidade.** A issue é visível para qualquer pessoa, e publicá-la antes da correção transforma o relato em instrução de ataque.
+
+Use o **[relato privado de vulnerabilidade do GitHub](https://github.com/victorfob/FateConnect/security/advisories/new)**. Ele abre um canal fechado entre você e quem mantém o projeto, sem expor nada até a correção sair.
+
+Ajuda muito incluir:
+
+- o que a falha permite fazer, em uma frase;
+- o passo a passo para reproduzir;
+- a parte afetada — front, API de contas, API de caronas — se souber;
+- a versão ou o commit onde encontrou.
+
+## O que esperar
+
+Um projeto acadêmico não tem plantão. O compromisso é responder ao relato assim que ele for visto, dizer se a falha foi confirmada, e avisar quando a correção sair. Se você quiser crédito no aviso publicado, diga no relato.
+
+## Fora de escopo
+
+O ambiente de homologação existe para testes do próprio projeto e roda com dados fictícios. Achado que dependa de acesso já autorizado a ele — ou de credencial que a própria pessoa possui — não é vulnerabilidade.


### PR DESCRIPTION
## Objetivo

A lista de **Community Standards** do GitHub estava em 2 de 8. Este PR fecha os seis que faltavam.

⚠️ **Um deles não é forma, é consequência real.** Repositório público **sem licença** significa, juridicamente, *todos os direitos reservados*: ninguém podia copiar, adaptar ou reutilizar nada — nem para estudar, que é o ponto de um repositório acadêmico aberto. O repo estava assim desde o primeiro commit.

## Alterações

| Arquivo | O que resolve |
| --- | --- |
| `LICENSE` | **MIT**, copyright 2026. Vale para o repositório inteiro, inclusive os documentos das disciplinas em `ESII/`, `ESIII/` e `LBD/` |
| `CONTRIBUTING.md` | o caminho curto de quem vai contribuir: issue primeiro, ambiente, branch e commit, PR, changelog e padrões de código |
| `CODE_OF_CONDUCT.md` | texto próprio, em pt-BR, no tom de um projeto de aprendizado |
| `SECURITY.md` | como relatar vulnerabilidade sem expor a falha antes da correção |
| `.github/ISSUE_TEMPLATE/` | dois formulários em pt-BR — defeito e funcionalidade — e um `config.yml` que desvia relato de segurança para o canal privado |
| `.github/PULL_REQUEST_TEMPLATE.md` | as quatro seções que já usamos: Objetivo, Alterações, Issue, Evidências |

O `CONTRIBUTING.md` **não repete o README**: aponta para ele. O README já documenta estrutura, idioma, versionamento e CI por inteiro, e duplicar isso é exatamente como os dois divergem depois.

O formulário de defeito pede explicitamente **com que dado** reproduzir. Não é zelo: dado escolhido errado esconde o comportamento que se quer ver, e o relato chega dizendo que algo não existe quando existe.

## A decisão sobre contato

O Code of Conduct e a Security policy precisam de um canal de relato. O formato mais comum na comunidade é um **e-mail dentro do arquivo**, e ele foi descartado de propósito: e-mail em repositório público e indexável vira alvo de spam, e não sai do histórico depois.

No lugar dele foi **ligado o relato privado de vulnerabilidade do GitHub**, e os dois arquivos apontam para o formulário dele. Confirmado no endpoint, não pelo código de saída do comando:

```
$ gh api repos/victorfob/FateConnect/private-vulnerability-reporting
{"enabled":true}
```

**Nenhum e-mail pessoal entrou no repositório.**

## Harness

A skill `create-release` passa a dizer que o **bump e o corte do CHANGELOG saem no mesmo commit**, e que dois commits é o teto quando a branch de release leva correção junto. Veio de correção nas duas releases de hoje, em que eu tinha separado os dois passos.

## README corrigido junto

O README descrevia um repositório que já não existia. As quatro divergências:

| Onde | Dizia | É |
| --- | --- | --- |
| Lista de skills | 4 | **8** |
| Tabela de CI | 2 workflows | **5** — faltavam `deploy.yml`, `publish.yml` e `sonar-main.yml` |
| Release | "os dois passos" | **três jobs** — a publicação em produção entrou depois, e ninguém releu a frase |
| Cobertura | "quem reprova é o limite do Vitest" | o **quality gate do Sonar** também, e é ele que mede o código novo |

E a maior: **o Sonar não aparecia em lugar nenhum do README**, apesar de ser o check obrigatório da `develop`. Agora aparece, junto com o motivo de a `main` precisar ser analisada — é ela que dá a linha de base contra a qual o código novo de cada PR é calculado.

Entraram também um apontador para o `CONTRIBUTING.md`, uma seção de licença, e os arquivos novos na árvore de estrutura.

É o defeito que a `comments.md` descreve — *texto que descreve o vizinho envelhece com ele*. Cada uma das quatro linhas nasceu de um PR que mudou o vizinho sem reler a frase ao lado.

## Evidências
