### PR TITLE
fix: keep https when the nginx site config is regenerated

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -136,6 +136,12 @@ sudo certbot --nginx -d hml.fateconnect.com.br
 O certbot edita a configuração do nginx sozinho e instala um agendamento de
 renovação. Confira com `systemctl list-timers | grep certbot`.
 
+⚠️ **O bloco 443 que ele escreve fica dentro do arquivo que o `install-site.sh`
+gera.** Rodar o script de novo sobrescreveria o arquivo inteiro e derrubaria o
+HTTPS — por isso ele reaplica o TLS sozinho quando já existe certificado para o
+domínio. Se a HTTPS sumir depois de um `install-site.sh`, foi isso, e
+`sudo certbot --nginx -d <domínio>` devolve.
+
 Depois troque `PUBLIC_URL` para `https://` nos dois `.env` e **reconstrua o
 front** — o endereço da API fica gravado dentro do bundle, então reiniciar não
 basta:
@@ -199,30 +205,28 @@ cat ~/.ssh/github-actions.pub >> ~/.ssh/authorized_keys
 O conteúdo de `~/.ssh/github-actions` (sem o `.pub`) vai no secret
 `DEPLOY_SSH_KEY`. Ele nunca deve ser colado em conversa, chamado ou commit.
 
-## Atualizar o código da VPS
+## Como o código chega na VPS
 
-⛔ **A pipeline não faz isso.** Ela envia o `dist/` do front por `rsync` e roda o
-`deploy.sh` que **já está na VPS** — nunca um `git pull`. Tudo o que vem do
-repositório continua no commit do último `pull` manual: o `docker-compose.yml`,
-os scripts daqui, o template do nginx e o **código da API**, que o compose
-constrói de `../FateConnect/FateConnect.Api`.
+O `deploy.sh` se atualiza antes de qualquer outra coisa: `fetch`, `checkout` da
+branch daquele ambiente — `develop` para `hml`, `main` para `prod` —,
+`pull --ff-only`, e então **se re-executa** na versão recém-baixada. Não existe
+`git pull` manual.
 
-```bash
-cd ~/FateConnect && git pull
-```
+O checkout é **um só** para os dois ambientes, então publicar troca a branch
+dele. É daí que vem o comportamento que mais surpreende: **produção continua no
+mundo da última release** mesmo com a `develop` bem à frente, porque o
+`deploy.sh prod` volta para a `main` antes de construir. O contêiner da API é
+construído desse mesmo checkout, então ele segue a branch do ambiente.
 
-Sem isso, uma mudança em `deploy/` ou na API entra no repositório e não chega ao
-ar — e a publicação seguinte roda a versão antiga sem acusar nada.
-
-⚠️ **Mudou o template do nginx?** O `deploy.sh` não toca no nginx. Depois do
-`pull`, rode `sudo ./install-site.sh <ambiente>` para regenerar a configuração,
-uma vez por ambiente.
+⚠️ **O que o deploy não faz é mexer no nginx.** Mudou `nginx/site.conf.template`?
+Rode `sudo ./install-site.sh <ambiente>`, uma vez por ambiente — é o único passo
+manual de uma publicação. Ele reaplica o HTTPS sozinho quando já existe
+certificado para o domínio.
 
 ## Dia a dia
 
 | O que você quer | Comando |
 | --- | --- |
-| Atualizar o código da VPS | `cd ~/FateConnect && git pull` |
 | Publicar a `develop` | `./build-front.sh hml && ./deploy.sh hml` |
 | Publicar uma release | `./build-front.sh prod && ./deploy.sh prod` |
 | Ver o que está de pé | `docker compose -p fateconnect-prod ps` |

--- a/deploy/install-site.sh
+++ b/deploy/install-site.sh
@@ -54,7 +54,19 @@ echo "==> Conferindo a configuração antes de recarregar"
 nginx -t
 systemctl reload nginx
 
