### PR TITLE
docs: standardize dotnet testing and sharpen the review rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,11 +38,10 @@ cd FateConnect/Web && yarn test:ci      # suíte inteira com cobertura
 cd FateConnect/Web && yarn lint && yarn typecheck
 ```
 
-APIs (.NET 8):
+API (.NET 8):
 
 ```bash
-dotnet test FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
-dotnet test FateConnect/Carona/Api.Tests/Api.Tests.csproj
+dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln
 ```
 
 ```bash

--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,8 +1,18 @@
 ---
-description: Quando comentar — só o estritamente essencial, e o teste é se o comentário impede uma mudança errada
+description: Quando comentar — zero no back-end .NET, e no front só o estritamente essencial, cujo teste é impedir uma mudança errada
 ---
 
 # Comentário
+
+## No back-end .NET, zero
+
+⛔ **Nenhum comentário em C#** — nem `//`, nem `///`, nem XML doc, em código de produção ou de teste. Não há exceção a pesar caso a caso: a regra é a ausência.
+
+Decidido pelo Victor em 2026-08-28, durante a reescrita da `fix/176`: *"vamos ajustar a regra de comentários, zero comentários no backend"*. Saíram 20 linhas de 4 arquivos na mesma rodada — a política de fallback, a guarda de migration, os XML docs da fábrica de teste e a explicação do segredo acentuado —, e nenhum teste caiu.
+
+**Onde a explicação passa a morar:** no nome do símbolo, no corpo do PR, ou na issue. Se um trecho de C# só se entende com texto ao lado, é o trecho que precisa mudar.
+
+⚠️ **A regra é do código, não do repositório.** YAML de workflow, script de shell, Markdown e o front seguem pela seção abaixo — lá o comentário existe, só é raro.
 
 ⛔ **Comentário só quando for estritamente essencial:** trecho não óbvio, que não se explica sozinho. **Se o código precisa ser explicado, o problema é o código** — renomeie, extraia, simplifique, e o comentário deixa de ser necessário.
 

--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -8,7 +8,15 @@ description: Quando comentar — zero no back-end .NET, e no front só o estrita
 
 ⛔ **Nenhum comentário em C#** — nem `//`, nem `///`, nem XML doc, em código de produção ou de teste. Não há exceção a pesar caso a caso: a regra é a ausência.
 
-Decidido pelo Victor em 2026-08-28, durante a reescrita da `fix/176`: *"vamos ajustar a regra de comentários, zero comentários no backend"*. Saíram 20 linhas de 4 arquivos na mesma rodada — a política de fallback, a guarda de migration, os XML docs da fábrica de teste e a explicação do segredo acentuado —, e nenhum teste caiu.
+Decidido pelo Victor em 2026-08-28, durante a reescrita da `fix/176`: *"vamos ajustar a regra de comentários, zero comentários no backend"*. Saíram **25 linhas de 5 arquivos** — a política de fallback, a guarda de migration, os XML docs da fábrica de teste, a explicação do segredo acentuado e o XML doc do `TimeOnlyJsonConverter` —, e nenhum teste caiu.
+
+⛔ **Ao apagar um comentário ou uma declaração, procure o nome dela em `.claude/`.** Rule e skill citam código por nome, e nada as avisa quando o código sai — o texto continua sintaticamente perfeito descrevendo algo que não existe.
+
+```bash
+grep -rn "<NomeDoSímbolo>" .claude/
+```
+
+Aconteceu nesta mesma rodada: apagado o XML doc do `TimeOnlyJsonConverter`, a `write-review-comment` continuou ensinando a ancorar o comentário de review "em cima do XML doc que explicava por que ele existia" — técnica que esta regra tinha acabado de proibir. Quem viu foi o Victor.
 
 **Onde a explicação passa a morar:** no nome do símbolo, no corpo do PR, ou na issue. Se um trecho de C# só se entende com texto ao lado, é o trecho que precisa mudar.
 

