### PR TITLE
docs: sweep before the harness pr and offer decisions over assumptions

### DIFF
--- a/.claude/rules/harness-evolution.md
+++ b/.claude/rules/harness-evolution.md
@@ -96,3 +96,9 @@ Gatilho que dispara no meio de uma tarefa: **termine a tarefa primeiro**, depois
 ## Fechamento de rodada
 
 Ao fim de uma rodada com correções do usuário, antes de partir para a próxima tarefa: cruzar **cada** correção contra o harness e terminar em um de dois estados explícitos — **coberta** (dizer por qual rule/skill/memória) ou **descartada por decisão consciente** (dizer o motivo). Auditar também a memória contra as rules: memória órfã é regra que só dispara se eu lembrar de procurá-la.
+
+⛔ **A varredura roda ANTES de abrir o PR de harness, não depois.** É o único momento em que o item que ela encontra entra de graça: com o PR aberto, ele custa outro PR; com o PR mergeado, ele fica esperando o próximo — e "o próximo" é onde item conversado evapora.
+
+Aconteceu em 2026-08-28. Saíram **dois** PRs de harness no mesmo dia e um item conhecido não entrou em nenhum: o Victor tinha corrigido, horas antes do primeiro, que suposição com ele presente deveria virar pergunta. Eu só cruzei as correções contra o harness depois do segundo PR mergear, e a cobrança foi direta — *"acabamos de fazer um PR de harness, pq vc não sugeriu colocar nele isso?"*.
+
+**O gatilho é escrever `gh pr create` num PR que toca `.claude/`.** Antes de rodar: releia a conversa inteira procurando correção do usuário, não só a que motivou este PR.

--- a/.claude/skills/spec-issue/SKILL.md
+++ b/.claude/skills/spec-issue/SKILL.md
@@ -69,6 +69,16 @@ O corpo carrega, nessa ordem: as decisões em tabela, o modelo de dados ou contr
 
 Na dúvida entre as duas seções, é suposição: a decisão errada custa uma pergunta, a suposição errada custa a implementação.
 
+### Antes de registrar a suposição, ofereça a decisão
+
+⛔ **Suposição é para o que não dá para perguntar agora** — usuário ausente, resposta que depende de terceiro, detalhe que só a implementação revela. Com ele presente, parquear uma escolha na tabela de suposições é adiar trabalho que sairia por uma pergunta.
+
+O custo real de uma suposição não é ela estar errada: é **alguém ter que voltar nela**. Cada linha da tabela é uma conversa marcada para depois, e "depois" costuma ser no meio da implementação, com código já escrito em cima.
+
+⛔ Aconteceu na #184. Escrevi três suposições — projeto único no Sonar, análise dentro do job existente, chave do projeto sem nome — e o Victor respondeu *"não quero que fique suposições, vamos transformar elas em decisões"*. As três viraram um bloco de `AskUserQuestion` e foram decididas em uma rodada, com o motivo de cada uma registrado na tabela de decisões. A tabela de suposições sumiu do corpo.
+
+**A regra prática:** montou a lista de suposições, releia procurando as que **cabem numa pergunta com duas opções concretas**. Essas não são suposições — são perguntas que você não fez.
+
 ## 4. Dividir em sub-issues
 
 **Uma sub-issue é um PR.** O teste: dá para revisar e reverter sozinha?


### PR DESCRIPTION
## Objetivo

Uma correção que escapou de dois PRs de harness no mesmo dia, e o defeito de processo que a deixou escapar. **Não são dois itens soltos:** o segundo é a causa do primeiro ter ficado para trás.

## Alterações

### Antes de registrar a suposição, ofereça a decisão

`.claude/skills/spec-issue/SKILL.md` já mandava separar **decisão** (o que o usuário decidiu) de **suposição** (o que eu fechei sozinho para conseguir seguir). Faltava dizer que a suposição não é a primeira saída, é a última.

Suposição é para o que **não dá para perguntar agora**: usuário ausente, resposta que depende de terceiro, detalhe que só a implementação revela. Com ele presente, parquear uma escolha na tabela é adiar trabalho que sairia por uma pergunta.

O custo real de uma suposição não é ela estar errada — é **alguém ter que voltar nela**. Cada linha daquela tabela é uma conversa marcada para depois, e "depois" costuma ser no meio da implementação, com código já escrito em cima.

A regra prática que fecha a seção: montada a lista de suposições, releia procurando as que **cabem numa pergunta com duas opções concretas**. Essas não são suposições — são perguntas que não foram feitas.

Ancorada na #184: três suposições viraram um bloco de perguntas, foram decididas numa rodada, e a tabela de suposições sumiu do corpo da issue.

### A varredura de fechamento roda antes do PR, não depois

`.claude/rules/harness-evolution.md` já mandava cruzar cada correção do usuário contra o harness ao fim da rodada. Faltava o **quando**.

Agora está escrito: a varredura roda **antes de abrir o PR de harness**. É o único momento em que o item que ela encontra entra de graça — com o PR aberto ele custa outro PR, e com o PR mergeado fica esperando "o próximo", que é exatamente onde item conversado evapora.

O gatilho ficou concreto: **escrever `gh pr create` num PR que toca `.claude/`**. Antes de rodar, reler a conversa inteira procurando correção do usuário — não só a que motivou aquele PR.

## Como isso apareceu

Saíram dois PRs de harness no mesmo dia, #185 e #187. A correção sobre suposições tinha chegado **horas antes do primeiro** e não entrou em nenhum dos dois, porque eu só cruzei as correções contra o harness depois do segundo mergear. A cobrança foi direta: *"acabamos de fazer um PR de harness, pq vc não sugeriu colocar nele isso?"*.

## A varredura deste PR

Rodada antes de abrir, seguindo a regra que ele mesmo acrescenta:

- **Correções da sessão:** todas cobertas — idioma do código no back-end e local do PR de harness (#187), gatilho da `spec-issue` (#185), e as duas deste PR.
- **Inventários mantidos à mão:** 8 skills no disco, 8 citadas no `CLAUDE.md`, 8 no `README.md`; 5 workflows no disco, 5 linhas na tabela de CI. Sem divergência, nada a atualizar.

## Evidências
