### PR TITLE
fix(176): require an authenticated user by default on the api

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,7 +48,7 @@ dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln
 git config core.hooksPath .githooks     # habilita os hooks deste clone
 ```
 
-O `pre-push` roda só os testes **relacionados** aos arquivos enviados (via `Web/scripts/test-changed.sh`); a suíte inteira com cobertura fica no CI.
+O `pre-push` roda só os testes **relacionados** aos arquivos enviados (via `FateConnect/Web/scripts/test-changed.sh`); a suíte inteira com cobertura fica no CI.
 
 ## Stack do front
 

--- a/.claude/rules/dotnet-authorization.md
+++ b/.claude/rules/dotnet-authorization.md
@@ -1,0 +1,42 @@
+---
+description: Autorização da API .NET — as duas camadas que protegem um endpoint e onde o `[Authorize]` mora ao criar action ou controller novos.
+paths:
+  - FateConnect/FateConnect.Api/**
+  - FateConnect/FateConnect.Api.Tests/**
+---
+
+# Autorização na API
+
+## São duas camadas, e as duas ficam
+
+| Camada | Onde | O que faz |
+| --- | --- | --- |
+| Piso | `Program.cs` — `SetFallbackPolicy(RequireAuthenticatedUser())` | vale onde o endpoint **não declarou nada**: endpoint novo nasce fechado |
+| Explícito | `[Authorize]` | diz a regra no arquivo que quem lê abre |
+
+⛔ **Nunca troque uma pela outra.** O atributo explícito documenta; a fallback policy protege o que alguém esqueceu de anotar. Sem o piso, o modo de falha volta a ser *esqueceu → aberto*, que é exatamente como os cinco endpoints de carona ficaram abertos para qualquer um com a URL até a #176.
+
+⚠️ **Com `[Authorize]` explícito em todo endpoint, a suíte deixa de exercitar o piso** — todo endpoint testado passa pelo atributo. O piso segue valendo só para o endpoint que ninguém anotou, que por definição ainda não existe para ser testado. É o argumento de por que ele não sai, não de que ele é redundante.
+
+## Onde o `[Authorize]` mora: onde a regra vale para todo mundo
+
+⛔ **Endpoint novo nasce com `[Authorize]` explícito.** Não é o que protege — é o que faz a proteção aparecer para quem abre o controller em vez de ficar só no `Program.cs`. Pedido no review do #191.
+
+O nível depende de o controller ser homogêneo ou misto, e são casos diferentes:
+
+| Controller | Onde vai | Exemplo |
+| --- | --- | --- |
+| **Homogêneo** — toda action exige token | `[Authorize]` **na classe**, junto de `[ApiController]` e `[Route]` | `RidesController`: listar, ver, ofertar, editar e excluir |
+| **Misto** — tem pelo menos uma action pública | `[Authorize]` **em cada action** protegida, `[AllowAnonymous]` na pública | `UsuarioController`: `cadastro` é anônimo, e o `PATCH` de configurações e preferências vai exigir token |
+
+⛔ **Ao acrescentar a primeira action pública, o `[Authorize]` desce da classe para as actions.** Deixá-lo na classe com um `[AllowAnonymous]` embaixo afirma duas coisas contrárias no mesmo arquivo: funciona, mas quem lê o topo conclui errado sobre metade das actions.
+
+Endpoint novo entra na teoria de rotas do `AuthorizationTests`, que prova por HTTP (401 sem token, 200 com token). O par positivo é obrigatório — ver `dotnet-testing.md`.
+
+## Perfil ainda não se cobra
+
+O token já emite o perfil como `ClaimTypes.Role` (`TokenService.CriarClaimsDoUsuario`), então gate por perfil é `[Authorize(Roles = ...)]` na action — não precisa de guard próprio, o ASP.NET Core já entrega o atributo.
+
+⛔ **Mas não escreva a policy antes de existir o que ela proteja.** Quem decide o perfil de quem se cadastra é `UsuarioService`, e é lá que se vê qual perfil o sistema realmente produz hoje. Policy sem endpoint administrativo e sem usuário que alcance o perfil nasce sem consumidor e sem teste possível — tem cara de segurança e não barra nada.
+
+Quando a hierarquia entre perfis for decidida (um perfil "conter" o outro), ela precisa sair no token ou numa policy nomeada: um `[Authorize(Roles = "Operator")]` **barra** quem tem só a claim de administrador, porque o `TokenService` emite uma claim de role por usuário.

--- a/.claude/rules/fateconnect-web-react.md
+++ b/.claude/rules/fateconnect-web-react.md
@@ -54,7 +54,7 @@ Componente = pasta com `index.tsx`, `styles.ts`, `types.ts` (quando houver tipo)
 | `vite.config.ts`, `coverage.include` | os arquivos saem do denominador, e o limite de 90% passa a medir outra coisa |
 | `sonar-project.properties` | a pasta sai da análise, inclusive da regra de 0% de duplicação |
 
-Mais `scripts/test-changed.sh`, cujo `case` decide entre testes relacionados e suíte completa, e o script `format` do `package.json`.
+Mais `FateConnect/Web/scripts/test-changed.sh`, cujo `case` decide entre testes relacionados e suíte completa, e o script `format` do `package.json`.
 
 **Cada um se prova com número, porque "passou" não prova nada aqui:** `grep -c '^SF:' coverage/lcov.info` para a cobertura, `files indexed` no log do Sonar comparado com a run anterior, e rodar o hook de verdade no `/bin/bash` com um arquivo da pasta nova.
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,15 +1,15 @@
 name: Check Pull Request
 
-# Só o front React é validado aqui, e só quando a mudança toca nele: PR de
-# backend não tem por que pagar a suíte de front. Sem filtro de branch de
-# destino no PR, porque PR empilhado (base em outra feature branch) também
+# Um job por lado do repositório, e cada um roda só quando a mudança toca o seu:
+# PR de backend não paga a suíte de front, nem o contrário. Sem filtro de branch
+# de destino no PR, porque PR empilhado (base em outra feature branch) também
 # precisa ser validado.
 #
-# O recorte é feito DENTRO do job, não em `paths` no gatilho, porque este check
-# é obrigatório para mergear. Workflow que não dispara não deixa o check
-# ausente: deixa ele `Pending` para sempre, e o PR fica impossível de mergear.
-# Rodando sempre, o contexto sempre reporta — e o PR que não toca o front paga
-# só a partida do runner, não a suíte.
+# O recorte é feito DENTRO de cada job, não em `paths` no gatilho, porque o job
+# do front é o check obrigatório para mergear. Workflow que não dispara não deixa
+# o check ausente: deixa ele `Pending` para sempre, e o PR fica impossível de
+# mergear. Rodando sempre, o contexto sempre reporta — e o PR que não toca aquele
+# lado paga só a partida do runner, não a suíte.
 on:
   pull_request
 
@@ -148,3 +148,50 @@ jobs:
           projectBaseDir: FateConnect/Web
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  api:
+    name: .NET API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Mesmo recorte do job acima, e pelo mesmo motivo: o checkout traz um
+      # commit só, então `git diff` contra a base não tem com o que comparar. O
+      # padrão não leva barra ao final para alcançar também o projeto de teste,
+      # que mora em `FateConnect.Api.Tests`, ao lado e não dentro.
+      - name: Changed paths
+        id: changes
+        run: |
+          set -euo pipefail
+
+          changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
+
+          if printf '%s\n' "$changed" | grep -qE '^(FateConnect/FateConnect\.Api|global\.json)'; then
+            echo 'api=true' >> "$GITHUB_OUTPUT"
+            echo 'A mudança alcança a API — validando.'
+            exit 0
+          fi
+
+          echo 'api=false' >> "$GITHUB_OUTPUT"
+          echo 'Nada na API — nada a validar aqui.'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - uses: actions/setup-dotnet@v4
+        if: steps.changes.outputs.api == 'true'
+        with:
+          dotnet-version: 8.0.x
+
+      # Aponta para a solução, e não para cada projeto de teste, porque assim o
+      # projeto novo entra na esteira ao ser adicionado à solução — o mesmo gesto
+      # que o faz aparecer na IDE.
+      #
+      # A suíte sobe a própria aplicação com banco em memória, então não há
+      # Postgres a provisionar aqui.
+      - name: Tests
+        if: steps.changes.outputs.api == 'true'
+        run: |
+          set -euo pipefail
+
+          dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 # Sobreposição local do compose: existe só na máquina de quem está testando.
 docker-compose.override.yml
 
+# Saída de build dos projetos .NET. Fica aqui, e não em mais um `.gitignore` por
+# projeto, porque a regra é a mesma para todos e projeto novo já nasce coberto.
+[Bb]in/
+[Oo]bj/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige a busca de carona por destino, que respondia erro em vez de listar o resultado (#186) [Backend]
 - Corrige a ordem da listagem de caronas, que ignorava a hora da partida e podia variar entre duas consultas iguais (#186) [Backend]
 
+### Security
+
+- Passa a exigir token nas caronas: listar, ver, ofertar, editar e excluir eram atendidos para qualquer pessoa com o endereço, sem identificação; entrar e cadastrar seguem abertos (#191) [Backend]
+
 ## [0.4.1] - 2026-08-27
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,12 @@ Antes de pedir review, rode os mesmos portões que o CI roda:
 cd FateConnect/Web && yarn lint && yarn typecheck && yarn test:ci
 ```
 