--- a/.claude/rules/dotnet-testing.md
+++ b/.claude/rules/dotnet-testing.md
@@ -1,0 +1,90 @@
+---
+description: Como escrever teste na API .NET — projeto separado, nome em três partes, sem lógica e sem comentário, e o par positivo que impede a suíte de concordar com o defeito
+paths:
+  - "FateConnect/FateConnect.Api/**"
+  - "FateConnect/FateConnect.Api.Tests/**"
+---
+
+# Teste na API .NET
+
+## O teste mora em projeto separado
+
+⛔ **Nunca coloque teste dentro do projeto da API.** O MSBuild não tem `devDependencies`: `PackageReference` é dependência de compilação **e** de runtime, entra no `deps.json` e é copiada para a publicação.
+
+Medido em 2026-08-28, publicando a `FateConnect.Api` dos dois jeitos:
+
+| | dlls | tamanho |
+| --- | --- | --- |
+| projeto de teste separado | 22 | **10 MB** |
+| pacotes de teste dentro da API | 30 | **21 MB** |
+
+Vão para dentro do contêiner de produção `xunit.core`, `xunit.assert`, `xunit.execution.dotnet`, `xunit.abstractions`, `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.EntityFrameworkCore.InMemory` e um `MvcTestingAppManifest.json` — inclusive um provedor de banco alternativo disponível no processo que atende a internet.
+
+É também o que a Microsoft manda por escrito — *"Separate unit tests from integration tests into different projects"* — e o que os projetos de referência fazem: o `dotnet/eShop` tem `src/Catalog.API` com `tests/Catalog.FunctionalTests` ao lado, o `dotnet/aspnetcore` repete `src/` e `test/` em cada módulo, o `MediatR` tem `src/` e `test/`.
+
+**A única peça de apoio a teste que pode morar no app** é tornar o `Program` visível para o `WebApplicationFactory`. O eShop faz isso com um arquivo de três linhas, e explica que `InternalsVisibleTo` não resolve porque a acessibilidade do tipo é verificada. Aqui o `Program` já é público, então nem isso é preciso.
+
+⚠️ **Quando a suíte crescer, separe por tipo.** Hoje `FateConnect.Api.Tests` mistura unidade (`TokenServiceTests`) e integração (`AuthorizationTests`, que sobe a aplicação). Com 10 testes não paga; o eShop separaria em `.UnitTests` e `.FunctionalTests`, e é para lá que a divisão vai quando a suíte justificar.
+
+## Nome em três partes
+
+`Método_Cenário_ComportamentoEsperado`, como a Microsoft padroniza — o nome é o que se lê quando o teste falha, e deve dispensar a leitura do corpo.
+
+```csharp
+RideEndpoints_WithoutToken_RespondUnauthorized
+GerarJwtToken_IsAcceptedByAKeyBuiltInUtf8
+```
+
+Nome de teste é código, então segue a regra de idioma: **inglês**.
+
+## Arrange, Act, Assert — em branco, não em comentário
+
+A estrutura é obrigatória; **os rótulos `// Arrange`, `// Act`, `// Assert` não entram**. Os exemplos da Microsoft os usam, e a `comments.md` deste repo proíbe qualquer comentário em C#. As três fases se separam por **linha em branco**.
+
+```csharp
+[Fact]
+public async Task RideEndpoints_WithAValidToken_ReachTheController()
+{
+    HttpClient client = _factory.CreateClient();
+    client.DefaultRequestHeaders.Authorization =
+        new AuthenticationHeaderValue("Bearer", AccountApiFactory.IssueToken());
+
+    HttpResponseMessage response = await client.GetAsync("/Rides");
+
+    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+}
+```
+
+## O par positivo é obrigatório
+
+⛔ **Teste que só prova a recusa passa também numa API que recusa tudo.** Todo conjunto que afirma um bloqueio precisa do caso que atravessa.
+
+O par acima é o exemplo: `GET /Rides` sem cabeçalho responde 401, e **a mesma rota** com token válido responde 200. Sem o segundo, apagar a autenticação inteira mantém a suíte verde.
+
+Vale para além de autorização: validação que rejeita precisa do caso que aceita, filtro que exclui precisa do que inclui.
+
+## Um Act por teste, e nenhuma lógica
+
+Sem `if`, `for`, `while` ou concatenação dentro do teste — bug em suíte de teste é o pior lugar para procurar. Vários casos viram `[Theory]` com `[InlineData]` ou `[MemberData]`, nunca laço sobre uma lista.
+
+Valor fixo que não se explica sozinho vira constante nomeada, não literal solto no meio da chamada.
+
+## Estado compartilhado: helper, não Setup
+
+`SetUp`/`TearDown` não existem no xUnit 2.x. Estado comum vai em método auxiliar ou no construtor da classe de teste; fixture cara vai em `IClassFixture<T>`, como o `AccountApiFactory`.
+
+## Método privado se testa pelo público
+
+Nunca exponha membro só para testar. O que interessa é o resultado do método público que chama o privado.
+
+## Estático precisa de costura
+
+`DateTime.UtcNow`, `TimeZoneInfo` e afins tiram o controle do teste. Enquanto a costura não existir, **não escreva o teste que depende do relógio** — ele passa hoje e falha sozinho depois.
+
+Aqui isso já espera por alguém: `Ride.ValidateDepartureDateTime` compara a partida com `DateTime.UtcNow`, então testar a regra de "partida no futuro" exige injetar o tempo antes.
+
+## Subir a aplicação sem banco
+
+O `AccountApiFactory` troca o provedor por `UseInMemoryDatabase`, e o `Program` só chama `Migrate()` quando `database.IsRelational()` — sem essa guarda a aplicação não sobe no teste, porque provedor em memória não tem migration.
+
+⚠️ **O provedor em memória não é o Postgres.** Ele não avalia `unaccent` nem `ILike`, então filtro por destino não se prova ali: ou o teste evita esse caminho, ou a prova é gerar o SQL e lê-lo.

