### PR TITLE
docs: settle where harness changes land and the back-end code language

### DIFF
--- a/.claude/rules/fateconnect-locale-code.md
+++ b/.claude/rules/fateconnect-locale-code.md
@@ -1,12 +1,12 @@
 ---
-description: Front — pt-BR para UI e URLs; inglês para código TypeScript e estrutura; domínio Ride e contrato da API Caronas
+description: pt-BR para UI e URLs; inglês para código e estrutura — absoluto no front, boy-scout no back-end .NET; domínio Ride e contrato da API Caronas
 paths:
-  - "FateConnect/Web/**"
+  - "FateConnect/**"
 ---
 
 # FateConnect — idioma da interface vs idioma do código
 
-Separar o que é **experiência do usuário (pt-BR)** do que é **base de código (inglês)**.
+Separar o que é **experiência do usuário (pt-BR)** do que é **base de código (inglês)**. O que vem a seguir descreve o front; o back-end .NET tem seção própria no fim, com rigor diferente.
 
 ## O que fica em **pt-BR**
 
@@ -23,6 +23,20 @@ Separar o que é **experiência do usuário (pt-BR)** do que é **base de códig
 - **`id` e seletor** usados só pelo código (não copy): inglês.
 - **Tokens** do design system: inglês (`primary`, `surfaceWhite`, `textMuted`).
 - **Teste:** `describe` e `it` em inglês, no padrão `should <fazer algo>`. O código dentro do teste também é inglês. Copy de produto em asserção continua em pt-BR, porque é o texto real da tela.
+
+## Back-end .NET: inglês no que nasce, boy-scout no que existe
+
+O idioma é o mesmo dos dois lados; o **rigor** não.
+
+**No front é absoluto** — nenhum identificador em português, e `Ride` no lugar de `Carona`.
+
+**No back-end é boy-scout**, porque o C# nasceu misto: verbo em inglês e domínio em português no mesmo símbolo (`GerarJwtToken`, `CriarClaimsDoUsuario`, `chaveSeguranca`, `CaronasController`).
+
+- **Arquivo, classe, método ou variável novo nasce em inglês**, mesmo cercado de português. `AuthorizationTests` ao lado de `GerarJwtToken` é o estado esperado durante a migração, não inconsistência a corrigir.
+- **O que já existe fica.** Renomear símbolo público arrasta interface, chamadas e às vezes migration — PR de funcionalidade não é lugar para isso.
+- **Traduza o símbolo que o próprio PR já estiver reescrevendo** por outro motivo. É o único rename que sai de graça.
+
+⛔ **Comentário continua em pt-BR dos dois lados**, `///` de C# incluído. O idioma do código e o idioma da explicação são decisões separadas.
 
 ## Contrato com a **API Caronas**
 

--- a/.claude/rules/harness-evolution.md
+++ b/.claude/rules/harness-evolution.md
@@ -17,10 +17,11 @@ Tudo vive no próprio repositório e é editável direto — não há package ne
 | Skills | `.claude/skills/<nome>/SKILL.md` | sob demanda, por `description` ou `/<nome>` |
 | Memória do projeto | `~/.claude/projects/-Users-victorbrayner-Development-Projects-FateConnect/memory/` | por recall, indexada em `MEMORY.md` |
 
-`.claude/` é **versionada**: mudar uma rule é mudar o repositório, entra no mesmo PR da mudança que a motivou e passa por review como qualquer código. Duas consequências práticas:
+`.claude/` é **versionada**: mudar uma rule é mudar o repositório e passa por review como qualquer código. Duas consequências práticas:
 
 - **A restrição do repositório vale aqui.** Rule e skill são conteúdo público: nada de nome de empregador, repositório interno, pacote privado ou ferramenta corporativa. Quando a orientação vier de fonte interna, registrar só a **decisão e a justificativa autônoma**.