+Mexeu na API, rode também a suíte dela:
+
+```bash
+dotnet test FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
+```
+
 Erro reprova. Warning não.
 
 ## Mudança que o usuário percebe entra no CHANGELOG

--- a/FateConnect/FateConnect.Api.Tests/AccountApiFactory.cs
+++ b/FateConnect/FateConnect.Api.Tests/AccountApiFactory.cs
@@ -1,0 +1,48 @@
+using FateConnect.Api.Infrastructure.Database;
+using FateConnect.Api.Modules.Auth.Entities;
+using FateConnect.Api.Modules.Auth.Services;
+using FateConnect.Api.Modules.Usuarios;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace FateConnect.Api.Tests;
+
+public class AccountApiFactory : WebApplicationFactory<Program>
+{
+    public const string FakeSecret = "fake-test-secret-with-no-value-outside-this-suite";
+
+    public AccountApiFactory()
+    {
+        Environment.SetEnvironmentVariable("JWT_SECRET", FakeSecret);
+        Environment.SetEnvironmentVariable("JWT_ISSUER", "FateConnectTest");
+        Environment.SetEnvironmentVariable("JWT_AUDIENCE", "FateConnectTestWeb");
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            ServiceDescriptor registration = services.Single(
+                service => service.ServiceType == typeof(DbContextOptions<FateConnectDbContext>));
+
+            services.Remove(registration);
+            services.AddDbContext<FateConnectDbContext>(options => options.UseInMemoryDatabase("accounts"));
+        });
+    }
+
+    public static string IssueToken()
+    {
+        JwtOptions options = new()
+        {
+            Secret = FakeSecret,
+            Issuer = "FateConnectTest",
+            Audience = "FateConnectTestWeb",
+        };
+
+        return new TokenService(Options.Create(options))
+            .GerarJwtToken(new Usuario { Id = 1, EmailFatec = "pessoa@fatec.sp.gov.br" });
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/AuthorizationTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/AuthorizationTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace FateConnect.Api.Tests;
+
+public class AuthorizationTests : IClassFixture<AccountApiFactory>
+{
+    private readonly AccountApiFactory _factory;
+
+    public AuthorizationTests(AccountApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public static TheoryData<string, string> RideRoutes() => new()
+    {
+        { "GET", "/Rides" },
+        { "GET", "/Rides/8a1b0f2e-0000-4000-8000-000000000000" },
+        { "POST", "/Rides" },
+        { "PUT", "/Rides/8a1b0f2e-0000-4000-8000-000000000000" },
+        { "DELETE", "/Rides/8a1b0f2e-0000-4000-8000-000000000000" }
+    };
+
+    [Theory]
+    [MemberData(nameof(RideRoutes))]
+    public async Task RideEndpoints_WithoutToken_RespondUnauthorized(string method, string route)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), route);
+
+        HttpResponseMessage response = await _factory.CreateClient().SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RideEndpoints_WithAValidToken_ReachTheController()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", AccountApiFactory.IssueToken());
+
+        HttpResponseMessage response = await client.GetAsync("/Rides");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("/auth/login")]
+    [InlineData("/usuario/cadastro")]
+    public async Task AnonymousEndpoints_WithoutToken_ReachTheController(string route)
+    {
+        HttpResponseMessage response = await _factory.CreateClient().PostAsJsonAsync(route, new { });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Swagger_WithoutToken_RespondsOk()
+    {
+        HttpResponseMessage response = await _factory.CreateClient().GetAsync("/swagger/v1/swagger.json");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
+++ b/FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FateConnect.Api\FateConnect.Api.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/FateConnect/FateConnect.Api.Tests/TokenServiceTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/TokenServiceTests.cs
@@ -1,0 +1,49 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using FateConnect.Api.Modules.Auth.Entities;
+using FateConnect.Api.Modules.Auth.Services;
+using FateConnect.Api.Modules.Usuarios;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FateConnect.Api.Tests;
+
+public class TokenServiceTests
+{
+    private const string SecretWithAccent = "segredo-de-teste-com-acentuação-e-tamanho-suficiente";
+
+    private const string Issuer = "FateConnectTest";
+    private const string Audience = "FateConnectTestWeb";
+
+    [Fact]
+    public void GerarJwtToken_IsAcceptedByAKeyBuiltInUtf8()
+    {
+        JwtOptions options = new()
+        {
+            Secret = SecretWithAccent,
+            Issuer = Issuer,
+            Audience = Audience,
+        };
+
+        string token = new TokenService(Options.Create(options))
+            .GerarJwtToken(new Usuario { Id = 7, EmailFatec = "pessoa@fatec.sp.gov.br" });
+
+        ClaimsPrincipal principal = new JwtSecurityTokenHandler().ValidateToken(
+            token,
+            new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = Issuer,
+                ValidAudience = Audience,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(SecretWithAccent)),
+                ClockSkew = TimeSpan.Zero,
+            },
+            out SecurityToken _);
+
+        Assert.Equal("7", principal.FindFirstValue(ClaimTypes.NameIdentifier));
+    }
+}