--- a/.claude/rules/fateconnect-locale-code.md
+++ b/.claude/rules/fateconnect-locale-code.md
@@ -35,6 +35,7 @@ O idioma é o mesmo dos dois lados; o **rigor** não.
 - **Arquivo, classe, método ou variável novo nasce em inglês**, mesmo cercado de português. `AuthorizationTests` ao lado de `GerarJwtToken` é o estado esperado durante a migração, não inconsistência a corrigir.
 - **O que já existe fica.** Renomear símbolo público arrasta interface, chamadas e às vezes migration — PR de funcionalidade não é lugar para isso.
 - **Traduza o símbolo que o próprio PR já estiver reescrevendo** por outro motivo. É o único rename que sai de graça.
+- **Enum leva o prefixo `Enum`** — `EnumRideType`, `EnumGender`, `EnumProfileType` —, enquanto no front a regra é o sufixo (`RideTypeEnum`, `RoutePathEnum`). A divergência não é descuido e **não se corrige**: a análise da Microsoft reprova o sufixo pela **CA1711**, e com o `TreatWarningsAsErrors` do `.csproj` isso é erro de compilação, não preferência. Medido em 2026-08-28: um `public enum SondaEnum` derruba o build com `error CA1711: Rename type name SondaEnum so that it does not end in 'Enum'`.
 
 ⛔ **Comentário continua em pt-BR dos dois lados**, `///` de C# incluído. O idioma do código e o idioma da explicação são decisões separadas.
 

--- a/.claude/rules/fateconnect-overview.md
+++ b/.claude/rules/fateconnect-overview.md
@@ -6,5 +6,5 @@ description: Onde está cada parte do repositório FateConnect
 
 - **Front:** `FateConnect/Web` — React + Vite, MUI + Emotion, design system local em `design-system/`, fora de `src` (barrels `@design-system` e `@design-system/icons`), variáveis em `.env*` (`VITE_*`). Padrões: **`.claude/rules/fateconnect-web-react.md`**.
 - **Idioma:** `.claude/rules/fateconnect-locale-code.md` — UI e URLs em pt-BR; código TypeScript e estrutura em inglês; domínio **Ride** no código.
-- **API Caronas (.NET):** [FateConnect/Carona/Api](FateConnect/Carona/Api) — HTTP para caronas. Não assumir autenticação, achados ou denúncias sem código correspondente.
+- **API (.NET 8):** [FateConnect/FateConnect.Api](FateConnect/FateConnect.Api) — uma só, em módulos por domínio (`Auth`, `Common`, `Rides`, `Usuarios`), com o projeto de teste em `FateConnect.Api.Tests`, pasta **irmã** e não filha. O microsserviço de caronas foi dissolvido aqui pela #44. Não assumir achados nem denúncias sem código correspondente.
 - **Não existe tela de contato.** O contato é **seção da landing** — âncora `#contato`, atendida pelo rodapé. Não há rota `/contato`: ela não está no `RoutePathEnum` nem no `routeConfig`, e um link antigo cai no curinga que leva à landing. Ao mexer em `constants/navigation.ts` ou nas rotas, não "restaurar" nem o item de menu nem a rota.