-- **A correção anda junto com o código.** Rule que descreve um padrão deve chegar no mesmo PR em que o padrão aparece — separar as duas coisas é como elas divergem.
+- **Onde a mudança de harness entra é decisão de quem revisa — pergunte.** O instinto é mandar rule e código juntos, para não divergirem; mas abrir um PR inteiro por uma frase de rule é cerimônia que não paga, e levar uma rule sem relação nenhuma dentro de um PR de funcionalidade polui o review dele. Com a mudança na mão, ofereça as duas saídas: aproveitar um PR já aberto, ou abrir um só de harness.
+- ⛔ **Indo para PR próprio, vai `.claude/` inteiro — não metade.** Em 2026-08-28 escolhi sozinho levar a rule dentro do PR de autenticação; mandado separar, separei só o que não tinha relação com aquele PR e deixei para trás o que ele mesmo havia causado. A correção foi *"falei tudo relacionado a harness num PR proprio"*. **Documentação do repositório não é harness:** `README.md` e `CONTRIBUTING.md` continuam com o código que os motivou.
 
 ## Gatilhos — quando escrever em vez de só corrigir
 


### PR DESCRIPTION
## Objetivo

Duas regras que estavam contradizendo a prática — uma porque o repositório mandava o contrário do que foi decidido, outra porque simplesmente não existia. As duas nasceram de correções feitas durante o trabalho da autenticação das APIs.

## Alterações

### Onde uma mudança de harness entra passa a ser pergunta, não regra fixa

`.claude/rules/harness-evolution.md` dizia:

> A correção anda junto com o código. Rule que descreve um padrão deve chegar no mesmo PR em que o padrão aparece — separar as duas coisas é como elas divergem.

Isso deixou de valer. Agora a regra manda **oferecer as duas saídas** e deixar a escolha com quem revisa: aproveitar um PR já aberto, ou abrir um só de harness. O motivo de a pergunta existir está escrito junto — abrir um PR inteiro para trocar uma frase de rule é cerimônia que não paga, e levar uma rule sem relação nenhuma dentro de um PR de funcionalidade polui o review dele.

Um segundo item registra o limite que faltava: **indo para PR próprio, vai `.claude/` inteiro, não metade.** E deixa explícito que `README.md` e `CONTRIBUTING.md` **não são harness** — continuam com o código que os motivou.

A frase do parágrafo acima do item, que também dizia *"entra no mesmo PR da mudança que a motivou"*, foi corrigida na mesma passada. Sem isso ficaria um vizinho envelhecido contradizendo a regra nova — exatamente o padrão que a `comments.md` descreve.

### A regra de idioma passa a cobrir o back-end

`.claude/rules/fateconnect-locale-code.md` era escopada a `FateConnect/Web/**` e não dizia **nada** sobre C#. Agora cobre `FateConnect/**`, com uma seção própria para o .NET.

O idioma é o mesmo dos dois lados; o **rigor** não:

| | |
| --- | --- |
| **Front** | absoluto — nenhum identificador em português, `Ride` no lugar de `Carona` |
| **Back-end .NET** | boy-scout, porque o C# nasceu misto: verbo em inglês e domínio em português no mesmo símbolo (`GerarJwtToken`, `CriarClaimsDoUsuario`, `chaveSeguranca`, `CaronasController`) |

As três instruções do lado .NET:

- **símbolo novo nasce em inglês**, mesmo cercado de português. `AuthorizationTests` ao lado de `GerarJwtToken` é o estado esperado durante a migração, não inconsistência a corrigir;
- **o que já existe fica** — renomear símbolo público arrasta interface, chamadas e às vezes migration, e PR de funcionalidade não é lugar para isso;
- **traduza o símbolo que o próprio PR já estiver reescrevendo** por outro motivo, que é o único rename de graça.

Fecha registrando que **comentário continua em pt-BR dos dois lados**, `///` de C# incluído: o idioma do código e o idioma da explicação são decisões separadas.

A frase de abertura da rule ganhou um aviso de que as seções seguintes descrevem o front. Sem ele, alguém aplicaria a regra absoluta do front no C# e sairia renomeando meio back-end.

## Por que agora

A primeira regra saiu de eu ter montado o corte do PR errado **nas duas direções no mesmo dia**: primeiro levando a mudança de harness dentro do PR de autenticação por conta própria, depois separando só parte dela.

A segunda saiu dos primeiros projetos de teste das APIs. Não havia em lugar nenhum do repositório o que responder sobre o idioma, e quem pegasse o back-end amanhã veria `GerarJwtToken` ao lado de `AuthorizationTests` sem saber qual dos dois é o padrão.

⚠️ A migração do back-end para inglês está em curso por outra frente, e a #44 deve converter boa parte do que sobrou. **A rule descreve o regime permanente, não o mutirão** — ela continua valendo depois que a migração terminar.

## Evidências