--- a/FateConnect/FateConnect.Api/FateConnect.Api.sln
+++ b/FateConnect/FateConnect.Api/FateConnect.Api.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FateConnect.Api", "FateConnect.Api.csproj", "{0F9EF8F5-D33F-AF1A-B090-86EA3AF49C05}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FateConnect.Api.Tests", "..\FateConnect.Api.Tests\FateConnect.Api.Tests.csproj", "{A7902BDD-7500-425E-94D1-78DABDC7FB1C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,6 +16,10 @@ Global
 		{0F9EF8F5-D33F-AF1A-B090-86EA3AF49C05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F9EF8F5-D33F-AF1A-B090-86EA3AF49C05}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F9EF8F5-D33F-AF1A-B090-86EA3AF49C05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7902BDD-7500-425E-94D1-78DABDC7FB1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7902BDD-7500-425E-94D1-78DABDC7FB1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7902BDD-7500-425E-94D1-78DABDC7FB1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7902BDD-7500-425E-94D1-78DABDC7FB1C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FateConnect/FateConnect.Api/Modules/Rides/Controllers/RidesController.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Controllers/RidesController.cs
@@ -2,11 +2,13 @@ namespace FateConnect.Api.Modules.Rides.Controllers;
 
 using FateConnect.Api.Modules.Rides.DTOs;
 using FateConnect.Api.Modules.Rides.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
 [ApiController]
 [Route("[controller]")]
+[Authorize]
 [SwaggerTag("Ride Management")]
 public class RidesController(IRideService rideService) : ControllerBase
 {

--- a/FateConnect/FateConnect.Api/Program.cs
+++ b/FateConnect/FateConnect.Api/Program.cs
@@ -18,6 +18,7 @@ using FateConnect.Api.Modules.Usuarios.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
@@ -163,7 +164,9 @@ public class Program
 
         using (IServiceScope scope = app.Services.CreateScope())
         {
-            scope.ServiceProvider.GetRequiredService<FateConnectDbContext>().Database.Migrate();
+            DatabaseFacade database = scope.ServiceProvider.GetRequiredService<FateConnectDbContext>().Database;
+
+            if (database.IsRelational()) database.Migrate();
         }
 
         app.UseMiddleware<GlobalExceptionMiddleware>();

--- a/FateConnect/FateConnect.Api/Program.cs
+++ b/FateConnect/FateConnect.Api/Program.cs
@@ -16,6 +16,7 @@ using FateConnect.Api.Modules.Usuarios.Interfaces;
 using FateConnect.Api.Modules.Usuarios.Repositories;
 using FateConnect.Api.Modules.Usuarios.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Any;
@@ -147,6 +148,11 @@ public class Program
                     ClockSkew = TimeSpan.Zero
                 };
             });