--- a/.claude/rules/harness-evolution.md
+++ b/.claude/rules/harness-evolution.md
@@ -47,6 +47,20 @@ Antes de escrever, escolha o lugar — os quatro não são intercambiáveis:
 - `description` em rule é documentação para humanos — mantenha precisa, mas não espere que condicione nada. **Só skill dispara por `description`.**
 - Esta rule é uma das exceções sem `paths`: os gatilhos disparam em qualquer arquivo.
 
+## Caminho citado no harness tem check
+
+Rule e skill citam código por caminho, e nada as avisa quando o código sai — o texto continua sintaticamente perfeito descrevendo algo que não existe.
+
+```bash
+./scripts/check-harness-paths.sh
+```
+
+Ele lista todo caminho ancorado numa entrada real da raiz do repositório que não corresponde a arquivo nem diretório rastreado. Rodando contra o harness de antes da limpeza do #186, encontrou os quatro que uma leitura à mão tinha encontrado — inclusive um dentro de bloco de código e um sem extensão, que uma varredura por crase perde.
+
+⚠️ **Ele cobre caminho, não nome de símbolo.** O XML doc do `TimeOnlyJsonConverter` foi citado por nome numa skill e sobreviveu à remoção sem o check acusar. Para símbolo, o `grep -rn "<Nome>" .claude/` da `comments.md` continua sendo o que existe.
+
+⚠️ **A resposta é relativa à branch.** Caminho que nasce noutro PR aparece como órfão até aquele PR mergear — é correto, não defeito.
+
 ## Rule também tem fim de vida
 
 Quando a pasta que uma rule descreve deixa de existir, a rule é **deletada, não reescrita** para o que ficou no lugar. Ela descrevia corretamente algo que não existe mais; reaproveitar o arquivo mistura dois contextos e produz orientação híbrida que não vale para nenhum dos dois. O mesmo vale para skill: procedimento sem alvo sai do repo, não vira procedimento genérico.

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -60,23 +60,24 @@ A da raiz sobe **sempre**. As outras sobem **só se aquele lado mudou** — vers
 ```bash
 git fetch origin
 git diff --name-only origin/main..origin/develop -- FateConnect/Web | head -1
-git diff --name-only origin/main..origin/develop -- FateConnect/FateConnect.Api FateConnect/Carona | head -1
+git diff --name-only origin/main..origin/develop -- FateConnect/FateConnect.Api | head -1
 ```
 
 | Onde | Sobe quando |
 | --- | --- |
 | `package.json` da raiz | **sempre** — é a versão da release e vira a tag |
 | `FateConnect/Web/package.json` | houve mudança em `FateConnect/Web/` |
-| `FateConnect/FateConnect.Api/FateConnect.Api.csproj` | houve mudança em `FateConnect/FateConnect.Api/` |
-| `FateConnect/Carona/Directory.Build.props` | houve mudança em `FateConnect/Carona/` — cobre os projetos da pasta |
+| `FateConnect/FateConnect.Api/FateConnect.Api.csproj` | houve mudança em `FateConnect/FateConnect.Api/` ou em `FateConnect/FateConnect.Api.Tests/` |
 
-⚠️ **As duas APIs versionam separado**, porque sobem como contêineres separados. Mudança só em caronas não move a versão da API de contas.
+⚠️ **O front e a API versionam separado**, porque sobem como artefatos separados — estáticos servidos pelo nginx e um contêiner. Mudança só no front não move a versão da API.
+
+⚠️ **O projeto de teste conta como mudança na API.** Ele mora em `FateConnect.Api.Tests`, pasta irmã e não filha, então um filtro por `FateConnect/FateConnect.Api/` com barra no final não o alcança.
 
 Uma pista rápida do que cada lado recebeu: as entradas do `Unreleased` terminam em `[Frontend]` ou `[Backend]`. É indício, não prova — refactor e correção de infraestrutura não aparecem no changelog e mesmo assim mudam o código.
 