+# O passo acima sobrescreve o arquivo inteiro, e o template só descreve a porta
+# 80 — então o bloco 443 que o certbot escreveu some a cada execução. Reaplicar
+# não reemite certificado: só devolve o TLS ao arquivo recém-gerado.
+if [ -d "/etc/letsencrypt/live/$DOMAIN" ]; then
+  echo "==> Devolvendo o HTTPS à configuração recém-gerada"
+  certbot install --nginx --cert-name "$DOMAIN"
+  nginx -t
+  systemctl reload nginx
+fi
+
 echo
 echo "Pronto: $DOMAIN servido a partir de $TARGET"
-echo "Para ligar o HTTPS depois que o domínio estiver respondendo:"
-echo "  sudo certbot --nginx -d $DOMAIN"
+if [ ! -d "/etc/letsencrypt/live/$DOMAIN" ]; then
+  echo "Para ligar o HTTPS depois que o domínio estiver respondendo:"
+  echo "  sudo certbot --nginx -d $DOMAIN"
+fi


### PR DESCRIPTION
## Objetivo

Dois consertos que apareceram ao aplicar a #189 em homologação — um deles é uma queda de HTTPS esperando para acontecer em produção.

## O defeito

O `install-site.sh` **sempre** reescreve `/etc/nginx/sites-available/fateconnect-<ambiente>` a partir do template, e o template só descreve a porta 80. O bloco `listen 443` que o certbot escreve mora **dentro desse mesmo arquivo** — então toda execução do script apaga o HTTPS daquele ambiente.

Aconteceu agora em homologação: depois do `sudo ./install-site.sh hml`, o `fateconnect-hml` ficou sem `listen 443`, e o HTTPS passou a cair no server block `default`. **O `nginx -t` passa**, porque o arquivo continua sintaticamente válido — nada acusa.

⚠️ Sem esta correção, `sudo ./install-site.sh prod` no dia da release derruba o HTTPS de **produção**, do mesmo jeito e igualmente em silêncio.

## Alterações

**`deploy/install-site.sh`** — depois de gerar a configuração e recarregar, se já existir `/etc/letsencrypt/live/$DOMAIN`, o script reaplica o TLS e recarrega de novo:

```bash
certbot install --nginx --cert-name "$DOMAIN"
```

`certbot install` **não reemite nem renova** certificado: só reescreve a configuração do nginx a partir do que já está emitido. O script vira idempotente quanto ao HTTPS, em vez de depender de alguém lembrar do passo 6 do README. A dica final de "ligue o HTTPS" passa a aparecer só quando ainda não há certificado.

**`deploy/README.md`** — a seção "Atualizar o código da VPS", que entrou no #195, **estava errada**. Ela afirmava que a pipeline nunca faz `git pull` e mandava rodar um manualmente. O `deploy.sh` faz `fetch`, `checkout` da branch do ambiente, `pull --ff-only` e **se re-executa** na versão nova, logo no início — não há passo manual.

A seção foi reescrita para o que o script faz, e ganhou a consequência que não estava documentada em lugar nenhum: **o checkout é um só e a branch troca por ambiente** (`develop` para `hml`, `main` para `prod`), que é a razão de produção continuar no mundo da última release mesmo com a `develop` bem à frente. O que o deploy realmente não faz — mexer no nginx — continua registrado.

A seção do HTTPS ganhou o aviso de que o bloco 443 mora no arquivo que o `install-site.sh` regenera.

## Como foi verificado

Medido na VPS, em homologação, com o `install-site.sh` já executado:

| O que | Resultado |
| --- | --- |
| `grep -rl "listen.*443"` nos sites | só `prod` e `default` — o `hml` tinha perdido o bloco |
| `/api/Rides` em HTTP, no `server_name` do hml | `401` — a rota nova está correta, e 401 é o esperado desde a #176 |
| `/api/Rides` em HTTPS | `200 text/html` — o SPA respondendo, prova de que não havia rota |

## Issue

Sem issue: correção pequena e avulsa, encontrada durante a publicação da #189. Se preferir rastreada, abro.

## Evidências