+
+        builder.Services.AddAuthorizationBuilder()
+            .SetFallbackPolicy(new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build());
 
         string connectionString = Environment.GetEnvironmentVariable("DB_CONNECTION") ?? string.Empty;
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ A validação consulta as tags no **remoto**. Consultar localmente aprovaria qua
 
 | Workflow          | Quando                                        | O que faz                                                                   |
 | ----------------- | --------------------------------------------- | --------------------------------------------------------------------------- |
-| `check.yml`       | PR que toca `FateConnect/Web/**` ou a versão  | valida a versão, tipos, lint, testes, build e a análise do Sonar            |
+| `check.yml`       | todo PR                                       | um job por lado: front (versão, tipos, lint, testes, build e Sonar) e API (testes)      |
 | `deploy.yml`      | push na `develop`                             | publica em homologação                                                      |
 | `release.yml`     | push na `main`                                | cria a tag, publica em produção e devolve a `main` para a `develop`         |
 | `sonar-main.yml`  | push na `main`                                | analisa a `main`, que é a linha de base do código novo de cada PR           |
 | `publish.yml`     | chamado pelos dois de publicação              | constrói o front e sobe um ambiente — os passos que homologação e produção compartilham |
 
-O `check.yml` não roda em PR que não mexe no front: mudança de back-end não tem por que pagar a suíte de front. O `package.json` da raiz entra no filtro por causa da validação de versão — mudança de versão não pode escapar dela.
+O `check.yml` dispara em todo PR, e cada job decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. O `package.json` da raiz entra no filtro do front por causa da validação de versão — mudança de versão não pode escapar dela. Só o job do front é exigido para mergear.
 
 Os três jobs da release moram no mesmo workflow porque acontecem no mesmo evento: o push que a `main` recebe quando a release entra. Eles não dependem uns dos outros — falha ao marcar a tag não impede a publicação nem a sincronização, e vice-versa.
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Objetivo