-⚠️ **Só a da raiz é lida por alguma coisa.** As outras três não alimentam build, tag nem Sentry — existem para o artefato não mentir sobre si. Saber disso evita duas coisas: tratar um bump esquecido como incidente, e supor que mexer nelas afeta a publicação.
+⚠️ **Só a da raiz é lida por alguma coisa.** As outras duas não alimentam build, tag nem Sentry — existem para o artefato não mentir sobre si. Saber disso evita duas coisas: tratar um bump esquecido como incidente, e supor que mexer nelas afeta a publicação.
 
-Depois de tocar `.csproj` ou `Directory.Build.props`, **confirme que o número chegou** e que o build passa:
+Depois de tocar o `.csproj`, **confirme que o número chegou** e que o build passa:
 
 ```bash
 dotnet msbuild <projeto>.csproj -getProperty:Version

--- a/.claude/skills/write-review-comment/SKILL.md
+++ b/.claude/skills/write-review-comment/SKILL.md
@@ -18,6 +18,8 @@ Problema: o que está errado e o que acontece por causa disso.
 Solução proposta: o que fazer.
 ```
 
+⛔ **O `Problema:` cabe em duas frases.** Não cabendo, o que sobra é contexto do corpo do PR e não do thread — de onde a regra veio, o que eu já tinha pedido antes, o que aconteceria noutro cenário. Cobrado na rodada do PR #186: *"seja mais objetivo na explicação do problema, teve uns que ficaram com 6 linhas"*. Os mesmos sete apontamentos couberam em duas frases cada sem perder nada.
+
 ⛔ **Nada de comentário solto.** Todo apontamento vai numa linha específica. Comentário na aba de conversa não aparece ao lado do código, e quem corrige tem que caçar o lugar.
 
 ⛔ **Um problema por comentário.** Dois threads sobre linhas vizinhas é ruído; se dois apontamentos têm a **mesma correção**, são um comentário só — foi o caso do `[Range]` duplicado e do `[Required]` inútil, que estavam no mesmo bloco de anotações e terminavam na mesma frase: enxugar o DTO.
@@ -45,9 +47,39 @@ gh api --method POST repos/<dono>/<repo>/pulls/<n>/comments \
 
 ⛔ **Nunca marque thread como resolvida.** Resolver é de quem comentou ou de quem revisa, não de quem apontou.
 
+## Convenção nossa não se cobra no PR dos outros
+
+⛔ **O que vale entre mim e o Victor não vira exigência para quem só contribui.** Densidade de comentário, forma do JSDoc, ordem de import, nome de arquivo: são acordos da nossa dupla, escritos nas rules deste repo porque nos servem — não porque quem abre um PR aqui os assinou.
+
+Cobrado no review do PR #186. Eu tinha redigido um apontamento pedindo a restauração de três comentários apagados, citando a `comments.md`; a resposta foi *"ele não gosta de comentários, não precisamos forçar ele a seguir um padrão nosso"*.
+
+**O corte é o efeito, não a convenção.** Defeito, contrato quebrado, código morto e incoerência **dentro do próprio PR** valem sempre, porque nenhum deles depende de acordo prévio. Preferência de estilo só entra quando o autor já a segue — aí é incoerência dele com ele mesmo, e o comentário mostra isso em vez de citar a nossa regra.
+
+## Pedir mudança em código executável
+
+⛔ **Todo pedido que altera código que roda precisa dizer o que a linha faz hoje e o que tem de continuar valendo depois.** "Enxugue isto" é um pedido sem contorno: quem atende decide sozinho onde termina o corte, e o que cai junto some sem ninguém decidir.
+
+Aconteceu **três vezes no mesmo PR**, o #186, sempre pelo mesmo gesto meu:
+
+| O que eu pedi | O que caiu junto |
+| --- | --- |
+| enxugar o `UpdateRideDto` | `[EnumDataType]` — o `PUT` passou a aceitar `"rideType": 99` |
+| tirar o `Deconstruct` do `FilterRideDto` | `[StringLength(100)]` do filtro |
+| — (o DTO de criação, na mesma leva) | `MinimumLength = 3` do destino |
+
+**A forma:** nomeie a regra que a linha carrega e para onde ela vai. *"Tirar o `[Range]`, que a entidade já valida; o `[EnumDataType]` precisa ficar ou migrar para a entidade, porque nada mais checa o enum"* custa uma frase e não deixa buraco.
+
+⛔ **Sugestão de forma para código de consulta se mede antes de sair, não depois.** Na mesma rodada eu pedi escape de `%` e `_` no filtro por destino; o escape saiu correto, mas a edição trocou concatenação por interpolação — e dentro de uma árvore de expressão `$"%{x}%"` compila para `string.Format`, que o EF Core **não traduz**. Toda busca por destino passou a responder 500, pior que o defeito que eu tinha apontado.
+
+**O que a medição precisa ser:** chamar o método real do commit, não reconstruir a consulta numa sonda. O controle que provou foi chamar `GetAllAsync` duas vezes — sem `Destination` a query chega a abrir conexão, com `Destination` estoura na tradução. Reconstruir teria medido o meu código, não o dele.
+
 ## Meça antes de afirmar
 
 ⛔ **Afirmação sobre dado, contagem, extensão ou configuração de ambiente exige medição.** Escrevi que uma migração deixaria as caronas órfãs e que a tela ficaria vazia em produção — os bancos não tinham uma linha. No mesmo review, medir transformou um achado hipotético sobre `unaccent` no defeito mais grave da rodada: o filtro por destino já respondia 500 em produção.
