### PR TITLE
docs: update the harness rules and skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,6 +38,13 @@ cd FateConnect/Web && yarn test:ci      # suíte inteira com cobertura
 cd FateConnect/Web && yarn lint && yarn typecheck
 ```
 
+APIs (.NET 8):
+
+```bash
+dotnet test FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
+dotnet test FateConnect/Carona/Api.Tests/Api.Tests.csproj
+```
+
 ```bash
 git config core.hooksPath .githooks     # habilita os hooks deste clone
 ```

--- a/.claude/rules/harness-evolution.md
+++ b/.claude/rules/harness-evolution.md
@@ -50,6 +50,28 @@ Antes de escrever, escolha o lugar — os quatro não são intercambiáveis:
 
 Quando a pasta que uma rule descreve deixa de existir, a rule é **deletada, não reescrita** para o que ficou no lugar. Ela descrevia corretamente algo que não existe mais; reaproveitar o arquivo mistura dois contextos e produz orientação híbrida que não vale para nenhum dos dois. O mesmo vale para skill: procedimento sem alvo sai do repo, não vira procedimento genérico.
 
+## Criou skill, rule ou workflow? A lista que o enumera muda no mesmo PR
+
+⛔ **Dois inventários deste repo são mantidos à mão, e um deles mora em dois lugares.** Criar o item sem atualizar a lista não quebra nada e não deixa rastro: meses depois ninguém sabe qual PR a deixou para trás.
+
+| Inventário | Onde é enumerado |
+| --- | --- |
+| Skills | `.claude/CLAUDE.md` **e** `README.md` — duas cópias, que divergem |
+| Workflows | tabela de integração contínua do `README.md` |
+
+**As rules não entram na tabela porque ninguém as enumera** — os dois documentos descrevem o mecanismo (`paths:`, quando carrega) e apontam para um arquivo específico quando precisam. É por isso que elas nunca drifaram. Ao documentar algo novo, prefira descrever o mecanismo a listar os itens: **lista não escrita é lista que não mente.**
+
+**A conferência é contagem, não leitura** — foi lendo e achando certo que ela drifou:
+
+```bash
+ls -d .claude/skills/*/ | wc -l      # contra os nomes citados no CLAUDE.md E no README
+ls .github/workflows/*.yml | wc -l   # contra as linhas da tabela de CI
+```
+
+Em 2026-08-28 o README dizia **4 skills** quando eram 8 e **2 workflows** quando eram 5; o `CLAUDE.md`, que lista as mesmas skills, estava certo — a divergência entre as duas cópias é o sintoma. Junto vieram duas frases envelhecidas do mesmo jeito: *"os dois passos da release"*, que virou três jobs, e *"quem reprova por cobertura é o limite do Vitest"*, depois que o Sonar passou a reprovar também.
+
+⚠️ **O pior caso não é o número errado, é a ausência.** O Sonar não aparecia em lugar nenhum do README, sendo o check obrigatório da `develop` — e ausência não deixa frase errada apontando para ela. Só a comparação com o inventário real a encontra.
+
 ## O que NÃO fazer
 
 - **Não duplique silenciosamente.** Antes de criar rule nova, verifique se uma existente deveria ser estendida. Rules sobrepostas diluem o contexto e divergem com o tempo.

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -68,7 +68,7 @@ git diff --name-only origin/main..origin/develop -- FateConnect/FateConnect.Api 
 | `package.json` da raiz | **sempre** — é a versão da release e vira a tag |
 | `FateConnect/Web/package.json` | houve mudança em `FateConnect/Web/` |
 | `FateConnect/FateConnect.Api/FateConnect.Api.csproj` | houve mudança em `FateConnect/FateConnect.Api/` |
-| `FateConnect/Carona/Directory.Build.props` | houve mudança em `FateConnect/Carona/` — cobre os quatro projetos |
+| `FateConnect/Carona/Directory.Build.props` | houve mudança em `FateConnect/Carona/` — cobre os projetos da pasta |
 
 ⚠️ **As duas APIs versionam separado**, porque sobem como contêineres separados. Mudança só em caronas não move a versão da API de contas.
 

--- a/.claude/skills/spec-issue/SKILL.md
+++ b/.claude/skills/spec-issue/SKILL.md
@@ -1,23 +1,26 @@
 ---
 name: spec-issue
 description: >-
-  Especifica uma issue do GitHub por sabatina — perguntas em blocos até fechar as ambiguidades entre
-  o que a issue diz e o que o código mostra, decisões registradas no corpo da issue e divisão em
-  sub-issues de um PR cada. Use quando o usuário pedir para especificar, detalhar, refinar, planejar
-  ou quebrar uma issue.
+  Escreve ou especifica uma issue do GitHub por sabatina — perguntas em blocos até fechar as
+  ambiguidades entre o que se quer e o que o código mostra, decisões registradas no corpo da issue e
+  divisão em sub-issues de um PR cada. Use quando o usuário pedir para **criar** ou **abrir** uma
+  issue, e também para especificar, detalhar, refinar, planejar ou quebrar uma que já existe.
 ---
 
 # Especificar uma issue
 
 A issue diz o que se quer; o código diz o que existe. A especificação fecha a distância entre os dois — e quem fecha é o usuário, respondendo perguntas, não eu escolhendo em silêncio.
 
-⛔ **Não crie issue, branch ou label sem o usuário pedir.** Esta skill só cria sub-issues depois de listar todas e receber o sim.
+⛔ **Não crie issue, branch ou label sem o usuário pedir.** Pedida a issue, ela nasce ao fim da sabatina — nunca antes, porque é a sabatina que decide o que vai no corpo. Sub-issue só depois de listar todas e receber o sim.
 
 ## 1. Ler antes de perguntar
 
 Pergunta feita sem ler é pergunta que o repositório já respondia. Antes do primeiro bloco:
 
 - A issue e as que ela cita — `gh issue view <n> --json title,body,comments,milestone,assignees`
+- **Quando a issue ainda não existe**, não há o que abrir: leia no lugar as issues que ela vai
+  encostar — a que ela destrava, a que vai desfazer parte do que ela monta — e confira com
+  `gh issue list --state all --search` se alguém já abriu a mesma coisa
 - O **protótipo anexado**, quando houver: o corpo traz um `<img src="https://github.com/user-attachments/...">` e `curl -sL` baixa. Export de tela inteira vem alto demais para uma leitura só — fatiar com `sips` e ler banda a banda
 - A tela ou o módulo mais parecido que já existe — é dele que saem as opções fundamentadas
 - Os arquivos que a mudança vai tocar, com `Grep` e `Read`


### PR DESCRIPTION
## Objetivo

Fechar três buracos do harness que apareceram nesta rodada de trabalho. Nenhum deles quebrava nada — todos eram documento descrevendo um estado que deixou de existir, ou gatilho que não disparava. O PR toca **só `.claude/`**.

Mudança de harness dispensa issue, mas não dispensa PR: `.claude/` é versionada e passa por review como qualquer código.

## Alterações

### A lista que enumera algo à mão muda no mesmo PR

`.claude/rules/harness-evolution.md` ganha uma seção sobre os inventários mantidos à mão. O caso que a originou: o README dizia **4 skills** quando já eram 8, e **2 workflows** quando eram 5 — enquanto o `CLAUDE.md`, que lista as mesmas skills, estava certo. A divergência entre as duas cópias é o próprio sintoma.

O que a regra registra:

- os dois inventários à mão são as **skills** (enumeradas em dois lugares, `CLAUDE.md` e `README.md`) e os **workflows** (tabela do README);
- as **rules nunca drifaram** justamente porque ninguém as enumera — os documentos descrevem o mecanismo e apontam para um arquivo quando precisam. Daí a orientação de preferir descrever o mecanismo a listar itens;
- a conferência é **contagem**, não leitura: `ls -d .claude/skills/*/ | wc -l` contra os nomes citados. Foi lendo e achando certo que a lista drifou.

O pior caso não é o número errado, é a **ausência**: o Sonar não aparecia em lugar nenhum do README, sendo o check obrigatório da `develop` — e ausência não deixa frase errada apontando para ela.

### A skill `spec-issue` passa a disparar em "criar"

Três correções, todas de uma falha real desta sessão — a issue #184 foi escrita sem a skill, porque ela não se ofereceu:

| O que estava | O que ficou |
| --- | --- |
| `description` cobria "especificar, detalhar, refinar, planejar ou quebrar" | inclui **criar** e **abrir** — só a `description` dispara skill, e "criar" não estava lá |
| Passo 1 mandava ler a issue com `gh issue view <n>` | cobre o caso em que a issue ainda vai nascer: ler as que ela vai encostar e procurar duplicata com `gh issue list --search` |
| O ⛔ do topo dizia que a skill "só cria sub-issues" | a issue pedida nasce **ao fim** da sabatina, nunca antes; sub-issue segue exigindo a lista e o sim |

A terceira linha é a própria regra de comentário do repo em ação: a frase envelheceu no mesmo commit que a contradisse, porque a mudança fez a skill criar issue de topo e o texto ao lado continuou dizendo que ela não fazia isso.

### O harness alcança os projetos de teste das APIs

- `.claude/CLAUDE.md`: a seção **Comandos** ganha os dois `dotnet test`. Ela só tinha comando de front porque até agora não havia suíte nenhuma no back-end.
- `.claude/skills/create-release/SKILL.md`: a linha do `Directory.Build.props` dizia "cobre os **quatro** projetos" da solução de caronas. Com o projeto de teste passaram a ser cinco. Trocado por "cobre os projetos da pasta", que não volta a mentir na próxima vez que o número mudar — a mesma lição da regra acima.

## Ordem de merge

⚠️ **Este PR fica melhor depois do PR da #176**, que ainda não foi aberto.

Os dois últimos itens descrevem projetos de teste que só passam a existir na `develop` quando aquele PR entrar. Se este entrar primeiro, o `CLAUDE.md` documenta por um tempo dois comandos `dotnet test` apontando para projetos que ainda não existem ali. **Nada quebra** — não há automação lendo esses caminhos —, mas o documento fica adiantado em relação ao código.

As saídas são três: mergear a #176 primeiro, empilhar este naquele, ou aceitar a janela. A primeira é a mais simples.

## Evidências
