### PR TITLE
docs: add the write-review-comment skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,7 @@ Planejamento e rastreio ficam no **GitHub** (issues + Project board do repositó
 ## Organização desta configuração
 
 - `.claude/rules/` — regras do projeto. Sem `paths:` carregam sempre; com `paths:` carregam quando um arquivo que casa é lido.
-- `.claude/skills/` — fluxos sob demanda: `spec-issue` (especificar uma issue e dividir em sub-issues), `pr-creator` (abrir/atualizar PR), `resolve-pr-comments` (triar e responder review), `write-commit` (mensagem de commit e agrupamento em commits), `changelog-writer` (entrada do CHANGELOG), `create-release` (cortar uma versão e publicar), `ux-writing` (texto de interface) e `fateconnect-create-component` (criar componente no front).
+- `.claude/skills/` — fluxos sob demanda: `spec-issue` (especificar uma issue e dividir em sub-issues), `pr-creator` (abrir/atualizar PR), `resolve-pr-comments` (triar e responder review), `write-review-comment` (comentar o PR de outra pessoa), `write-commit` (mensagem de commit e agrupamento em commits), `changelog-writer` (entrada do CHANGELOG), `create-release` (cortar uma versão e publicar), `ux-writing` (texto de interface) e `fateconnect-create-component` (criar componente no front).
 - `.claude/` é **versionada**: rule e skill passam por review no PR como qualquer código, e valem igual para quem clonar o repo. Por isso a restrição do repositório acima se aplica a elas também.
 
 ## Fluxo de trabalho

--- a/.claude/skills/write-review-comment/SKILL.md
+++ b/.claude/skills/write-review-comment/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: write-review-comment
+description: >-
+  Escreve comentário de review em PR deste repositório — formato Problema/Solução proposta, ancorado
+  na linha exata. Use quando o usuário pedir para comentar, revisar ou apontar problemas no PR de
+  outra pessoa, ou para levar achados de um code review para o PR. Para responder comentários que
+  outros escreveram, use `resolve-pr-comments`.
+---
+
+# Escrever comentário de review
+
+O comentário existe para quem vai corrigir, não para provar que eu li. Duas linhas, ancoradas onde o problema está.
+
+## O formato
+
+```
+Problema: o que está errado e o que acontece por causa disso.
+Solução proposta: o que fazer.
+```
+
+⛔ **Nada de comentário solto.** Todo apontamento vai numa linha específica. Comentário na aba de conversa não aparece ao lado do código, e quem corrige tem que caçar o lugar.
+
+⛔ **Um problema por comentário.** Dois threads sobre linhas vizinhas é ruído; se dois apontamentos têm a **mesma correção**, são um comentário só — foi o caso do `[Range]` duplicado e do `[Required]` inútil, que estavam no mesmo bloco de anotações e terminavam na mesma frase: enxugar o DTO.
+
+## Onde ancorar
+
+```bash
+gh api --method POST repos/<dono>/<repo>/pulls/<n>/comments \
+  -f commit_id="$(gh pr view <n> --json headRefOid --jq .headRefOid)" \
+  -f path="<caminho>" -F line=<n> -f side="RIGHT" -f body='...'
+```
+
+- ⛔ **A linha precisa estar dentro de uma seção do diff**, senão a API responde 422. Confira antes mapeando as seções — o `Program.cs` tinha um vão de duas linhas exatamente onde eu queria comentar.
+- **Problema num arquivo apagado: `side: LEFT`, no arquivo antigo.** É a melhor âncora para comportamento removido — o comentário sobre o `TimeOnlyJsonConverter` ficou em cima do XML doc que explicava por que ele existia, então o motivo e o apontamento chegam juntos.
+- Editar: `PATCH .../pulls/comments/<id>`. Apagar: `DELETE` no mesmo caminho.
+
+⛔ **Quando o problema é ausência, não há âncora.** Arquivo que o PR *não* tocou não está no diff. Aí o apontamento não é comentário: vira issue, ou não é levantado. **Decida com o usuário** — foi assim que o contrato do front virou uma issue em vez de um thread.
+
+## O que a redação precisa carregar
+
+- **A consequência concreta**, não a categoria. "Toda chamada do navegador é recusada e nada aparece no log da API" faz o autor entender em cinco segundos; "problema de configuração de CORS" não.
+- **O custo da correção, quando é baixo.** *"Nenhum `using` muda, porque o namespace já é esse"* transforma um pedido que parecia varredura num `git mv`.
+- **De onde o defeito veio, quando não é do autor.** O `unaccent` e a ordenação sem desempate vieram do código antigo. Dizer isso evita que o comentário soe como cobrança — e mantém o pedido, porque a oportunidade de corrigir é agora.
+- **Uma solução**, quando o código responde qual é a certa. **Duas**, apenas quando a escolha é do autor — e aí ordenadas, com a recomendada primeiro.
+
+⛔ **Nunca marque thread como resolvida.** Resolver é de quem comentou ou de quem revisa, não de quem apontou.
+
+## Meça antes de afirmar
+
+⛔ **Afirmação sobre dado, contagem, extensão ou configuração de ambiente exige medição.** Escrevi que uma migração deixaria as caronas órfãs e que a tela ficaria vazia em produção — os bancos não tinham uma linha. No mesmo review, medir transformou um achado hipotético sobre `unaccent` no defeito mais grave da rodada: o filtro por destino já respondia 500 em produção.
+
+O tempo verbal denuncia: *"vai ficar"*, *"responderia"*, *"em banco novo"*. Troque por passado medido.
+
+**Errou depois de publicar?** Edite o comentário para o texto correto e sem meta-narrativa — o histórico de edição do GitHub já registra. A explicação do erro vai para o usuário, não para o thread do autor.
+
+## Fechamento da rodada
+
+⛔ **Cruze a lista de achados contra os comentários publicados — não conte de cabeça.**
+
+```bash
+gh api repos/<dono>/<repo>/pulls/<n>/comments --jq '.[] | "\(.path):\(.line)"'
+```
+
+Cada achado termina num estado dito em voz alta: **comentado**, **virou issue**, **descartado porque eu estava errado**, ou **dispensado por decisão do usuário**. "Não mencionei mais" não é estado — foi assim que um achado evaporou entre dois turnos, e quem percebeu foi o usuário.
+
+## Idioma
+
+Comentário em **pt-BR**, como issue e descrição de PR. Nome de símbolo, arquivo e comando ficam como estão no código.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A pasta **`.claude/`** guarda o contexto que um agente de código carrega ao tra
 | `rules/*.md`        | Padrão que vale para uma área do código                               | pelo `paths:` do arquivo — ao abrir um arquivo que casa                |
 | `skills/*/SKILL.md` | Procedimento sob demanda, com passos                                  | quando a tarefa casa com a `description`, ou pelo nome (`/pr-creator`) |
 
-As skills de hoje: **`spec-issue`** (especificar uma issue e dividir em sub-issues), **`pr-creator`** (abrir e atualizar PR), **`resolve-pr-comments`** (triar e responder review), **`write-commit`** (mensagem de commit e agrupamento em commits), **`changelog-writer`** (entrada do `CHANGELOG.md`), **`create-release`** (cortar uma versão e publicar), **`ux-writing`** (texto de interface) e **`fateconnect-create-component`** (criar componente no front).
+As skills de hoje: **`spec-issue`** (especificar uma issue e dividir em sub-issues), **`pr-creator`** (abrir e atualizar PR), **`resolve-pr-comments`** (triar e responder review), **`write-review-comment`** (comentar o PR de outra pessoa), **`write-commit`** (mensagem de commit e agrupamento em commits), **`changelog-writer`** (entrada do `CHANGELOG.md`), **`create-release`** (cortar uma versão e publicar), **`ux-writing`** (texto de interface) e **`fateconnect-create-component`** (criar componente no front).
 
 ### Como mexer nela
 


### PR DESCRIPTION
## Objetivo

O repositório tinha procedimento para **responder** review — a `resolve-pr-comments` — e nada para **escrever** um. O formato saiu definido durante a revisão do PR #186 e some com a conversa se não for registrado.

## Alterações

### `write-review-comment`, skill nova

O formato, antes de tudo: duas linhas, `Problema:` e `Solução proposta:`, **ancoradas numa linha específica**. Comentário solto não aparece ao lado do código, e quem corrige tem que caçar o lugar.

O resto da skill é o que a rodada de ontem ensinou por tropeço:

| O que ficou escrito | De onde veio |
| --- | --- |
| A linha precisa estar **dentro de uma seção do diff**, senão a API responde 422 | o `Program.cs` tinha um vão de duas linhas exatamente onde eu queria comentar |
| Problema em arquivo apagado ancora com **`side: LEFT`** | foi a melhor âncora do dia: o comentário sobre o conversor de `TimeOnly` ficou em cima do XML doc que explicava por que ele existia |
| **Ausência não tem âncora** — vira issue, ou não é levantada, e a decisão é do usuário | arquivo que o PR não tocou não está no diff; foi assim que o contrato do front virou a #189 |
| Dois apontamentos com a **mesma correção** são um comentário só | `[Range]` duplicado e `[Required]` inútil estavam no mesmo bloco e terminavam na mesma frase |
| Dizer o **custo da correção** quando ele é baixo | *"nenhum `using` muda, porque o namespace já é esse"* transforma o que parecia varredura num `git mv` |
| Dizer **de onde o defeito veio** quando não é do autor | `unaccent` e ordenação sem desempate vieram do código antigo |
| **Uma** solução quando o código responde qual é a certa; duas só quando a escolha é do autor | |

### Meça antes de afirmar

A seção mais importante, porque nasceu do erro mais caro da rodada. Escrevi que uma migração deixaria as caronas órfãs e que *"a tela aparece vazia em produção"* — os bancos não tinham uma linha, e o achado inteiro ruiu.

No mesmo review, o oposto: medir transformou um apontamento hipotético sobre a extensão `unaccent` no defeito mais grave do dia — **o filtro por destino já responde 500 em produção**, e ninguém tinha notado porque a lista sem filtro funciona.

O sinal que a skill manda vigiar é o **tempo verbal**: "vai ficar", "responderia", "em banco novo". Futuro e condicional é onde a suposição se esconde.

E o que fazer quando o erro já foi publicado: editar o comentário para o texto certo, **sem meta-narrativa** — o histórico de edição do GitHub já registra, e a explicação do erro é para quem pediu o review, não para o thread do autor.

### Fechamento por lista, não por memória

Cruzar os achados contra os comentários publicados com `gh api`, e terminar cada um num estado dito em voz alta: comentado, virou issue, descartado por eu estar errado, ou dispensado por decisão. "Não mencionei mais" não é estado — um achado evaporou entre dois turnos, e quem percebeu foi quem pediu o review.

### Os dois inventários

`.claude/CLAUDE.md` e `README.md` ganham a entrada da skill nova, como manda a regra que entrou no #185. Conferido por contagem, não por leitura: **9 no disco, 9 no `CLAUDE.md`, 9 no `README.md`**.

## Varredura de fechamento

Rodada **antes** de abrir este PR, seguindo a regra do #188:

- **Correções da rodada:** as três estão cobertas — o formato do comentário (a skill), a afirmação sobre dados sem medir (seção própria mais memória) e a contagem de cabeça que perdeu um achado (seção própria mais memória).
- **Decisões de rodada que não viram regra:** comentar um de cada vez, deixar o `unaccent` para o autor corrigir, e não apontar a falta de testes porque a suíte chega pela branch da #176.
- **Inventários:** sem divergência.

## Evidências