+
+⛔ **Meça no ambiente que o projeto usa, não no seu.** No PR #186 eu publiquei que a API não compilava, com a saída do `dotnet build` na mão. Ela compilava: o meu SDK era o 10 e o projeto tem como alvo o `net8.0`, cujo `sdk:8.0` é o que o Dockerfile e a esteira usam. A regra que reprovou nasceu no .NET 9, e o `AnalysisLevel=latest-recommended` liga os analisadores do **SDK instalado**. O autor corrigiu um defeito que não existia para ele.
+
+**A pergunta antes de publicar:** esta saída viria igual na máquina de quem vai corrigir e no servidor que constrói? Toolchain, versão de runtime e variável de ambiente mudam o veredito, e a saída não avisa qual delas usou.
 
 O tempo verbal denuncia: *"vai ficar"*, *"responderia"*, *"em banco novo"*. Troque por passado medido.
 
@@ -62,6 +94,12 @@ gh api repos/<dono>/<repo>/pulls/<n>/comments --jq '.[] | "\(.path):\(.line)"'
 ```
 
 Cada achado termina num estado dito em voz alta: **comentado**, **virou issue**, **descartado porque eu estava errado**, ou **dispensado por decisão do usuário**. "Não mencionei mais" não é estado — foi assim que um achado evaporou entre dois turnos, e quem percebeu foi o usuário.
+
+⛔ **Rodada de correção é diff novo, e pede review novo.** Conferir que cada correção faz o que diz **não é** revisar — os commits de correção são código que ninguém leu ainda.
+
+Cobrado duas vezes no PR #186, com a mesma pergunta: *"nenhum achado novo nas novas alterações?"*. Da primeira vez o passe encontrou uma validação de enum que sumira junto com o que eu pedi para remover. Da segunda, um defeito pior que o original: a correção do escape trocou concatenação por interpolação, e a busca por destino passou a responder 500.
+
+⛔ **O resumo abre com o número de achados, e cada um aparece nomeado.** Destacar os mais graves é certo; comprimir a cauda num parágrafo corrido não é — quem lê conta o que consegue ver. Na rodada do PR #186 eu apresentei 3 em destaque e os outros 12 numa frase só, e a pergunta que veio foi *"só foram 3 mesmo?"*. Uma tabela de três colunas — estado, quantos, quais — resolve, e é a mesma contagem que o `gh api` acima confere.
 
 ## Idioma
 

--- a/.claude/skills/write-review-comment/SKILL.md
+++ b/.claude/skills/write-review-comment/SKILL.md
@@ -33,7 +33,7 @@ gh api --method POST repos/<dono>/<repo>/pulls/<n>/comments \
 ```
 
 - ⛔ **A linha precisa estar dentro de uma seção do diff**, senão a API responde 422. Confira antes mapeando as seções — o `Program.cs` tinha um vão de duas linhas exatamente onde eu queria comentar.
