### PR TITLE
fix(189): follow the unified api contract on the rides and signup front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Passa a atender as caronas pela mesma API do cadastro, em `/Rides`, com o contrato em inglês: mudam os nomes dos filtros e os valores de tipo de carona e de gênero (#186) [Backend]
+- Passa a consumir as caronas pela mesma API do cadastro e a enviar os valores novos de tipo de carona e de gênero; os rótulos na tela não mudam (#194) [Frontend]
 
 ### Fixed
 

--- a/FateConnect/Web/.env.example
+++ b/FateConnect/Web/.env.example
@@ -1,5 +1,4 @@
 # Copie para .env.development e preencha com os endereços do seu ambiente.
 # Nenhum endereço real deve ser versionado.
 VITE_API_URL=
-VITE_RIDE_API_URL=
 VITE_SENTRY_DSN=

--- a/FateConnect/Web/src/components/SessionExpiryGate/SessionExpiryGate.test.tsx
+++ b/FateConnect/Web/src/components/SessionExpiryGate/SessionExpiryGate.test.tsx
@@ -9,7 +9,7 @@ import { render, screen, waitFor } from '@app/test/testing-library';
 
 import { SESSION_EXPIRED_TITLE } from '../SessionExpiredScreen/constants';
 
-const RIDES_URL = 'https://rides.fateconnect.test/caronas';
+const RIDES_URL = 'https://api.fateconnect.test/Rides';
 
 function renderRides() {
   render(

--- a/FateConnect/Web/src/observability/initSentry.test.ts
+++ b/FateConnect/Web/src/observability/initSentry.test.ts
@@ -46,11 +46,7 @@ describe('initSentry', () => {
 
     expect(mockInit).toHaveBeenCalledWith(
       expect.objectContaining({
-        tracePropagationTargets: [
-          'localhost',
-          'https://api.fateconnect.test',
-          'https://rides.fateconnect.test',
-        ],
+        tracePropagationTargets: ['localhost', 'https://api.fateconnect.test'],
       }),
     );
   });

--- a/FateConnect/Web/src/observability/initSentry.ts
+++ b/FateConnect/Web/src/observability/initSentry.ts
@@ -13,7 +13,7 @@ const REPLAY_ON_ERROR_SAMPLE_RATE = 1;
 
 /** Só nas nossas APIs o cabeçalho de rastro é propagado. */
 function tracePropagationTargets(): string[] {
-  const apis = [import.meta.env.VITE_API_URL, import.meta.env.VITE_RIDE_API_URL];
+  const apis = [import.meta.env.VITE_API_URL];
 
   return ['localhost', ...apis.filter(Boolean)];
 }

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -19,21 +19,20 @@ import { RIDE_DRIVER } from './helpers/rideDriver';
 import * as C from './constants';
 import { Rides } from '.';
 
-const RIDES_URL = 'https://rides.fateconnect.test/caronas';
+const RIDES_URL = 'https://api.fateconnect.test/Rides';
 
 /** Cobre a tentativa inicial, os 2s de espera e a repetição. */
 const RETRY_WINDOW_MS = 5000;
 
 const RIDE: Ride = {
   id: 'b1b0f5b4-7a6f-4f1e-9d3a-2f5c8e4a1d70',
-  qtdVagas: 3,
-  destino: 'Fatec Sorocaba',
-  dataPartida: '2026-05-22T00:00:00',
-  horaPartida: '07:30:00',
-  dataCadastro: '2026-05-01T00:00:00',
-  tipoCarona: RideTypeEnum.PHILANTHROPIC,
-  descricao: 'Saída do centro, com parada no terminal.',
-  ativo: true,
+  availableSeats: 3,
+  destination: 'Fatec Sorocaba',
+  departureDate: '2026-05-22T00:00:00',
+  departureTime: '07:30:00',
+  createdAt: '2026-05-01T00:00:00',
+  rideType: RideTypeEnum.SOLIDARITY,
+  description: 'Saída do centro, com parada no terminal.',
 };
 
 function listReturning(rides: Ride[], onRequest?: (url: URL) => void) {
@@ -142,10 +141,10 @@ describe('Rides', () => {
     listReturning([RIDE]);
     renderComponent();
 
-    expect(await screen.findByText(RIDE.destino)).toBeInTheDocument();
+    expect(await screen.findByText(RIDE.destination)).toBeInTheDocument();
     expect(screen.getByText('22/05/2026')).toBeInTheDocument();
     expect(screen.getByText('07:30')).toBeInTheDocument();
-    expect(screen.getByText(C.seatsLabel(RIDE.qtdVagas))).toBeInTheDocument();
+    expect(screen.getByText(C.seatsLabel(RIDE.availableSeats))).toBeInTheDocument();
     expect(screen.getAllByText('Solidária')).toHaveLength(1);
   });
 
@@ -195,7 +194,7 @@ describe('Rides', () => {
     await userEvent.type(screen.getByLabelText(FILTER_LABELS.destination), 'Sorocaba');
     await userEvent.click(screen.getByRole('button', { name: FILTER_SUBMIT_LABEL }));
 
-    await waitFor(() => expect(requestUrl?.searchParams.get('Destino')).toBe('Sorocaba'));
+    await waitFor(() => expect(requestUrl?.searchParams.get('destination')).toBe('Sorocaba'));
     // O ponto do painel não tem papel de acessibilidade: chega-se a ele pelo título.
     const activeDot = screen
       .getByText(FILTER_PANEL_TITLE)
@@ -208,18 +207,20 @@ describe('Rides', () => {
     listReturning([RIDE]);
     loggedAsTheDriver();
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: C.RIDE_CARD_LABELS.delete }));
 
     const dialog = within(await screen.findByRole('dialog'));
     expect(dialog.getByRole('heading', { name: DELETE_DIALOG.title })).toBeInTheDocument();
-    expect(dialog.getByText(RIDE.destino)).toBeInTheDocument();
+    expect(dialog.getByText(RIDE.destination)).toBeInTheDocument();
 
     await userEvent.click(dialog.getByRole('button', { name: DELETE_DIALOG.cancelLabel }));
 
     // O cartão só volta a ser alcançável quando o diálogo termina de fechar.
-    expect(within(await screen.findByRole('article')).getByText(RIDE.destino)).toBeInTheDocument();
+    expect(
+      within(await screen.findByRole('article')).getByText(RIDE.destination),
+    ).toBeInTheDocument();
   });
 
   it('should delete the ride once the removal is confirmed', async () => {
@@ -234,7 +235,7 @@ describe('Rides', () => {
       }),
     );
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: C.RIDE_CARD_LABELS.delete }));
     const dialog = within(await screen.findByRole('dialog'));
@@ -249,7 +250,7 @@ describe('Rides', () => {
     loggedAsTheDriver();
     server.use(http.delete(`${RIDES_URL}/:rideId`, () => new HttpResponse(null, { status: 500 })));
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: C.RIDE_CARD_LABELS.delete }));
     const dialog = within(await screen.findByRole('dialog'));
@@ -261,7 +262,7 @@ describe('Rides', () => {
   it('should show the contact of whoever offered the ride', async () => {
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: CONTACT_LABEL }));
 
@@ -273,7 +274,7 @@ describe('Rides', () => {
   it('should copy the email and say so', async () => {
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: CONTACT_LABEL }));
     const dialog = within(await screen.findByRole('dialog'));
@@ -288,7 +289,7 @@ describe('Rides', () => {
     clipboardWrite.mockRejectedValueOnce(new Error('denied'));
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: CONTACT_LABEL }));
     const dialog = within(await screen.findByRole('dialog'));
@@ -300,7 +301,7 @@ describe('Rides', () => {
   it('should open the conversation already mentioning the destination of the ride', async () => {
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: CONTACT_LABEL }));
 
@@ -309,14 +310,14 @@ describe('Rides', () => {
 
     expect(conversation).toHaveAttribute(
       'href',
-      expect.stringContaining(encodeURIComponent(RIDE.destino)),
+      expect.stringContaining(encodeURIComponent(RIDE.destination)),
     );
   });
 
   it('should give the card back when the contact is dismissed', async () => {
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: CONTACT_LABEL }));
     await screen.findByRole('dialog');
@@ -325,14 +326,16 @@ describe('Rides', () => {
     // diálogo fecha, seja qual for o gesto que o fechou.
     await userEvent.keyboard('{Escape}');
 
-    expect(within(await screen.findByRole('article')).getByText(RIDE.destino)).toBeInTheDocument();
+    expect(
+      within(await screen.findByRole('article')).getByText(RIDE.destination),
+    ).toBeInTheDocument();
   });
 
   it('should not offer contact on a ride offered by the logged user', async () => {
     tokenStorage.save('token', RIDE_DRIVER.name);
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     expect(screen.queryByRole('button', { name: CONTACT_LABEL })).not.toBeInTheDocument();
   });
@@ -340,7 +343,7 @@ describe('Rides', () => {
   it('should keep the owner actions off a ride offered by someone else', async () => {
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     expect(screen.queryByRole('button', { name: C.RIDE_CARD_LABELS.edit })).not.toBeInTheDocument();
     expect(
@@ -353,7 +356,7 @@ describe('Rides', () => {
     tokenStorage.save('token', RIDE_DRIVER.name);
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     expect(screen.getByText(C.OWN_RIDE_LABEL)).toBeInTheDocument();
   });
@@ -361,7 +364,7 @@ describe('Rides', () => {
   it('should keep that announcement off a ride offered by someone else', async () => {
     listReturning([RIDE]);
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     expect(screen.queryByText(C.OWN_RIDE_LABEL)).not.toBeInTheDocument();
   });
@@ -370,14 +373,14 @@ describe('Rides', () => {
     listReturning([RIDE]);
     loggedAsTheDriver();
     renderComponent();
-    await screen.findByText(RIDE.destino);
+    await screen.findByText(RIDE.destination);
 
     await userEvent.click(screen.getByRole('button', { name: C.RIDE_CARD_LABELS.edit }));
 
     expect(await screen.findByRole('heading', { name: EDIT_MODE.title })).toBeInTheDocument();
     expect(
       screen.getByRole('textbox', { name: new RegExp(RIDE_FORM_LABELS.destination) }),
-    ).toHaveValue(RIDE.destino);
+    ).toHaveValue(RIDE.destination);
     expect(screen.getByRole('tab', { name: C.OFFER_TAB_LABEL, hidden: true })).toHaveAttribute(
       'aria-selected',
       'false',

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/RideDeleteConfirmation/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/RideDeleteConfirmation/index.tsx
@@ -37,7 +37,7 @@ export function RideDeleteConfirmation({ ride, onDelete }: RideDeleteConfirmatio
         <Dialog.Body>
           <S.ConfirmationMessage variant="subtitle">
             {DELETE_DIALOG.messagePrefix}
-            <strong>{ride.destino}</strong>
+            <strong>{ride.destination}</strong>
             {DELETE_DIALOG.messageSuffix}
           </S.ConfirmationMessage>
         </Dialog.Body>

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
@@ -21,19 +21,19 @@ type RideCardProps = Readonly<{
 }>;
 
 export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
-  const typeLabel = rideTypeDisplayLabel(ride.tipoCarona);
-  const tone = rideTypeTone(ride.tipoCarona);
+  const typeLabel = rideTypeDisplayLabel(ride.rideType);
+  const tone = rideTypeTone(ride.rideType);
 
   return (
     <ListCard own={isOwnRide(RIDE_DRIVER)} ownLabel={C.OWN_RIDE_LABEL}>
       <ListCard.Header>
-        <Typography variant="subtitleBold">{ride.destino}</Typography>
+        <Typography variant="subtitleBold">{ride.destination}</Typography>
 
         <ListCard.Actions>
           <StatusTag tone={tone}>{typeLabel}</StatusTag>
 
           <ListCard.ActionButtons>
-            <RideDriverContact destination={ride.destino} />
+            <RideDriverContact destination={ride.destination} />
 
             <RideOwnerActions ride={ride} onEdit={onEdit} onDelete={onDelete} />
           </ListCard.ActionButtons>
@@ -44,28 +44,28 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
         <ListCard.InfoItem>
           <CalendarTodayIcon />
           <Typography variant="caption" color="inherit">
-            {format(parseISO(ride.dataPartida), DATE_FORMAT)}
+            {format(parseISO(ride.departureDate), DATE_FORMAT)}
           </Typography>
         </ListCard.InfoItem>
 
         <ListCard.InfoItem>
           <AccessTimeIcon />
           <Typography variant="caption" color="inherit">
-            {ride.horaPartida.slice(0, TIME_LENGTH)}
+            {ride.departureTime.slice(0, TIME_LENGTH)}
           </Typography>
         </ListCard.InfoItem>
 
         <ListCard.InfoItem>
           <GroupsIcon />
           <Typography variant="caption" color="inherit">
-            {C.seatsLabel(ride.qtdVagas)}
+            {C.seatsLabel(ride.availableSeats)}
           </Typography>
         </ListCard.InfoItem>
       </ListCard.InfoRow>
 
       <ListCard.Description>
         <Typography variant="subtitle" color="inherit">
-          {ride.descricao}
+          {ride.description}
         </Typography>
       </ListCard.Description>
     </ListCard>

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormDialog.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormDialog.test.tsx
@@ -9,7 +9,7 @@ import { toApiDate } from '@app/utils/apiDate';
 import { EDIT_MODE, OFFER_MODE, RIDE_FORM_LABELS } from './constants';
 import { RideFormDialog, type RideFormDialogProps } from '.';
 
-const RIDES_URL = 'https://rides.fateconnect.test/caronas';
+const RIDES_URL = 'https://api.fateconnect.test/Rides';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DAYS_AHEAD = 30;
@@ -20,14 +20,13 @@ const TYPED_DATE = format(OFFERED_AT, 'ddMMyyyy');
 
 const RIDE: Ride = {
   id: 'b1b0f5b4-7a6f-4f1e-9d3a-2f5c8e4a1d70',
-  qtdVagas: 4,
-  destino: 'Fatec Sorocaba',
-  dataPartida: toApiDate(new Date(Date.now() + DAYS_AHEAD * DAY_MS)),
-  horaPartida: '07:30:00',
-  dataCadastro: '2026-05-01T00:00:00',
-  tipoCarona: RideTypeEnum.EGALITARIAN,
-  descricao: 'Saída do centro, com parada no terminal.',
-  ativo: true,
+  availableSeats: 4,
+  destination: 'Fatec Sorocaba',
+  departureDate: toApiDate(new Date(Date.now() + DAYS_AHEAD * DAY_MS)),
+  departureTime: '07:30:00',
+  createdAt: '2026-05-01T00:00:00',
+  rideType: RideTypeEnum.EGALITARIAN,
+  description: 'Saída do centro, com parada no terminal.',
 };
 
 const onClose = vi.fn();
@@ -57,10 +56,10 @@ describe('RideFormDialog', () => {
 
     expect(await screen.findByRole('heading', { name: EDIT_MODE.title })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: EDIT_MODE.submitLabel })).toBeInTheDocument();
-    expect(destinationField()).toHaveValue(RIDE.destino);
+    expect(destinationField()).toHaveValue(RIDE.destination);
     expect(
       screen.getByRole('textbox', { name: new RegExp(RIDE_FORM_LABELS.description) }),
-    ).toHaveValue(RIDE.descricao);
+    ).toHaveValue(RIDE.description);
   });
 
   it('should refuse to submit an empty form and say what is missing', async () => {
@@ -95,12 +94,12 @@ describe('RideFormDialog', () => {
 
     await waitFor(() => expect(onClose).toHaveBeenCalled());
     expect(body).toEqual({
-      qtdVagas: RIDE.qtdVagas,
-      destino: RIDE.destino,
-      dataPartida: RIDE.dataPartida,
-      horaPartida: '07:30',
-      tipoCarona: RIDE.tipoCarona,
-      descricao: RIDE.descricao,
+      availableSeats: RIDE.availableSeats,
+      destination: RIDE.destination,
+      departureDate: RIDE.departureDate,
+      departureTime: '07:30',
+      rideType: RIDE.rideType,
+      description: RIDE.description,
     });
   });
 
@@ -113,7 +112,7 @@ describe('RideFormDialog', () => {
 
     expect(await screen.findByText(EDIT_MODE.failed)).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
-    expect(destinationField()).toHaveValue(RIDE.destino);
+    expect(destinationField()).toHaveValue(RIDE.destination);
   });
 
   it('should offer the ride the form describes', async () => {
@@ -149,12 +148,12 @@ describe('RideFormDialog', () => {
 
     await waitFor(() => expect(onClose).toHaveBeenCalled());
     expect(body).toEqual({
-      qtdVagas: 3,
-      destino: 'Terminal Santo Antônio',
-      dataPartida: toApiDate(OFFERED_AT),
-      horaPartida: '18:30',
-      tipoCarona: RideTypeEnum.PHILANTHROPIC,
-      descricao: '',
+      availableSeats: 3,
+      destination: 'Terminal Santo Antônio',
+      departureDate: toApiDate(OFFERED_AT),
+      departureTime: '18:30',
+      rideType: RideTypeEnum.SOLIDARITY,
+      description: '',
     });
   });
 });

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.test.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.test.ts
@@ -5,14 +5,13 @@ import { toFormValues, toRideInput } from './mapper';
 
 const RIDE: Ride = {
   id: 'b1b0f5b4-7a6f-4f1e-9d3a-2f5c8e4a1d70',
-  qtdVagas: 4,
-  destino: 'Fatec Sorocaba',
-  dataPartida: '2026-05-22T00:00:00',
-  horaPartida: '07:30:00',
-  dataCadastro: '2026-05-01T00:00:00',
-  tipoCarona: RideTypeEnum.EGALITARIAN,
-  descricao: 'Saída do centro.',
-  ativo: true,
+  availableSeats: 4,
+  destination: 'Fatec Sorocaba',
+  departureDate: '2026-05-22T00:00:00',
+  departureTime: '07:30:00',
+  createdAt: '2026-05-01T00:00:00',
+  rideType: RideTypeEnum.EGALITARIAN,
+  description: 'Saída do centro.',
 };
 
 describe('toFormValues', () => {
@@ -30,7 +29,7 @@ describe('toFormValues', () => {
   });
 
   it('should turn a missing description into an empty field', () => {
-    expect(toFormValues({ ...RIDE, descricao: null }).description).toBe('');
+    expect(toFormValues({ ...RIDE, description: null }).description).toBe('');
   });
 });
 
@@ -46,12 +45,12 @@ describe('toRideInput', () => {
     };
 
     expect(toRideInput(values)).toEqual({
-      qtdVagas: 4,
-      destino: 'Fatec Sorocaba',
-      dataPartida: '2026-05-22',
-      horaPartida: '07:30',
-      tipoCarona: RideTypeEnum.EGALITARIAN,
-      descricao: 'Saída do centro.',
+      availableSeats: 4,
+      destination: 'Fatec Sorocaba',
+      departureDate: '2026-05-22',
+      departureTime: '07:30',
+      rideType: RideTypeEnum.EGALITARIAN,
+      description: 'Saída do centro.',
     });
   });
 });

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.ts
@@ -12,23 +12,23 @@ export function toFormValues(ride: Ride | undefined): RideFormInput {
   if (!ride) return EMPTY_RIDE_FORM;
 
   return {
-    destination: ride.destino,
-    departureDate: ride.dataPartida.slice(0, DATE_LENGTH),
-    departureTime: ride.horaPartida.slice(0, TIME_LENGTH),
-    rideType: ride.tipoCarona,
-    seats: String(ride.qtdVagas),
-    description: ride.descricao ?? '',
+    destination: ride.destination,
+    departureDate: ride.departureDate.slice(0, DATE_LENGTH),
+    departureTime: ride.departureTime.slice(0, TIME_LENGTH),
+    rideType: ride.rideType,
+    seats: String(ride.availableSeats),
+    description: ride.description ?? '',
   };
 }
 
 /** O schema já entregou os campos aparados e o tipo estreitado. */
 export function toRideInput(values: RideFormValues): RideInput {
   return {
-    qtdVagas: Number(values.seats),
-    destino: values.destination,
-    dataPartida: values.departureDate,
-    horaPartida: values.departureTime,
-    tipoCarona: values.rideType,
-    descricao: values.description,
+    availableSeats: Number(values.seats),
+    destination: values.destination,
+    departureDate: values.departureDate,
+    departureTime: values.departureTime,
+    rideType: values.rideType,
+    description: values.description,
   };
 }

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.test.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.test.ts
@@ -12,7 +12,7 @@ const VALID: RideFormInput = {
   destination: 'Fatec Sorocaba',
   departureDate: toApiDate(new Date(Date.now() + DAYS_AHEAD * DAY_MS)),
   departureTime: '07:30',
-  rideType: RideTypeEnum.PHILANTHROPIC,
+  rideType: RideTypeEnum.SOLIDARITY,
   seats: '3',
   description: 'Saída do centro.',
 };
@@ -29,7 +29,7 @@ describe('rideFormSchema', () => {
     const result = rideFormSchema.safeParse(VALID);
 
     expect(result.success).toBe(true);
-    expect(result.data?.rideType).toBe(RideTypeEnum.PHILANTHROPIC);
+    expect(result.data?.rideType).toBe(RideTypeEnum.SOLIDARITY);
   });
 
   it('should trim the destination and the description', () => {

--- a/FateConnect/Web/src/pages/Rides/helpers/rideType.test.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/rideType.test.ts
@@ -4,10 +4,10 @@ import { parseRideType, rideTypeDisplayLabel, rideTypeTone } from './rideType';
 
 describe('parseRideType', () => {
   it.each([
-    ['Filantropica', RideTypeEnum.PHILANTHROPIC],
-    ['filantropica', RideTypeEnum.PHILANTHROPIC],
-    ['Igualitaria', RideTypeEnum.EGALITARIAN],
-    ['igualitaria', RideTypeEnum.EGALITARIAN],
+    ['Solidarity', RideTypeEnum.SOLIDARITY],
+    ['solidarity', RideTypeEnum.SOLIDARITY],
+    ['Egalitarian', RideTypeEnum.EGALITARIAN],
+    ['egalitarian', RideTypeEnum.EGALITARIAN],
   ])('should read %s as a canonical value', (raw, expected) => {
     expect(parseRideType(raw)).toBe(expected);
   });
@@ -19,8 +19,8 @@ describe('parseRideType', () => {
 
 describe('rideTypeDisplayLabel', () => {
   it('should label the known types in pt-BR', () => {
-    expect(rideTypeDisplayLabel('Filantropica')).toBe('Solidária');
-    expect(rideTypeDisplayLabel('igualitaria')).toBe('Igualitária');
+    expect(rideTypeDisplayLabel('Solidarity')).toBe('Solidária');
+    expect(rideTypeDisplayLabel('egalitarian')).toBe('Igualitária');
   });
 
   it('should keep an unknown value, falling back to a dash when it is blank', () => {
@@ -31,8 +31,8 @@ describe('rideTypeDisplayLabel', () => {
 
 describe('rideTypeTone', () => {
   it.each([
-    ['Filantropica', 'success'],
-    ['Igualitaria', 'warning'],
+    ['Solidarity', 'success'],
+    ['Egalitarian', 'warning'],
     ['desconhecido', 'neutral'],
   ])('should give %s the expected tone', (value, expected) => {
     expect(rideTypeTone(value)).toBe(expected);

--- a/FateConnect/Web/src/pages/Rides/helpers/rideType.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/rideType.ts
@@ -3,17 +3,17 @@ import type { StatusTagTone } from '@design-system';
 import { RideTypeEnum } from '@app/services/rides/types';
 
 const LOWERCASE_TO_RIDE_TYPE: Readonly<Record<string, RideTypeEnum>> = {
-  filantropica: RideTypeEnum.PHILANTHROPIC,
-  igualitaria: RideTypeEnum.EGALITARIAN,
+  solidarity: RideTypeEnum.SOLIDARITY,
+  egalitarian: RideTypeEnum.EGALITARIAN,
 };
 
 const RIDE_TYPE_LABEL: Readonly<Record<RideTypeEnum, string>> = {
-  [RideTypeEnum.PHILANTHROPIC]: 'Solidária',
+  [RideTypeEnum.SOLIDARITY]: 'Solidária',
   [RideTypeEnum.EGALITARIAN]: 'Igualitária',
 };
 
 const RIDE_TYPE_TONE: Readonly<Record<RideTypeEnum, StatusTagTone>> = {
-  [RideTypeEnum.PHILANTHROPIC]: 'success',
+  [RideTypeEnum.SOLIDARITY]: 'success',
   [RideTypeEnum.EGALITARIAN]: 'warning',
 };
 
@@ -23,7 +23,7 @@ const UNKNOWN_LABEL = '—';
 
 /** Escolhas de tipo — uma fonte só, servindo o filtro e o formulário de carona. */
 export const RIDE_TYPE_OPTIONS: readonly { value: RideTypeEnum; label: string }[] = [
-  { value: RideTypeEnum.PHILANTHROPIC, label: RIDE_TYPE_LABEL[RideTypeEnum.PHILANTHROPIC] },
+  { value: RideTypeEnum.SOLIDARITY, label: RIDE_TYPE_LABEL[RideTypeEnum.SOLIDARITY] },
   { value: RideTypeEnum.EGALITARIAN, label: RIDE_TYPE_LABEL[RideTypeEnum.EGALITARIAN] },
 ];
 

--- a/FateConnect/Web/src/pages/Signup/@types/index.ts
+++ b/FateConnect/Web/src/pages/Signup/@types/index.ts
@@ -1,6 +1,6 @@
 /** Gênero com o nome que o enum do back usa — é esse texto que vai no payload. */
 export enum GenderValueEnum {
-  MALE = 'Masculino',
-  FEMALE = 'Feminino',
-  OTHER = 'Outro',
+  MALE = 'Male',
+  FEMALE = 'Female',
+  OTHER = 'Other',
 }

--- a/FateConnect/Web/src/pages/Signup/Signup.test.tsx
+++ b/FateConnect/Web/src/pages/Signup/Signup.test.tsx
@@ -306,7 +306,7 @@ describe('Signup', () => {
       nomeCompleto: VALID_SIGNUP.fullName,
       emailFatec: VALID_SIGNUP.fatecEmail,
       senha: VALID_SIGNUP.password,
-      genero: 'Feminino',
+      genero: 'Female',
       dataNascimento: '1999-05-22T00:00:00Z',
       enderecos: [
         {

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -22,7 +22,7 @@ describe('routeConfig', () => {
   // Caronas e achados e perdidos listam assim que montam.
   beforeEach(() => {
     server.use(
-      http.get('https://rides.fateconnect.test/caronas', () => HttpResponse.json([])),
+      http.get('https://api.fateconnect.test/Rides', () => HttpResponse.json([])),
       http.get('https://api.fateconnect.test/achado', () => HttpResponse.json([])),
     );
   });

--- a/FateConnect/Web/src/services/httpClient.ts
+++ b/FateConnect/Web/src/services/httpClient.ts
@@ -73,10 +73,5 @@ function withInterceptors(client: AxiosInstance): AxiosInstance {
   return client;
 }
 
-/** API principal — autenticação e cadastro. */
+/** Cliente único da API. */
 export const apiClient = withInterceptors(axios.create({ baseURL: import.meta.env.VITE_API_URL }));
-
-/** API de caronas, que tem endereço próprio. */
-export const rideApiClient = withInterceptors(
-  axios.create({ baseURL: import.meta.env.VITE_RIDE_API_URL }),
-);

--- a/FateConnect/Web/src/services/rides/ridesService.test.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.test.ts
@@ -5,15 +5,15 @@ import { server } from '@app/mocks/server';
 import { createRide, deleteRide, listRides, updateRide } from './ridesService';
 import { RideTypeEnum, type RideInput } from './types';
 
-const RIDES_URL = 'https://rides.fateconnect.test/caronas';
+const RIDES_URL = 'https://api.fateconnect.test/Rides';
 
 const RIDE_INPUT: RideInput = {
-  qtdVagas: 3,
-  destino: 'Fatec Sorocaba',
-  dataPartida: '2026-05-22',
-  horaPartida: '07:30',
-  tipoCarona: RideTypeEnum.PHILANTHROPIC,
-  descricao: 'Saída do centro.',
+  availableSeats: 3,
+  destination: 'Fatec Sorocaba',
+  departureDate: '2026-05-22',
+  departureTime: '07:30',
+  rideType: RideTypeEnum.SOLIDARITY,
+  description: 'Saída do centro.',
 };
 
 describe('ridesService', () => {
@@ -33,10 +33,10 @@ describe('ridesService', () => {
       rideType: RideTypeEnum.EGALITARIAN,
     });
 
-    expect(received!.get('Destino')).toBe('Sorocaba');
-    expect(received!.get('DataPartida')).toBe('2026-08-20');
-    expect(received!.get('HoraPartida')).toBe('07:30');
-    expect(received!.get('TipoCarona')).toBe(RideTypeEnum.EGALITARIAN);
+    expect(received!.get('destination')).toBe('Sorocaba');
+    expect(received!.get('departureDate')).toBe('2026-08-20');
+    expect(received!.get('departureTime')).toBe('07:30');
+    expect(received!.get('rideType')).toBe(RideTypeEnum.EGALITARIAN);
   });
 
   it('should omit parameters that were not filled in', async () => {
@@ -50,11 +50,11 @@ describe('ridesService', () => {
 
     await listRides({ destination: 'Sorocaba' });
 
-    expect([...received!.keys()]).toEqual(['Destino']);
+    expect([...received!.keys()]).toEqual(['destination']);
   });
 
   it('should list rides without filters', async () => {
-    server.use(http.get(RIDES_URL, () => HttpResponse.json([{ id: 1, destino: 'Sorocaba' }])));
+    server.use(http.get(RIDES_URL, () => HttpResponse.json([{ id: 1, destination: 'Sorocaba' }])));
 
     const rides = await listRides();
 

--- a/FateConnect/Web/src/services/rides/ridesService.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.ts
@@ -1,24 +1,12 @@
-import { rideApiClient } from '../httpClient';
+import { apiClient } from '../httpClient';
 import type { Ride, RideFilter, RideInput } from './types';
 
-const RIDES_PATH = '/caronas';
+const RIDES_PATH = '/Rides';
 
 const INVALID_LIST_PAYLOAD_MESSAGE = 'A API de caronas respondeu algo que não é uma lista.';
 
-/** Tradução dos filtros do front para os nomes de parâmetro da API. */
-function toQueryParams(filters: RideFilter = {}): Record<string, string> {
-  const params: Record<string, string> = {};
-
-  if (filters.destination) params.Destino = filters.destination;
-  if (filters.departureDate) params.DataPartida = filters.departureDate;
-  if (filters.departureTime) params.HoraPartida = filters.departureTime;
-  if (filters.rideType) params.TipoCarona = filters.rideType;
-
-  return params;
-}
-
 export async function listRides(filters?: RideFilter): Promise<Ride[]> {
-  const { data } = await rideApiClient.get<Ride[]>(RIDES_PATH, { params: toQueryParams(filters) });
+  const { data } = await apiClient.get<Ride[]>(RIDES_PATH, { params: filters });
 
   // O tipo do axios é uma promessa de contrato, não uma garantia: sem o endereço
   // da API a requisição cai no próprio servidor de desenvolvimento, que responde
@@ -30,17 +18,17 @@ export async function listRides(filters?: RideFilter): Promise<Ride[]> {
 }
 
 export async function createRide(input: RideInput): Promise<Ride> {
-  const { data } = await rideApiClient.post<Ride>(RIDES_PATH, input);
+  const { data } = await apiClient.post<Ride>(RIDES_PATH, input);
 
   return data;
 }
 
 export async function updateRide(rideId: string, input: RideInput): Promise<Ride> {
-  const { data } = await rideApiClient.put<Ride>(`${RIDES_PATH}/${rideId}`, input);
+  const { data } = await apiClient.put<Ride>(`${RIDES_PATH}/${rideId}`, input);
 
   return data;
 }
 
 export async function deleteRide(rideId: string): Promise<void> {
-  await rideApiClient.delete(`${RIDES_PATH}/${rideId}`);
+  await apiClient.delete(`${RIDES_PATH}/${rideId}`);
 }

--- a/FateConnect/Web/src/services/rides/types.ts
+++ b/FateConnect/Web/src/services/rides/types.ts
@@ -1,29 +1,28 @@
 /** Valores canônicos alinhados à serialização do backend. */
 export enum RideTypeEnum {
-  PHILANTHROPIC = 'Filantropica',
-  EGALITARIAN = 'Igualitaria',
+  SOLIDARITY = 'Solidarity',
+  EGALITARIAN = 'Egalitarian',
 }
 
-/** Entidade como a API devolve (campos em pt-BR). O id é o `Guid` do backend. */
+/** Entidade como a API devolve. O id é o `Guid` do backend. */
 export type Ride = {
   id: string;
-  qtdVagas: number;
-  destino: string;
-  dataPartida: string;
-  horaPartida: string;
-  dataCadastro: string;
-  tipoCarona: RideTypeEnum;
-  descricao: string | null;
-  ativo: boolean;
+  availableSeats: number;
+  destination: string;
+  departureDate: string;
+  departureTime: string;
+  createdAt: string;
+  rideType: RideTypeEnum;
+  description: string | null;
 };
 
 /**
  * Corpo de criação e de atualização — a API aceita o mesmo conjunto de campos
  * nos dois verbos.
  */
-export type RideInput = Omit<Ride, 'id' | 'dataCadastro' | 'ativo'>;
+export type RideInput = Omit<Ride, 'id' | 'createdAt'>;
 
-/** Filtros do front, em inglês; o serviço traduz para os parâmetros da API. */
+/** Filtros da listagem, com os mesmos nomes que a API recebe na query. */
 export type RideFilter = {
   destination?: string;
   departureDate?: string;

--- a/FateConnect/Web/src/services/signup/signupService.test.ts
+++ b/FateConnect/Web/src/services/signup/signupService.test.ts
@@ -12,7 +12,7 @@ const PAYLOAD: SignupRequest = {
   senha: 'segredo123',
   nomeCompleto: 'Fulano de Tal',
   dataNascimento: '2000-01-01T00:00:00Z',
-  genero: 'Feminino',
+  genero: 'Female',
   enderecos: [],
   contatos: [],
 };

--- a/FateConnect/Web/src/vite-env.d.ts
+++ b/FateConnect/Web/src/vite-env.d.ts
@@ -2,7 +2,6 @@
 
 type ImportMetaEnv = {
   readonly VITE_API_URL: string;
-  readonly VITE_RIDE_API_URL: string;
   /** Ausente em desenvolvimento e em teste: sem ela o Sentry não sobe. */
   readonly VITE_SENTRY_DSN?: string;
 };

--- a/FateConnect/Web/vitest.setup.ts
+++ b/FateConnect/Web/vitest.setup.ts
@@ -10,10 +10,9 @@ failOnConsole({ shouldFailOnWarn: true, shouldFailOnError: true });
 
 process.env.TZ = 'America/Sao_Paulo';
 
-// Endereços fictícios: os clientes HTTP são criados na carga do módulo, então o
+// Endereço fictício: o cliente HTTP é criado na carga do módulo, então o
 // stub precisa acontecer antes de qualquer import de teste.
 vi.stubEnv('VITE_API_URL', 'https://api.fateconnect.test');
-vi.stubEnv('VITE_RIDE_API_URL', 'https://rides.fateconnect.test');
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {


### PR DESCRIPTION
## Objetivo

A #44, mergeada pelo #186, unificou a API de caronas dentro da `FateConnect.Api` e trocou o contrato HTTP inteiro — sem tocar em nenhum arquivo do front. Este PR faz a metade do front acompanhar, para que caronas e cadastro voltem a funcionar contra a API unificada.

A metade de infraestrutura da issue (`docker-compose`, nginx, `deploy.sh`, `publish.yml`, os `.env.example` e os READMEs) e as duas rules defasadas vêm em PR separado.

## Alterações

**Contrato das caronas**

- `Ride` passa a espelhar a API em inglês: `availableSeats`, `destination`, `departureDate`, `departureTime`, `createdAt`, `rideType`, `description`.
- `ativo` sai do tipo — a API deixou de expor o campo, porque os dois caminhos de leitura já filtram por ativo e ele valia sempre `true`. `RideInput` passa a ser `Omit<Ride, 'id' | 'createdAt'>`.
- `RideTypeEnum` passa a `Solidarity` e `Egalitarian`; o membro `PHILANTHROPIC` vira `SOLIDARITY`, senão o nome contradiz o valor.
- O caminho vira `/Rides` e o `toQueryParams` sai. **A tradução virou identidade de verdade:** o `RideFilter` já guarda cada campo antes de montar o objeto (`if (destination.trim())`, `if (rideType)`), então as guardas do tradutor eram redundantes com as dele — tirá-lo não muda comportamento.

**Cliente HTTP único**

- `rideApiClient` sai; as caronas passam a usar o `apiClient`, com o mesmo `VITE_API_URL` do resto.
- `VITE_RIDE_API_URL` sai do `vite-env.d.ts`, do `.env.example`, do `vitest.setup.ts` e dos alvos de propagação de trace do Sentry.

**Cadastro**

- `GenderValueEnum` passa a `Male`, `Female` e `Other`, que é o que o `EnumGender` da API serializa. O campo continua `genero`; só o valor muda.

**O que a pessoa lê não muda:** "Solidária", "Igualitária", "Masculino", "Feminino" e "Prefiro não informar" seguem iguais — o `AccountSection/constants` e o `RIDE_TYPE_LABEL` já separavam valor de rótulo. As rotas de tela seguem em pt-BR (`/caronas`).

## Gates

- `vitest run` — **438 de 438**, em 66 arquivos
- `eslint` — exit 0 sobre os 19 arquivos alterados
- `tsc --noEmit` — exit 0

## Issue

- #189

**Não fecha a issue:** este PR entrega só a metade do front. A #189 fecha quando o PR de infraestrutura e rules entrar.

## Evidências