Nenhum endpoint da API exigia token. Listar, ver, ofertar, editar e excluir carona eram atendidos para qualquer pessoa com o endereço, sem identificação — a infraestrutura de JWT existia inteira e não protegia nada, porque `UseAuthorization()` sem regra declarada não recusa ninguém.

Este PR nega por padrão: endpoint sem atributo nasce protegido, e abrir o acesso passa a exigir um `[AllowAnonymous]` explícito.

## Alterações

**Autorização.** Política de fallback com `RequireAuthenticatedUser` no `Program.cs`. Os `[AllowAnonymous]` que já existiam em entrar e cadastrar passam a ter efeito real, em vez de decorar endpoints que seriam anônimos de qualquer forma.

**Decisão registrada:** tudo em `/Rides` exige token, inclusive listar e ver. A #176 deixava a listagem em aberto como decisão de produto; ela foi tomada por este PR.

**Primeiro projeto de teste da API** — `FateConnect.Api.Tests`, com 10 testes:

- os cinco endpoints de `/Rides` respondem **401** sem cabeçalho `Authorization`;
- a **mesma rota** responde **200** com token válido — sem este caso a suíte passaria também numa API que recusa todo mundo;
- entrar e cadastrar continuam alcançando o controller;
- o Swagger continua aberto;
- o token assinado é aceito por uma chave montada em UTF-8, com segredo acentuado, que é onde ASCII e UTF-8 divergem.

A suíte sobe a aplicação com banco em memória, então não há Postgres a provisionar. Para isso o `Database.Migrate()` ganhou uma guarda `IsRelational()` — provedor em memória não tem migration.

**Esteira.** Job `.NET API` no `check.yml`, apontando para a solução: projeto de teste novo entra sozinho ao ser adicionado a ela. O recorte por arquivos alterados não leva barra ao final, para alcançar também `FateConnect.Api.Tests`, que mora ao lado da API e não dentro.

**`global.json` fixando o SDK em 8.0.x.** Sem ele o build depende de qual SDK a pessoa tem instalada: o `AnalysisLevel=latest-recommended` liga os analisadores do **SDK**, não os do `net8.0` do projeto, e com `TreatWarningsAsErrors` isso vira erro de compilação. Medido no mesmo commit trocando só o SDK — 8.0.424 dá `Build succeeded`, 10.0.400 reprova numa regra que nasceu no .NET 9.

**Documentação.** O `.gitignore` da raiz passa a ignorar `bin/` e `obj/`, cobrindo projeto .NET novo sem mais um arquivo por projeto. `CONTRIBUTING.md` ganha a linha da suíte da API, e o `README.md` corrige a tabela de integração contínua.

## O que ficou de fora, e por quê

A branch foi **reescrita sobre a `develop`** depois do merge do #186, que unificou as caronas nesta API. Duas coisas saíram no caminho:

- **A correção do encoding do JWT não está mais aqui** — o #186 já a trouxe, atendendo aos comentários de review. Sobrou o teste que a protege.
- **Tudo que era da API de caronas morreu com ela**: a política naquele `Program.cs` e o projeto `Carona/Api.Tests`. A decisão de negar por padrão sobreviveu; a implementação mudou de arquivo.

## Issue

- #176

Closes #176

## Evidências