-- **Problema num arquivo apagado: `side: LEFT`, no arquivo antigo.** É a melhor âncora para comportamento removido — o comentário sobre o `TimeOnlyJsonConverter` ficou em cima do XML doc que explicava por que ele existia, então o motivo e o apontamento chegam juntos.
+- **Problema num arquivo apagado: `side: LEFT`, no arquivo antigo.** É a melhor âncora para comportamento removido: o thread nasce em cima do código que some, e não numa linha vizinha parecida. Ancore na **declaração** — a classe, o método —, nunca na chave de fechamento.
 - Editar: `PATCH .../pulls/comments/<id>`. Apagar: `DELETE` no mesmo caminho.
 
 ⛔ **Quando o problema é ausência, não há âncora.** Arquivo que o PR *não* tocou não está no diff. Aí o apontamento não é comentário: vira issue, ou não é levantado. **Decida com o usuário** — foi assim que o contrato do front virou uma issue em vez de um thread.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@ FateConnect/Web/ @victorfob
 
 # Backend
 
-FateConnect/Carona/ @Lautones
 FateConnect/FateConnect.Api/ @Lautones
+FateConnect/FateConnect.Api.Tests/ @Lautones
 
 # Database
 

--- a/FateConnect/FateConnect.Api/Infrastructure/Converters/TimeOnlyJsonConverter.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Converters/TimeOnlyJsonConverter.cs
@@ -4,11 +4,6 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-/// <summary>
-/// The default <see cref="TimeOnly"/> converter requires seconds, whereas browser
-/// time inputs send <c>HH:mm</c>. Accepting both formats keeps formatting tolerance
-/// inside the API without forcing every client to append seconds before sending.
-/// </summary>
 public class TimeOnlyJsonConverter : JsonConverter<TimeOnly>
 {
     private const string WriteFormat = "HH:mm:ss";

--- a/scripts/check-harness-paths.sh
+++ b/scripts/check-harness-paths.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Encontra caminho do repositório citado em .claude/ que não existe mais.
+#
+# Rule e skill citam código por nome, e nada as avisa quando o código sai: o
+# texto continua sintaticamente perfeito descrevendo algo que não existe. Este
+# check é o que avisa.
+#
+# Só considera caminho ancorado numa entrada real da raiz do repositório —
+# `Header/styles.ts` no meio de uma frase é exemplo, não referência.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Pastas documentadas de propósito que o git não rastreia.
+ignorados=(
+  ".claude/worktrees"                                                    # worktree de agente, fora do versionamento
+  ".claude/projects/-Users-victorbrayner-Development-Projects-FateConnect/memory"  # memória, fora do repositório
+)
+
+raizes=$(git ls-files | cut -d/ -f1 | sort -u | sed 's/\./\\./' | tr '\n' '|' | sed 's/|$//')
+
+conhecidos=$(mktemp)
+# Todos os ancestrais, e não só o pai imediato: um texto pode citar
+# `FateConnect/Web/src/pages`, que é diretório sem arquivo próprio.
+{
+  git ls-files
+  git ls-files | awk -F/ '{ caminho = $1; print caminho; for (i = 2; i < NF; i++) { caminho = caminho "/" $i; print caminho } }'
+  printf '%s\n' "${ignorados[@]}"
+} | sort -u > "$conhecidos"
+
+encontrados=0
+
+while IFS=: read -r arquivo linha citado; do
+  [ -z "${citado:-}" ] && continue
+  citado="${citado%/}"
+  grep -qxF "$citado" "$conhecidos" && continue
+  echo "  $arquivo:$linha  →  $citado"
+  encontrados=$((encontrados + 1))
+done < <(
+  grep -rnoE --include="*.md" "($raizes)/[A-Za-z0-9_./-]+" .claude/ | sed -E 's/[.,;:)]+$//' | sort -u
+)
+
+rm -f "$conhecidos"
+
+if [ "$encontrados" -gt 0 ]; then
+  echo
+  echo "$encontrados caminho(s) citado(s) em .claude/ não existem no repositório."
+  echo "Atualize o texto — ou, se o caminho é de propósito, acrescente-o a 'ignorados'."
+  exit 1
+fi
+
+echo "Nenhum caminho órfão em .claude/."


### PR DESCRIPTION
## Objetivo

Padronizar como se escreve teste na API .NET, registrar quatro decisões tomadas durante o review do #186 e a reescrita da #176, e **aplicar a regra nova ao código que já existe**.

Não há entrada de changelog: nenhum comportamento do produto muda.

## Alterações

### Rule nova: `dotnet-testing.md`

Escopada por `paths` para `FateConnect.Api/**` e `FateConnect.Api.Tests/**`, então só carrega quando alguém abre a API.

A pergunta que a originou foi se o teste não poderia morar dentro do projeto da API, como o Vitest mora no front. Pode, e o preço foi medido publicando a API dos dois jeitos:

| | dlls | tamanho |
| --- | --- | --- |
| projeto de teste separado | 22 | **10 MB** |
| pacotes de teste dentro da API | 30 | **21 MB** |

Vão para dentro do contêiner de produção `xunit.core`, `xunit.assert`, `xunit.execution.dotnet`, `xunit.abstractions`, `Mvc.Testing`, `EntityFrameworkCore.InMemory` e um `MvcTestingAppManifest.json` — inclusive um provedor de banco alternativo disponível no processo que atende a internet. A causa é que o MSBuild não tem `devDependencies`: `PackageReference` é dependência de compilação **e** de runtime.

A rule ainda fixa nome de teste em três partes, Arrange/Act/Assert **separado por linha em branco e não por comentário**, um Act por teste, nenhuma lógica dentro do teste, helper no lugar de `Setup`, e a exigência do **par positivo** — teste que só prova a recusa passa também numa API que recusa tudo.

### `comments.md`: zero comentário no back-end

Nenhum `//`, `///` ou XML doc em C#, produção ou teste, sem exceção caso a caso. Na aplicação da regra saíram 20 linhas de 4 arquivos e nenhum teste caiu. YAML, shell, Markdown e o front seguem pela regra antiga, em que o comentário existe e é raro.

### `fateconnect-locale-code.md`: o prefixo `Enum` no back

O back usa `EnumRideType` e o front usa `RideTypeEnum`, e a divergência **não se corrige**: a análise da Microsoft reprova o sufixo pela `CA1711`, e com o `TreatWarningsAsErrors` do `.csproj` isso é erro de compilação. Medido — um `public enum SondaEnum` derruba o build.

### `write-review-comment`: cinco lições da rodada

- O `Problema:` cabe em duas frases.
- Convenção nossa não se cobra no PR de quem só contribui — o corte é o efeito, não a convenção.
- Pedido que altera código executável nomeia o que a linha carrega e para onde vai. Três validações caíram sem ninguém decidir por falta disso.
- **Meça no ambiente que o projeto usa, não no seu.** Publiquei que a API não compilava com a saída do `dotnet build` na mão; ela compilava, e o que reprovava era uma regra do .NET 9 ligada pelo meu SDK 10 num projeto com alvo `net8.0`.
- **Rodada de correção é diff novo, e pede review novo.** Conferir que cada correção faz o que diz não é revisar — foi assim que uma quebra de runtime na busca por destino quase passou.

### A regra de comentários, aplicada

O único comentário que restava no C# da API saiu — o XML doc do `TimeOnlyJsonConverter`. Ele explicava algo que **não pode se perder**, e por isso a explicação passa a morar aqui, que é o destino que a própria regra prescreve:

> O conversor padrão de `TimeOnly` exige segundos, e o campo de hora do navegador envia `HH:mm`. Aceitar os dois formatos mantém a tolerância de formatação dentro da API, em vez de obrigar cada cliente a acrescentar os segundos antes de enviar.

O resto do back-end já estava sem comentário — o #186 tinha limpado. A varredura inteira foram 5 linhas em 1 arquivo.

### CODEOWNERS

Duas correções, e a segunda é a que foi pedida:

- **`FateConnect/Carona/ @Lautones` saiu** — a pasta foi apagada pelo #186 e a linha ficou apontando para o vazio.
- **`FateConnect/FateConnect.Api.Tests/ @Lautones` entrou.** A linha existente, `FateConnect/FateConnect.Api/`, tem barra no final e **não** alcança o projeto de teste, que é pasta irmã e não filha — a mesma armadilha que o filtro de arquivos do CI tinha.

⚠️ A pasta `FateConnect.Api.Tests` nasce no #191. Até ele mergear, a linha nova é inerte — casa com um caminho que ainda não existe, o que o GitHub tolera sem erro.

## Evidências

