### PR TITLE
chore(184): analyze the .NET api with sonar, in its own check workflow

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -41,13 +41,13 @@ Leia a seção `## [Unreleased]` inteira. Ela é a release: se estiver vazia, n�
 
 Em `0.x`, funcionalidade nova é **minor** — `0.2.0 → 0.3.0`. Só correção é **patch**.
 
-⛔ **A versão do projeto é a do `package.json` da raiz, e só ela.** É o que o `check-front.yml`, o `release.yml` e o `publish.yml` leem:
+⛔ **A versão do projeto é a do `package.json` da raiz, e só ela.** É o que o `check-version.yml`, o `release.yml`, o `publish.yml` e o `sonar-main.yml` leem:
 
 ```bash
 grep -rn 'jq -r .version' .github/workflows/
 ```
 
-O `check-front.yml` **reprova o PR para a `main`** se a tag `vX.Y.Z` já existir. Confira antes de abrir:
+O `check-version.yml` **reprova o PR para a `main`** se a tag `vX.Y.Z` já existir. Confira antes de abrir:
 
 ```bash
 git ls-remote --tags origin "refs/tags/v<versão>"     # tem que voltar vazio

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -41,13 +41,13 @@ Leia a seção `## [Unreleased]` inteira. Ela é a release: se estiver vazia, n�
 
 Em `0.x`, funcionalidade nova é **minor** — `0.2.0 → 0.3.0`. Só correção é **patch**.
 
-⛔ **A versão do projeto é a do `package.json` da raiz, e só ela.** É o que o `check.yml`, o `release.yml` e o `publish.yml` leem:
+⛔ **A versão do projeto é a do `package.json` da raiz, e só ela.** É o que o `check-front.yml`, o `release.yml` e o `publish.yml` leem:
 
 ```bash
 grep -rn 'jq -r .version' .github/workflows/
 ```
 
-O `check.yml` **reprova o PR para a `main`** se a tag `vX.Y.Z` já existir. Confira antes de abrir:
+O `check-front.yml` **reprova o PR para a `main`** se a tag `vX.Y.Z` já existir. Confira antes de abrir:
 
 ```bash
 git ls-remote --tags origin "refs/tags/v<versão>"     # tem que voltar vazio

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,10 @@
 
 .claude/ @victorfob
 
+# Integração contínua e configuração do repositório
+
+.github/ @victorfob
+
 # Configuração de deploy
 
 deploy @victorfob

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -1,19 +1,17 @@
 name: Check API
 
-# Irmão do `check-front.yml`, com a mesma estrutura e pelos mesmos motivos: o
-# recorte fica dentro do job para que o check sempre reporte, e o gatilho não
-# filtra branch de destino.
+# Como no `check-front.yml`, o recorte fica dentro do job: workflow que não
+# dispara deixa o check obrigatório `Pending` para sempre.
 on:
   pull_request
 
-# Grupo próprio: dividir com o check do front faria um cancelar o outro.
+# Grupo próprio: compartilhá-lo com o check do front faria um cancelar o outro.
 concurrency:
   group: check-api-${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  # Para ler a lista de arquivos do PR e decidir o que rodar.
   pull-requests: read
 
 jobs:
@@ -23,15 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Clone completo por causa do Sonar: sem histórico ele não sabe quem
-          # mudou o quê e perde a noção de código novo, que é o que o quality
-          # gate mede.
+          # Clone completo por causa do Sonar: sem histórico ele perde a noção
+          # de código novo, que é o que o quality gate mede.
           fetch-depth: 0
 
-      # Mesmo recorte do check do front, e pelo mesmo motivo: o checkout traz um
-      # commit só, então `git diff` contra a base não tem com o que comparar. O
-      # padrão não leva barra ao final para alcançar também o projeto de teste,
-      # que mora em `FateConnect.Api.Tests`, ao lado e não dentro.
       - name: Changed paths
         id: changes
         run: |
@@ -39,13 +32,13 @@ jobs:
 
           changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
 
-          # Documentação fica fora da decisão: nenhum `.md` é importado pelo
-          # código, então mudar um não altera o que o build produz. A lista para
-          # aqui de propósito — `.svg` é ícone que o front importa, e pular por
-          # engano deixa mudança sem validação, enquanto rodar à toa custa
-          # minutos.
+          # Nenhum `.md` é importado pelo código, então documentação não muda o
+          # que o build produz. A lista para aqui de propósito: pular por engano
+          # deixa mudança sem validação.
           relevant=$(printf '%s\n' "$changed" | grep -vE '\.md$' || true)
 
+          # O padrão não leva barra ao final para alcançar também o projeto de
+          # teste, que mora em `FateConnect.Api.Tests`, ao lado e não dentro.
           if printf '%s\n' "$relevant" | grep -qE '^(FateConnect/FateConnect\.Api|global\.json)'; then
             echo 'api=true' >> "$GITHUB_OUTPUT"
             echo 'A mudança alcança a API — validando.'
@@ -63,9 +56,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      # O scanner roda na JVM, mesmo analisando C#. A versão vai declarada para
-      # que uma troca da imagem do runner não derrube a análise sem ninguém ter
-      # tocado nela.
+      # O scanner roda na JVM, mesmo analisando C#.
       - uses: actions/setup-java@v6
         if: steps.changes.outputs.api == 'true'
         with:
@@ -77,27 +68,18 @@ jobs:
         run: dotnet tool install --global dotnet-sonarscanner --version 11.2.1
 
       # C# não é analisado pela action que o front usa: o scanner de .NET precisa
-      # **envolver** o build, porque lê o que o compilador produz. Daí o par
-      # begin/end com a compilação no meio — e daí a análise ser um passo deste
-      # job, e não um job próprio, que teria de construir a solução de novo.
+      # envolver o build, porque lê o que o compilador produz. Daí o par
+      # begin/end com a compilação no meio.
       #
-      # O contexto do PR vai explícito. A action do front recebe isso pronto do
-      # GitHub; aqui quem chama é a linha de comando, e sem os três valores a
-      # análise viraria análise de branch — o gate mediria o repositório inteiro
-      # em vez do que o PR mudou.
+      # ⛔ O contexto do PR chega por `env`, e não interpolado dentro do `run`.
+      # Nome de branch é escolhido por quem abre o PR, e `${{ }}` no comando cola
+      # o texto dele no shell antes de o shell existir: uma branch chamada
+      # `x"; curl ... | sh; #` executa. Sem os três valores, a análise viraria
+      # análise de branch e mediria o repositório inteiro.
       #
-      # ⛔ Os valores chegam por `env`, e não interpolados dentro do `run`. Nome
-      # de branch é escolhido por quem abre o PR: `${{ }}` dentro do comando
-      # cola o texto dele no shell antes de o shell existir, e uma branch
-      # chamada `x"; curl ... | sh; #` executa. Por `env` o valor é dado, não
-      # código. É o mesmo motivo do `PR_NUMBER` no passo de recorte acima.
-      #
-      # `qualitygate.wait` é o que faz o passo reprovar: sem ele o scan publica
-      # o resultado no painel e sai verde. O gate deste projeto é o `Backend`,
-      # igual ao do front menos a condição de cobertura.
-      #
-      # O front fica de fora porque tem projeto e gate próprios: sem a exclusão
-      # o mesmo código seria medido duas vezes, e a segunda com o gate errado.
+      # `qualitygate.wait` é o que faz o passo reprovar; sem ele o scan publica e
+      # sai verde. A exclusão mantém o front fora: ele tem projeto e gate
+      # próprios, e seria medido duas vezes, a segunda com o gate errado.
       - name: Sonar begin
         if: steps.changes.outputs.api == 'true'
         run: >
@@ -118,25 +100,17 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
 
       # Aponta para a solução, e não para cada projeto, porque assim o projeto
-      # novo entra na esteira ao ser adicionado à solução — o mesmo gesto que o
-      # faz aparecer na IDE.
+      # novo entra na esteira ao ser adicionado à solução.
       - name: Build
         if: steps.changes.outputs.api == 'true'
         run: dotnet build FateConnect/FateConnect.Api/FateConnect.Api.sln
 
-      # `--no-build` aproveita a compilação do passo acima. Sem ele o MSBuild
-      # roda de novo e um erro de compilação chegaria disfarçado de falha de
-      # teste, no passo errado.
-      #
       # A suíte sobe a própria aplicação com banco em memória, então não há
       # Postgres a provisionar aqui.
       - name: Tests
         if: steps.changes.outputs.api == 'true'
         run: dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build
 
-      # Falha na compilação ou na suíte encerra o job antes daqui, e então nada
-      # é publicado no Sonar — o que é o certo: análise de árvore quebrada não
-      # descreve nada.
       - name: Sonar end
         if: steps.changes.outputs.api == 'true'
         run: dotnet sonarscanner end /d:sonar.token=$SONAR_TOKEN

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -1,0 +1,65 @@
+name: Check API
+
+# Irmão do `check-front.yml`, com a mesma estrutura e pelos mesmos motivos: o
+# recorte fica dentro do job para que o check sempre reporte, e o gatilho não
+# filtra branch de destino.
+on:
+  pull_request
+
+# Grupo próprio: dividir com o check do front faria um cancelar o outro.
+concurrency:
+  group: check-api-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # Para ler a lista de arquivos do PR e decidir o que rodar.
+  pull-requests: read
+
+jobs:
+  api:
+    name: .NET API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Mesmo recorte do job acima, e pelo mesmo motivo: o checkout traz um
+      # commit só, então `git diff` contra a base não tem com o que comparar. O
+      # padrão não leva barra ao final para alcançar também o projeto de teste,
+      # que mora em `FateConnect.Api.Tests`, ao lado e não dentro.
+      - name: Changed paths
+        id: changes
+        run: |
+          set -euo pipefail
+
+          changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
+
+          if printf '%s\n' "$changed" | grep -qE '^(FateConnect/FateConnect\.Api|global\.json)'; then
+            echo 'api=true' >> "$GITHUB_OUTPUT"
+            echo 'A mudança alcança a API — validando.'
+            exit 0
+          fi
+
+          echo 'api=false' >> "$GITHUB_OUTPUT"
+          echo 'Nada na API — nada a validar aqui.'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - uses: actions/setup-dotnet@v4
+        if: steps.changes.outputs.api == 'true'
+        with:
+          dotnet-version: 8.0.x
+
+      # Aponta para a solução, e não para cada projeto de teste, porque assim o
+      # projeto novo entra na esteira ao ser adicionado à solução — o mesmo gesto
+      # que o faz aparecer na IDE.
+      #
+      # A suíte sobe a própria aplicação com banco em memória, então não há
+      # Postgres a provisionar aqui.
+      - name: Tests
+        if: steps.changes.outputs.api == 'true'
+        run: |
+          set -euo pipefail
+
+          dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -51,15 +51,19 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      # Aponta para a solução, e não para cada projeto de teste, porque assim o
-      # projeto novo entra na esteira ao ser adicionado à solução — o mesmo gesto
-      # que o faz aparecer na IDE.
+      # Aponta para a solução, e não para cada projeto, porque assim o projeto
+      # novo entra na esteira ao ser adicionado à solução — o mesmo gesto que o
+      # faz aparecer na IDE.
+      - name: Build
+        if: steps.changes.outputs.api == 'true'
+        run: dotnet build FateConnect/FateConnect.Api/FateConnect.Api.sln
+
+      # `--no-build` aproveita a compilação do passo acima. Sem ele o MSBuild
+      # roda de novo e um erro de compilação chegaria disfarçado de falha de
+      # teste, no passo errado.
       #
       # A suíte sobe a própria aplicação com banco em memória, então não há
       # Postgres a provisionar aqui.
       - name: Tests
         if: steps.changes.outputs.api == 'true'
-        run: |
-          set -euo pipefail
-
-          dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln
+        run: dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -39,7 +39,14 @@ jobs:
 
           changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
 
-          if printf '%s\n' "$changed" | grep -qE '^(FateConnect/FateConnect\.Api|global\.json)'; then
+          # Documentação fica fora da decisão: nenhum `.md` é importado pelo
+          # código, então mudar um não altera o que o build produz. A lista para
+          # aqui de propósito — `.svg` é ícone que o front importa, e pular por
+          # engano deixa mudança sem validação, enquanto rodar à toa custa
+          # minutos.
+          relevant=$(printf '%s\n' "$changed" | grep -vE '\.md$' || true)
+
+          if printf '%s\n' "$relevant" | grep -qE '^(FateConnect/FateConnect\.Api|global\.json)'; then
             echo 'api=true' >> "$GITHUB_OUTPUT"
             echo 'A mudança alcança a API — validando.'
             exit 0

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -22,8 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Clone completo por causa do Sonar: sem histórico ele não sabe quem
+          # mudou o quê e perde a noção de código novo, que é o que o quality
+          # gate mede.
+          fetch-depth: 0
 
-      # Mesmo recorte do job acima, e pelo mesmo motivo: o checkout traz um
+      # Mesmo recorte do check do front, e pelo mesmo motivo: o checkout traz um
       # commit só, então `git diff` contra a base não tem com o que comparar. O
       # padrão não leva barra ao final para alcançar também o projeto de teste,
       # que mora em `FateConnect.Api.Tests`, ao lado e não dentro.
@@ -51,6 +56,60 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      # O scanner roda na JVM, mesmo analisando C#. A versão vai declarada para
+      # que uma troca da imagem do runner não derrube a análise sem ninguém ter
+      # tocado nela.
+      - uses: actions/setup-java@v6
+        if: steps.changes.outputs.api == 'true'
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install the Sonar scanner
+        if: steps.changes.outputs.api == 'true'
+        run: dotnet tool install --global dotnet-sonarscanner --version 11.2.1
+
+      # C# não é analisado pela action que o front usa: o scanner de .NET precisa
+      # **envolver** o build, porque lê o que o compilador produz. Daí o par
+      # begin/end com a compilação no meio — e daí a análise ser um passo deste
+      # job, e não um job próprio, que teria de construir a solução de novo.
+      #
+      # O contexto do PR vai explícito. A action do front recebe isso pronto do
+      # GitHub; aqui quem chama é a linha de comando, e sem os três valores a
+      # análise viraria análise de branch — o gate mediria o repositório inteiro
+      # em vez do que o PR mudou.
+      #
+      # ⛔ Os valores chegam por `env`, e não interpolados dentro do `run`. Nome
+      # de branch é escolhido por quem abre o PR: `${{ }}` dentro do comando
+      # cola o texto dele no shell antes de o shell existir, e uma branch
+      # chamada `x"; curl ... | sh; #` executa. Por `env` o valor é dado, não
+      # código. É o mesmo motivo do `PR_NUMBER` no passo de recorte acima.
+      #
+      # `qualitygate.wait` é o que faz o passo reprovar: sem ele o scan publica
+      # o resultado no painel e sai verde. O gate deste projeto é o `Backend`,
+      # igual ao do front menos a condição de cobertura.
+      #
+      # O front fica de fora porque tem projeto e gate próprios: sem a exclusão
+      # o mesmo código seria medido duas vezes, e a segunda com o gate errado.
+      - name: Sonar begin
+        if: steps.changes.outputs.api == 'true'
+        run: >
+          dotnet sonarscanner begin
+          /k:fateconnect_FateConnect-api
+          /o:fateconnect
+          /d:sonar.host.url=https://sonarcloud.io
+          /d:sonar.token=$SONAR_TOKEN
+          /d:sonar.qualitygate.wait=true
+          /d:sonar.exclusions=FateConnect/Web/**
+          /d:sonar.pullrequest.key=$PR_NUMBER
+          /d:sonar.pullrequest.branch=$HEAD_REF
+          /d:sonar.pullrequest.base=$BASE_REF
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+
       # Aponta para a solução, e não para cada projeto, porque assim o projeto
       # novo entra na esteira ao ser adicionado à solução — o mesmo gesto que o
       # faz aparecer na IDE.
@@ -67,3 +126,12 @@ jobs:
       - name: Tests
         if: steps.changes.outputs.api == 'true'
         run: dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build
+
+      # Falha na compilação ou na suíte encerra o job antes daqui, e então nada
+      # é publicado no Sonar — o que é o certo: análise de árvore quebrada não
+      # descreve nada.
+      - name: Sonar end
+        if: steps.changes.outputs.api == 'true'
+        run: dotnet sonarscanner end /d:sonar.token=$SONAR_TOKEN
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/check-front.yml
+++ b/.github/workflows/check-front.yml
@@ -57,7 +57,14 @@ jobs:
 
           changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
 
-          if printf '%s\n' "$changed" | grep -qE '^(FateConnect/Web/|package\.json$)'; then
+          # Documentação fica fora da decisão: nenhum `.md` é importado pelo
+          # código, então mudar um não altera o que o build produz. A lista para
+          # aqui de propósito — `.svg` é ícone que o front importa, e pular por
+          # engano deixa mudança sem validação, enquanto rodar à toa custa
+          # minutos.
+          relevant=$(printf '%s\n' "$changed" | grep -vE '\.md$' || true)
+
+          if printf '%s\n' "$relevant" | grep -qE '^(FateConnect/Web/|package\.json$)'; then
             echo 'web=true' >> "$GITHUB_OUTPUT"
             echo 'A mudança alcança o front ou a versão do projeto — validando.'
             exit 0

--- a/.github/workflows/check-front.yml
+++ b/.github/workflows/check-front.yml
@@ -1,28 +1,19 @@
 name: Check front
 
-# Um workflow por lado do repositório: PR de backend não paga a suíte de front,
-# nem o contrário.
-#
-# O recorte é feito DENTRO do job, e não em `paths` no gatilho, porque este é o
-# check obrigatório para mergear. Workflow que não dispara não deixa o check
-# ausente: deixa ele `Pending` para sempre, e o PR fica impossível de mergear.
-# Rodando sempre, o contexto sempre reporta — e o PR que não toca o front paga
-# só a partida do runner, não a suíte.
-#
-# Sem filtro de branch de destino, porque PR empilhado (base em outra feature
-# branch) também precisa ser validado.
+# O recorte é feito DENTRO do job, e não em `paths` no gatilho, porque este é um
+# check obrigatório: workflow que não dispara não deixa o check ausente — deixa
+# ele `Pending` para sempre, e o PR fica impossível de mergear. Sem filtro de
+# branch de destino pelo mesmo tipo de motivo: PR empilhado precisa ser validado.
 on:
   pull_request
 
-# Execução nova na mesma ref cancela a anterior. O grupo leva o nome do
-# workflow: compartilhá-lo com o check da API faria um cancelar o outro.
+# Grupo próprio: compartilhá-lo com o check da API faria um cancelar o outro.
 concurrency:
   group: check-front-${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  # Para ler a lista de arquivos do PR e decidir o que rodar.
   pull-requests: read
 
 jobs:
@@ -35,18 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Clone completo por causa do Sonar: sem histórico ele não sabe quem
-          # mudou o quê e perde a noção de código novo, que é o que o quality
-          # gate mede.
+          # Clone completo por causa do Sonar: sem histórico ele perde a noção
+          # de código novo, que é o que o quality gate mede.
           fetch-depth: 0
 
-      # A lista vem da API do PR, não de `git diff`: o checkout traz um commit
-      # só, e comparar com a base exigiria clone completo por um dado que o
-      # GitHub já tem pronto.
-      #
       # É a API de arquivos, paginada, e não `gh pr diff`: aquele recusa PR com
       # mais de 300 arquivos (HTTP 406), e a release que trocou o front inteiro
-      # tinha 330. Um check obrigatório reprovaria exatamente no PR de release.
+      # tinha 330 — um check obrigatório reprovaria no PR de release.
       - name: Changed paths
         id: changes
         run: |
@@ -54,11 +40,9 @@ jobs:
 
           changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
 
-          # Documentação fica fora da decisão: nenhum `.md` é importado pelo
-          # código, então mudar um não altera o que o build produz. A lista para
-          # aqui de propósito — `.svg` é ícone que o front importa, e pular por
-          # engano deixa mudança sem validação, enquanto rodar à toa custa
-          # minutos.
+          # Nenhum `.md` é importado pelo código, então documentação não muda o
+          # que o build produz. A lista para aqui de propósito: `.svg` é ícone
+          # que o front importa, e pular por engano deixa mudança sem validação.
           relevant=$(printf '%s\n' "$changed" | grep -vE '\.md$' || true)
 
           if printf '%s\n' "$relevant" | grep -qE '^FateConnect/Web/'; then
@@ -80,9 +64,9 @@ jobs:
           cache: yarn
           cache-dependency-path: FateConnect/Web/yarn.lock
 
-      # `--ignore-scripts` porque instalar dependência não deve executar código:
-      # sem ele o `postinstall` de qualquer pacote da árvore roda no runner, com
-      # os segredos do job ao alcance.
+      # Instalar dependência não deve executar código: sem `--ignore-scripts` o
+      # `postinstall` de qualquer pacote da árvore roda com os segredos do job
+      # ao alcance.
       - name: Install dependencies
         if: steps.changes.outputs.web == 'true'
         run: yarn install --frozen-lockfile --ignore-scripts
@@ -96,13 +80,8 @@ jobs:
         run: yarn lint
 
       # Suíte inteira: os limites de cobertura são globais, então medi-los sobre
-      # um recorte reprovaria código saudável. O recorte por arquivo alterado
-      # fica no hook de pre-push, onde o objetivo é velocidade.
-      #
-      # Não há envio ao GitHub Code Quality: o recurso exige repositório de
-      # organização em plano Team ou Enterprise Cloud, e este é de conta pessoal
-      # — a API responde 404. Quem reprova por cobertura é o limite do Vitest,
-      # aplicado dentro do `test:ci`.
+      # um recorte reprovaria código saudável. Quem roda só o que mudou é o hook
+      # de pre-push, onde o objetivo é velocidade.
       - name: Tests and coverage
         if: steps.changes.outputs.web == 'true'
         run: yarn test:ci
@@ -111,19 +90,13 @@ jobs:
         if: steps.changes.outputs.web == 'true'
         run: yarn build
 
-      # Passo deste job, e não um job à parte, porque é este o check exigido
-      # pelo ruleset da develop: Sonar reprovado tem que impedir o merge, e um
-      # job separado só bloquearia se alguém o marcasse como obrigatório na
-      # configuração do repositório. Aqui a garantia é do próprio repositório.
+      # Passo deste job, e não um job à parte, porque é este o check que a
+      # ruleset exige: Sonar reprovado tem que impedir o merge sem depender de
+      # alguém marcar um segundo check como obrigatório.
       #
-      # Vem depois dos testes porque consome o lcov que eles produzem, e por
-      # último porque é o passo mais lento — o `sonar.qualitygate.wait` do
-      # sonar-project.properties espera o veredito do gate e é ele que faz este
-      # passo reprovar. Sem ele o scan publica o resultado e sai verde.
-      #
-      # Só o front é analisado: o scanner genérico não analisa C#, que exigiria
-      # o SonarScanner for .NET em volta do `dotnet build` e, por não poder
-      # dividir o mesmo projectKey, um projeto próprio no Sonar.
+      # Vem depois dos testes porque consome o lcov que eles produzem. Quem faz
+      # este passo reprovar é o `sonar.qualitygate.wait` do
+      # `sonar-project.properties`; sem ele o scan publica e sai verde.
       - name: Sonar
         if: steps.changes.outputs.web == 'true'
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0

--- a/.github/workflows/check-front.yml
+++ b/.github/workflows/check-front.yml
@@ -47,9 +47,6 @@ jobs:
       # É a API de arquivos, paginada, e não `gh pr diff`: aquele recusa PR com
       # mais de 300 arquivos (HTTP 406), e a release que trocou o front inteiro
       # tinha 330. Um check obrigatório reprovaria exatamente no PR de release.
-      #
-      # A versão do projeto mora no `package.json` da raiz, então ela entra no
-      # recorte junto do front: mudança de versão não pode escapar da validação.
       - name: Changed paths
         id: changes
         run: |
@@ -64,43 +61,17 @@ jobs:
           # minutos.
           relevant=$(printf '%s\n' "$changed" | grep -vE '\.md$' || true)
 
-          if printf '%s\n' "$relevant" | grep -qE '^(FateConnect/Web/|package\.json$)'; then
+          if printf '%s\n' "$relevant" | grep -qE '^FateConnect/Web/'; then
             echo 'web=true' >> "$GITHUB_OUTPUT"
-            echo 'A mudança alcança o front ou a versão do projeto — validando.'
+            echo 'A mudança alcança o front — validando.'
             exit 0
           fi
 
           echo 'web=false' >> "$GITHUB_OUTPUT"
-          echo 'Nada em FateConnect/Web nem na versão do projeto — nada a validar aqui.'
+          echo 'Nada em FateConnect/Web — nada a validar aqui.'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      # A tag da release nasce da versão do `package.json` da raiz, então PR para
-      # a main é a última chance de pegar versão repetida: ou o bump foi
-      # esquecido, ou a versão já foi publicada. Nos dois casos a release
-      # entraria sem tag nova.
-      #
-      # Só o PR para a main é validado — a versão que vale é a que está sendo
-      # publicada. Em PR de feature a versão é a da última release, e a tag dela
-      # existe: validar ali reprovaria toda feature.
-      #
-      # A busca é no remoto, não em `git tag -l`: o checkout traz um commit e
-      # nenhuma tag, então a busca local não acharia nada nunca e o passo
-      # aprovaria tudo em silêncio.
-      - name: Version
-        if: steps.changes.outputs.web == 'true' && github.base_ref == 'main'
-        run: |
-          set -euo pipefail
-
-          version=$(jq -r .version "$GITHUB_WORKSPACE/package.json")
-
-          if git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1; then
-            echo "::error::A versão $version já foi publicada (tag v$version). Atualize a versão no package.json da raiz e abra a seção correspondente no CHANGELOG.md."
-            exit 1
-          fi
-
-          echo "Versão $version disponível para publicação."
 
       - uses: actions/setup-node@v5
         if: steps.changes.outputs.web == 'true'

--- a/.github/workflows/check-front.yml
+++ b/.github/workflows/check-front.yml
@@ -1,21 +1,23 @@
-name: Check Pull Request
+name: Check front
 
-# Um job por lado do repositório, e cada um roda só quando a mudança toca o seu:
-# PR de backend não paga a suíte de front, nem o contrário. Sem filtro de branch
-# de destino no PR, porque PR empilhado (base em outra feature branch) também
-# precisa ser validado.
+# Um workflow por lado do repositório: PR de backend não paga a suíte de front,
+# nem o contrário.
 #
-# O recorte é feito DENTRO de cada job, não em `paths` no gatilho, porque o job
-# do front é o check obrigatório para mergear. Workflow que não dispara não deixa
-# o check ausente: deixa ele `Pending` para sempre, e o PR fica impossível de
-# mergear. Rodando sempre, o contexto sempre reporta — e o PR que não toca aquele
-# lado paga só a partida do runner, não a suíte.
+# O recorte é feito DENTRO do job, e não em `paths` no gatilho, porque este é o
+# check obrigatório para mergear. Workflow que não dispara não deixa o check
+# ausente: deixa ele `Pending` para sempre, e o PR fica impossível de mergear.
+# Rodando sempre, o contexto sempre reporta — e o PR que não toca o front paga
+# só a partida do runner, não a suíte.
+#
+# Sem filtro de branch de destino, porque PR empilhado (base em outra feature
+# branch) também precisa ser validado.
 on:
   pull_request
 
-# Execução nova na mesma ref cancela a anterior.
+# Execução nova na mesma ref cancela a anterior. O grupo leva o nome do
+# workflow: compartilhá-lo com o check da API faria um cancelar o outro.
 concurrency:
-  group: check-${{ github.head_ref }}
+  group: check-front-${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions:
@@ -148,50 +150,3 @@ jobs:
           projectBaseDir: FateConnect/Web
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  api:
-    name: .NET API
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      # Mesmo recorte do job acima, e pelo mesmo motivo: o checkout traz um
-      # commit só, então `git diff` contra a base não tem com o que comparar. O
-      # padrão não leva barra ao final para alcançar também o projeto de teste,
-      # que mora em `FateConnect.Api.Tests`, ao lado e não dentro.
-      - name: Changed paths
-        id: changes
-        run: |
-          set -euo pipefail
-
-          changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename')
-
-          if printf '%s\n' "$changed" | grep -qE '^(FateConnect/FateConnect\.Api|global\.json)'; then
-            echo 'api=true' >> "$GITHUB_OUTPUT"
-            echo 'A mudança alcança a API — validando.'
-            exit 0
-          fi
-
-          echo 'api=false' >> "$GITHUB_OUTPUT"
-          echo 'Nada na API — nada a validar aqui.'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - uses: actions/setup-dotnet@v4
-        if: steps.changes.outputs.api == 'true'
-        with:
-          dotnet-version: 8.0.x
-
-      # Aponta para a solução, e não para cada projeto de teste, porque assim o
-      # projeto novo entra na esteira ao ser adicionado à solução — o mesmo gesto
-      # que o faz aparecer na IDE.
-      #
-      # A suíte sobe a própria aplicação com banco em memória, então não há
-      # Postgres a provisionar aqui.
-      - name: Tests
-        if: steps.changes.outputs.api == 'true'
-        run: |
-          set -euo pipefail
-
-          dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln

--- a/.github/workflows/check-front.yml
+++ b/.github/workflows/check-front.yml
@@ -102,9 +102,12 @@ jobs:
           cache: yarn
           cache-dependency-path: FateConnect/Web/yarn.lock
 
+      # `--ignore-scripts` porque instalar dependência não deve executar código:
+      # sem ele o `postinstall` de qualquer pacote da árvore roda no runner, com
+      # os segredos do job ao alcance.
       - name: Install dependencies
         if: steps.changes.outputs.web == 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Types
         if: steps.changes.outputs.web == 'true'

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,14 +1,12 @@
 name: Check version
 
 # A tag da release nasce da versão do `package.json` da raiz, então PR para a
-# `main` é a última chance de pegar versão repetida: ou o bump foi esquecido, ou
-# a versão já foi publicada. Nos dois casos a release entraria sem tag nova.
+# `main` é a última chance de pegar versão repetida.
 #
-# Workflow próprio, e não um passo do check do front, porque a versão é do
-# repositório e não de um lado dele. Como passo de lá, a validação dependia do
-# recorte daquele job: PR para a `main` que não tocasse o front nem o
-# `package.json` a pulava em silêncio — e "não tocou o `package.json`" é
-# precisamente o bump esquecido que ela existe para pegar.
+# Workflow próprio, e não um passo do check do front: como passo de lá, a
+# validação dependia do recorte daquele job, e PR para a `main` que não tocasse
+# o front nem o `package.json` a pulava em silêncio — que é precisamente o bump
+# esquecido que ela existe para pegar.
 on:
   pull_request
 
@@ -26,13 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Só o PR para a `main` é validado — a versão que vale é a que está sendo
-      # publicada. Em PR de feature a versão é a da última release, e a tag dela
-      # existe: validar ali reprovaria toda feature.
+      # Só o PR para a `main` é validado: em PR de feature a versão é a da
+      # última release, e a tag dela existe — validar ali reprovaria toda
+      # feature.
       #
       # A busca é no remoto, não em `git tag -l`: o checkout traz um commit e
-      # nenhuma tag, então a busca local não acharia nada nunca e o passo
-      # aprovaria tudo em silêncio.
+      # nenhuma tag, então a busca local aprovaria tudo em silêncio.
       - name: Version
         if: github.base_ref == 'main'
         run: |

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,14 +1,16 @@
 name: Check version
 
-# A tag da release nasce da versão do `package.json` da raiz, então PR para a
-# `main` é a última chance de pegar versão repetida.
+# A tag da release nasce da versão do `package.json` da raiz, e este é o último
+# ponto onde uma versão repetida ainda dá para barrar.
 #
-# Workflow próprio, e não um passo do check do front: como passo de lá, a
-# validação dependia do recorte daquele job, e PR para a `main` que não tocasse
-# o front nem o `package.json` a pulava em silêncio — que é precisamente o bump
-# esquecido que ela existe para pegar.
+# `edited` está na lista porque trocar a base de um PR emite esse tipo, e não os
+# três padrão: sem ele, um PR reapontado da `develop` para a `main` nunca seria
+# validado.
 on:
-  pull_request
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - main
 
 concurrency:
   group: check-version-${{ github.head_ref }}
@@ -24,14 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Só o PR para a `main` é validado: em PR de feature a versão é a da
-      # última release, e a tag dela existe — validar ali reprovaria toda
-      # feature.
-      #
       # A busca é no remoto, não em `git tag -l`: o checkout traz um commit e
       # nenhuma tag, então a busca local aprovaria tudo em silêncio.
       - name: Version
-        if: github.base_ref == 'main'
         run: |
           set -euo pipefail
 

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,48 @@
+name: Check version
+
+# A tag da release nasce da versão do `package.json` da raiz, então PR para a
+# `main` é a última chance de pegar versão repetida: ou o bump foi esquecido, ou
+# a versão já foi publicada. Nos dois casos a release entraria sem tag nova.
+#
+# Workflow próprio, e não um passo do check do front, porque a versão é do
+# repositório e não de um lado dele. Como passo de lá, a validação dependia do
+# recorte daquele job: PR para a `main` que não tocasse o front nem o
+# `package.json` a pulava em silêncio — e "não tocou o `package.json`" é
+# precisamente o bump esquecido que ela existe para pegar.
+on:
+  pull_request
+
+concurrency:
+  group: check-version-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Só o PR para a `main` é validado — a versão que vale é a que está sendo
+      # publicada. Em PR de feature a versão é a da última release, e a tag dela
+      # existe: validar ali reprovaria toda feature.
+      #
+      # A busca é no remoto, não em `git tag -l`: o checkout traz um commit e
+      # nenhuma tag, então a busca local não acharia nada nunca e o passo
+      # aprovaria tudo em silêncio.
+      - name: Version
+        if: github.base_ref == 'main'
+        run: |
+          set -euo pipefail
+
+          version=$(jq -r .version package.json)
+
+          if git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1; then
+            echo "::error::A versão $version já foi publicada (tag v$version). Atualize a versão no package.json da raiz e abra a seção correspondente no CHANGELOG.md."
+            exit 1
+          fi
+
+          echo "Versão $version disponível para publicação."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,15 @@
 name: Deploy to staging
 
-# Homologação acompanha a develop: tudo que mergeia aparece lá antes de virar
-# release. Produção não sai daqui — ela é publicada pelo `release.yml`, junto da
-# tag, para que subir versão continue sendo um ato só.
+# Produção não sai daqui: ela é publicada pelo `release.yml`, junto da tag, para
+# que subir versão continue sendo um ato só.
 on:
   push:
     branches:
       - develop
-  # Permite republicar sem precisar de um commit novo, útil quando a VPS estava
-  # fora do ar durante o push.
+  # Permite republicar sem um commit novo, quando a VPS estava fora do ar.
   workflow_dispatch:
 
-# Duas publicações no mesmo ambiente não podem correr juntas: a segunda
+# Duas publicações do mesmo ambiente não podem correr juntas: a segunda
 # reconstruiria os contêineres enquanto a primeira ainda sobe.
 concurrency:
   group: deploy-hml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,11 @@ jobs:
           cache: yarn
           cache-dependency-path: FateConnect/Web/yarn.lock
 
+      # `--ignore-scripts` porque instalar dependência não deve executar código:
+      # sem ele o `postinstall` de qualquer pacote da árvore roda no runner, com
+      # os segredos do job ao alcance.
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
         working-directory: FateConnect/Web
 
       # A versão da raiz é a que nomeia a tag, e é ela que amarra o erro no

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,12 @@
 name: Publish
 
-# Publicação de um ambiente, chamada por quem tem o gatilho: o `release.yml`
-# para produção e o `deploy.yml` para homologação. Fica num arquivo só para que
-# os dois ambientes subam exatamente pelos mesmos passos — deploy que difere
+# Chamado pelo `release.yml` para produção e pelo `deploy.yml` para homologação.
+# Um arquivo só para que os dois subam pelos mesmos passos — deploy que difere
 # entre ambientes deixa de valer como ensaio.
 #
-# O front é construído AQUI, e é este `dist` que vai para a VPS. É o que mantém
-# os source maps enviados ao Sentry descrevendo o bundle que está no ar;
-# reconstruir no servidor produziria outro bundle, e o erro apontaria a linha
-# errada sem nada acusar.
+# O front é construído AQUI, e é este `dist` que vai para a VPS: é o que mantém
+# os source maps do Sentry descrevendo o bundle que está no ar. Reconstruir no
+# servidor produziria outro bundle, e o erro apontaria a linha errada.
 on:
   workflow_call:
     inputs:
@@ -25,8 +23,7 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
 
-    # É o ambiente do GitHub que separa as variáveis e os segredos dos dois
-    # destinos.
+    # É o ambiente do GitHub que separa variáveis e segredos dos dois destinos.
     environment:
       name: ${{ inputs.environment }}
       url: ${{ vars.PUBLIC_URL }}
@@ -47,8 +44,7 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-scripts
         working-directory: FateConnect/Web
 
-      # A versão da raiz é a que nomeia a tag, e é ela que amarra o erro no
-      # Sentry à release que o produziu.
+      # É ela que amarra o erro no Sentry à release que o produziu.
       - name: Read version
         id: version
         run: echo "value=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
@@ -77,11 +73,10 @@ jobs:
 
       - name: Send the front to the VPS
         run: |
-          # Quem serve estes arquivos é o nginx do host; a pasta é criada pelo
+          # Quem serve estes arquivos é o nginx do host; a pasta nasce no
           # install-site.sh, com dono no usuário do deploy.
           target="/var/www/fateconnect/${{ inputs.environment }}"
-          # --delete remove o que saiu do build: sem isso um arquivo apagado no
-          # código continuaria servido no ar indefinidamente.
+          # --delete: sem ele, arquivo apagado no código segue servido no ar.
           rsync -az --delete \
             -e "ssh -i ~/.ssh/deploy_key -o BatchMode=yes" \
             FateConnect/Web/dist/ \
@@ -100,8 +95,8 @@ jobs:
             "docker ps --filter 'name=fateconnect-${{ inputs.environment }}' --filter 'status=running' --format '{{.Names}}'" \
             > containers.txt
           echo 'No ar:'; cat containers.txt
-          # Um ambiente é um contêiner, o da API. O banco e o servidor web são
-          # os do próprio host, e não aparecem aqui.
+          # Um ambiente é um contêiner, o da API: banco e servidor web são do
+          # host e não aparecem aqui.
           total=$(grep -c . containers.txt || true)
           if [ "$total" -lt 1 ]; then
             echo "ERRO: nenhum contêiner de pé; esperado 1." >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
-# Todo push na main é uma release. A versão do projeto é a do `package.json` da
-# raiz — o front tem versão própria, que não diz nada sobre a release.
+# Todo push na main é uma release. A versão é a do `package.json` da raiz — o
+# front tem versão própria, que não diz nada sobre a release.
 on:
   push:
     branches:
@@ -13,13 +13,12 @@ concurrency:
   group: release
   cancel-in-progress: false
 
-# Cada job pede o que precisa; nada é concedido por padrão.
 permissions:
   contents: read
 
 jobs:
-  # O passo de versão do check já barrou versão repetida no PR, então aqui não
-  # sobra decisão: só marcar o commit que foi publicado.
+  # O `check-version.yml` já barrou versão repetida no PR, então aqui não sobra
+  # decisão: só marcar o commit publicado.
   tag:
     name: Create version tag
     runs-on: ubuntu-latest
@@ -34,15 +33,14 @@ jobs:
 
           version=$(jq -r .version package.json)
 
-          # Push na main sem bump — correção de documentação, ajuste que não
-          # muda o produto — não é erro: a tag já está lá e o job encerra verde.
-          # É também o que segura o caso da tag criada à mão.
+          # Push na main sem bump não é erro — correção de documentação, tag
+          # criada à mão: a tag já está lá e o job encerra verde.
           if git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1; then
             echo "A versão $version já está publicada na tag v$version — nada a fazer."
             exit 0
           fi
 
-          # Tag anotada, não leve: guarda data e autoria, então o histórico
+          # Anotada, não leve: guarda data e autoria, então o histórico
           # registra quando a versão saiu, não só onde ela caiu.
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
@@ -51,17 +49,9 @@ jobs:
 
           echo "Tag v$version criada em $GITHUB_SHA."
 
-  # O build de produção e a publicação moram no mesmo lugar porque o upload de
-  # source map tem que sair do MESMO build que vai ao ar: mapa gerado em outro
-  # build tem outro Debug ID, e o Sentry não simboliza nada com ele. Quem faz o
-  # upload é o plugin dentro do `yarn build` — não há passo separado.
-  #
   # Os passos estão em `publish.yml`, compartilhados com homologação, para que
-  # os dois ambientes subam pelo mesmo caminho. As variáveis e os segredos vêm
-  # do ambiente `prod` do GitHub.
-  #
-  # Independente do job da tag: falha ao criar a tag não tem por que impedir a
-  # publicação, e vice-versa.
+  # os dois ambientes subam pelo mesmo caminho. Independente do job da tag:
+  # falha ao marcar não tem por que impedir a publicação, e vice-versa.
   publish:
     name: Publish to production
     uses: ./.github/workflows/publish.yml
@@ -69,19 +59,14 @@ jobs:
       environment: prod
     secrets: inherit
 
-  # A release entra pela main, mas o trabalho continua na develop: sem trazer o
-  # merge de volta, a próxima release nasce de uma base que não conhece a
-  # anterior, e o primeiro PR depois dela já vem com conflito de changelog e
-  # versão.
+  # Sem trazer o merge de volta, a próxima release nasce de uma base que não
+  # conhece a anterior, e o primeiro PR depois dela já vem com conflito de
+  # changelog e versão.
   #
   # Espera a publicação porque o push que ele faz na develop dispara a de
-  # homologação, e as duas usam o mesmo checkout na VPS. Quem impede o atropelo é
-  # a trava do `deploy.sh`; esperar aqui evita que a de homologação comece só
-  # para ficar parada nela. Publicação que falha não perde o back-merge: a
-  # correção entra na main, e esse push refaz este workflow inteiro.
-  #
-  # A tag continua independente — falha ao criar tag é corrigível à mão e não
-  # tem por que segurar a develop.
+  # homologação, e as duas usam o mesmo checkout na VPS. Publicação que falha
+  # não perde o back-merge: a correção entra na main, e esse push refaz este
+  # workflow inteiro. A tag segue independente.
   back-merge:
     name: Sync develop with main
     needs: publish
@@ -93,9 +78,8 @@ jobs:
           # raso não tem os commits para contar.
           fetch-depth: 0
           # A deploy key é o que faz o push na develop passar — é a ela que a
-          # ruleset da develop concede bypass. Bypass para o app GitHub Actions
-          # não serve aqui: ele exige repositório de organização, e a API recusa
-          # em conta pessoal.
+          # ruleset concede bypass. Bypass para o app GitHub Actions exigiria
+          # repositório de organização, e a API recusa em conta pessoal.
           ssh-key: ${{ secrets.BACK_MERGE_SSH_KEY }}
 
       - name: Sync develop
@@ -116,8 +100,8 @@ jobs:
 
           git checkout -B develop origin/develop
 
-          # Caso comum: a develop não andou desde o corte da release, então a
-          # sincronização é fast-forward e não inventa commit nenhum.
+          # Caso comum: a develop não andou, então é fast-forward e não
+          # inventa commit nenhum.
           if [ "$ahead" -eq 0 ]; then
             git merge --ff-only origin/main
             git push origin develop
@@ -125,8 +109,8 @@ jobs:
             exit 0
           fi
 
-          # A develop andou por conta própria — feature mergeada enquanto a
-          # release estava aberta. Aí o merge é de verdade.
+          # A develop andou — feature mergeada enquanto a release estava
+          # aberta. Aí o merge é de verdade.
           if git merge --no-edit origin/main; then
             git push origin develop
             echo "main mergeada na develop em $(git rev-parse --short HEAD) ($ahead commit(s) próprios preservados)."

--- a/.github/workflows/sonar-main.yml
+++ b/.github/workflows/sonar-main.yml
@@ -1,24 +1,18 @@
 name: Sonar main
 
-# A `main` precisa ser analisada para o Sonar ter linha de base: é contra ela
-# que ele calcula o "código novo" de cada PR. Os checks de PR só disparam em
-# `pull_request`, então sem este workflow nenhuma análise da branch principal
-# existiria — e o painel avisa isso.
-#
-# São dois projetos no Sonar, um por lado, porque um `projectKey` não se divide
-# entre dois scanners: o front usa a action genérica, e C# exige o scanner de
-# .NET em volta do build. Daí também os dois gates, que diferem só na cobertura.
+# A `main` precisa ser analisada para o painel ter linha de base: é sobre ela que
+# o código novo da própria `main` é medido. Análise de PR não depende disto — o
+# código novo de um PR é o diff dele contra a base.
 on:
   push:
     branches:
       - main
   # Disparo manual porque o push na `main` só acontece em release: sem ele, uma
-  # análise fora de ciclo — depois de mexer na configuração do Sonar, por
-  # exemplo — esperaria semanas pela próxima versão.
+  # análise fora de ciclo esperaria semanas pela próxima versão.
   workflow_dispatch:
 
-# Duas análises da mesma branch em sequência não podem correr juntas: a segunda
-# publicaria um resultado calculado sobre um estado que já mudou.
+# Duas análises da mesma branch não podem correr juntas: a segunda publicaria um
+# resultado calculado sobre um estado que já mudou.
 concurrency:
   group: sonar-main
   cancel-in-progress: false
@@ -27,8 +21,6 @@ permissions:
   contents: read
 
 jobs:
-  # Workflow próprio, e não um job no `release.yml`: lá os jobs são sobre
-  # publicar, e análise falha por motivos diferentes de tag e deploy.
   web:
     name: Analyze the front
     runs-on: ubuntu-latest
@@ -38,8 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Mesmo motivo do `check-front.yml`: sem histórico completo o Sonar não
-          # sabe quem mudou o quê e perde a noção de código novo.
+          # Sem histórico completo o Sonar perde a noção de quem mudou o quê.
           fetch-depth: 0
 
       - uses: actions/setup-node@v5
@@ -48,22 +39,21 @@ jobs:
           cache: yarn
           cache-dependency-path: FateConnect/Web/yarn.lock
 
-      # `--ignore-scripts` porque instalar dependência não deve executar código:
-      # sem ele o `postinstall` de qualquer pacote da árvore roda no runner, com
-      # os segredos do job ao alcance.
+      # Instalar dependência não deve executar código: sem `--ignore-scripts` o
+      # `postinstall` de qualquer pacote da árvore roda com os segredos do job
+      # ao alcance.
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
 
-      # O scan consome o lcov e o `sonar-report.xml` que esta suíte produz —
-      # sem rodá-la, `sonar.testExecutionReportPaths` aponta para um arquivo que
-      # não existe e o scan falha.
+      # O scan consome o lcov e o `sonar-report.xml` que esta suíte produz — sem
+      # rodá-la, `sonar.testExecutionReportPaths` aponta para um arquivo que não
+      # existe e o scan falha.
       - name: Tests and coverage
         run: yarn test:ci
 
-      # A definição de código novo do projeto é `previous_version`, então sem
-      # versão declarada não há fronteira: as sete condições do gate são todas
-      # sobre código novo, nenhuma métrica `new_*` é calculada, e o veredito sai
-      # `NONE` — que o `sonar.qualitygate.wait` reprova como se fosse falha.
+      # A definição de código novo do projeto é `previous_version`: sem versão
+      # declarada não há fronteira, nenhuma métrica `new_*` é calculada, e o
+      # veredito sai `NONE` — que o `sonar.qualitygate.wait` reprova como falha.
       #
       # Vem daqui e não do `sonar-project.properties` porque o número mora no
       # `package.json` da raiz, fora do `projectBaseDir`.
@@ -71,15 +61,6 @@ jobs:
         id: version
         run: echo "value=$(jq -r .version "$GITHUB_WORKSPACE/package.json")" >> "$GITHUB_OUTPUT"
 
-      # Mesma configuração do PR, pelo `sonar-project.properties`. O
-      # `sonar.qualitygate.wait` de lá vale aqui também: na `main` ele não
-      # bloqueia merge nenhum, mas deixa o run vermelho quando o gate não sai
-      # `OK` — seja porque algo escapou do gate do PR, seja porque não houve
-      # código novo para avaliar.
-      #
-      # A versão só é declarada aqui: é a história de versões da `main` que
-      # forma a linha de base. Análise de PR usa o próprio diff como código
-      # novo e nunca consulta a versão.
       - name: Sonar
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         with:
@@ -94,8 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Mesmo motivo do job acima: sem histórico completo o Sonar perde a
-          # noção de quem mudou o quê.
+          # Sem histórico completo o Sonar perde a noção de quem mudou o quê.
           fetch-depth: 0
 
       - uses: actions/setup-dotnet@v4
@@ -115,9 +95,8 @@ jobs:
         id: version
         run: echo "value=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
-      # A suíte não roda aqui: o gate `Backend` não tem condição de cobertura,
-      # então nada do que ela produz é consumido. Teste quebrado é reprovado no
-      # check do PR, antes de chegar na main.
+      # A suíte não roda aqui: o gate `Backend` não tem condição de cobertura, e
+      # teste quebrado já foi reprovado no check do PR.
       - name: Sonar begin
         run: >
           dotnet sonarscanner begin

--- a/.github/workflows/sonar-main.yml
+++ b/.github/workflows/sonar-main.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Mesmo motivo do `check.yml`: sem histórico completo o Sonar não sabe
-          # quem mudou o quê e perde a noção de código novo.
+          # Mesmo motivo do `check-front.yml`: sem histórico completo o Sonar não
+          # sabe quem mudou o quê e perde a noção de código novo.
           fetch-depth: 0
 
       - uses: actions/setup-node@v5

--- a/.github/workflows/sonar-main.yml
+++ b/.github/workflows/sonar-main.yml
@@ -1,9 +1,13 @@
 name: Sonar main
 
 # A `main` precisa ser analisada para o Sonar ter linha de base: é contra ela
-# que ele calcula o "código novo" de cada PR. O `check.yml` só dispara em
-# `pull_request`, então até aqui nenhuma análise da branch principal existia — e
-# o painel do projeto avisava isso.
+# que ele calcula o "código novo" de cada PR. Os checks de PR só disparam em
+# `pull_request`, então sem este workflow nenhuma análise da branch principal
+# existiria — e o painel avisa isso.
+#
+# São dois projetos no Sonar, um por lado, porque um `projectKey` não se divide
+# entre dois scanners: o front usa a action genérica, e C# exige o scanner de
+# .NET em volta do build. Daí também os dois gates, que diferem só na cobertura.
 on:
   push:
     branches:
@@ -25,8 +29,8 @@ permissions:
 jobs:
   # Workflow próprio, e não um job no `release.yml`: lá os jobs são sobre
   # publicar, e análise falha por motivos diferentes de tag e deploy.
-  sonar:
-    name: Analyze the main branch
+  web:
+    name: Analyze the front
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -78,5 +82,56 @@ jobs:
         with:
           projectBaseDir: FateConnect/Web
           args: -Dsonar.projectVersion=${{ steps.version.outputs.value }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  api:
+    name: Analyze the API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Mesmo motivo do job acima: sem histórico completo o Sonar perde a
+          # noção de quem mudou o quê.
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      # O scanner roda na JVM, mesmo analisando C#.
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install the Sonar scanner
+        run: dotnet tool install --global dotnet-sonarscanner --version 11.2.1
+
+      - name: Project version
+        id: version
+        run: echo "value=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
+      # A suíte não roda aqui: o gate `Backend` não tem condição de cobertura,
+      # então nada do que ela produz é consumido. Teste quebrado é reprovado no
+      # check do PR, antes de chegar na main.
+      - name: Sonar begin
+        run: >
+          dotnet sonarscanner begin
+          /k:fateconnect_FateConnect-api
+          /o:fateconnect
+          /v:${{ steps.version.outputs.value }}
+          /d:sonar.host.url=https://sonarcloud.io
+          /d:sonar.token=$SONAR_TOKEN
+          /d:sonar.qualitygate.wait=true
+          /d:sonar.exclusions=FateConnect/Web/**
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Build
+        run: dotnet build FateConnect/FateConnect.Api/FateConnect.Api.sln
+
+      - name: Sonar end
+        run: dotnet sonarscanner end /d:sonar.token=$SONAR_TOKEN
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar-main.yml
+++ b/.github/workflows/sonar-main.yml
@@ -48,8 +48,11 @@ jobs:
           cache: yarn
           cache-dependency-path: FateConnect/Web/yarn.lock
 
+      # `--ignore-scripts` porque instalar dependência não deve executar código:
+      # sem ele o `postinstall` de qualquer pacote da árvore roda no runner, com
+      # os segredos do job ao alcance.
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       # O scan consome o lcov e o `sonar-report.xml` que esta suíte produz —
       # sem rodá-la, `sonar.testExecutionReportPaths` aponta para um arquivo que

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,11 @@ Antes de pedir review, rode os mesmos portões que o CI roda:
 cd FateConnect/Web && yarn lint && yarn typecheck && yarn test:ci
 ```
 
-Mexeu na API, rode também a suíte dela:
+Mexeu na API, compile e rode a suíte dela — a compilação é portão à parte, e reprova por aviso:
 
 ```bash
-dotnet test FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
+dotnet build FateConnect/FateConnect.Api/FateConnect.Api.sln
+dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build
 ```
 
 Erro reprova. Warning não.

--- a/FateConnect/Web/README.md
+++ b/FateConnect/Web/README.md
@@ -104,7 +104,7 @@ Use o `render` de `@app/test/testing-library`, que já monta tema, rotas e cache
 | ------------ | --------------------------------------------------- | --------- |
 | `pre-commit` | `lint-staged` sobre os arquivos preparados          | —         |
 | `pre-push`   | só os testes **relacionados** aos arquivos enviados | —         |
-| CI (no PR)   | tipos, lint, **suíte inteira**, build               | mede      |
+| CI (no PR)   | tipos, lint, **suíte inteira**, build e Sonar        | mede      |
 
 O `pre-push` usa `scripts/test-changed.sh`, que segue o grafo de imports com `vitest related`: mudar uma tela roda os testes que a alcançam, não a suíte inteira. Ele cai na suíte inteira quando a mudança sai de `src/` ou remove arquivo — nesses casos o grafo não alcança o efeito, e `vitest related vite.config.ts` sairia com sucesso sem rodar teste nenhum.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A validação consulta as tags no **remoto**. Consultar localmente aprovaria qua
 | `sonar-main.yml`  | push na `main`                                | analisa a `main` dos dois projetos, linha de base do código novo de cada PR |
 | `publish.yml`     | chamado pelos dois de publicação              | constrói o front e sobe um ambiente — os passos que homologação e produção compartilham |
 
-Os dois checks disparam em todo PR, e cada um decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. O `package.json` da raiz entra no filtro do front por causa da validação de versão — mudança de versão não pode escapar dela. Os dois são exigidos para mergear.
+Os dois checks disparam em todo PR, e cada um decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. O `package.json` da raiz entra no filtro do front por causa da validação de versão — mudança de versão não pode escapar dela. Mudança só de documentação não roda nem uma suíte nem outra: nenhum `.md` é importado pelo código, então não há o que validar. Os dois são exigidos para mergear, e um check que não teve o que fazer reporta verde do mesmo jeito.
 
 São dois workflows, e não dois jobs num só, para que cada lado tenha o seu arquivo. Cada um leva grupo de concorrência próprio: compartilhá-lo faria um cancelar o outro, já que execução nova na mesma branch cancela a anterior.
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,17 @@ A validação consulta as tags no **remoto**. Consultar localmente aprovaria qua
 | ----------------- | --------------------------------------------- | --------------------------------------------------------------------------- |
 | `check-front.yml` | todo PR                                       | valida o front: versão, tipos, lint, testes, build e Sonar                   |
 | `check-api.yml`   | todo PR                                       | valida a API: compilação, testes e Sonar                                    |
+| `check-version.yml` | todo PR, age nos que miram a `main`         | reprova quando a versão da raiz já tem tag                                  |
 | `deploy.yml`      | push na `develop`                             | publica em homologação                                                      |
 | `release.yml`     | push na `main`                                | cria a tag, publica em produção e devolve a `main` para a `develop`         |
 | `sonar-main.yml`  | push na `main`                                | analisa a `main` dos dois projetos, linha de base do código novo de cada PR |
 | `publish.yml`     | chamado pelos dois de publicação              | constrói o front e sobe um ambiente — os passos que homologação e produção compartilham |
 
-Os dois checks disparam em todo PR, e cada um decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. O `package.json` da raiz entra no filtro do front por causa da validação de versão — mudança de versão não pode escapar dela. Mudança só de documentação não roda nem uma suíte nem outra: nenhum `.md` é importado pelo código, então não há o que validar. Os dois são exigidos para mergear, e um check que não teve o que fazer reporta verde do mesmo jeito.
+Os checks disparam em todo PR, e cada um decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. Mudança só de documentação não roda suíte nenhuma: nenhum `.md` é importado pelo código, então não há o que validar. `React front (Web)` e `.NET API` são exigidos para mergear, e um check que não teve o que fazer reporta verde do mesmo jeito.
 
-São dois workflows, e não dois jobs num só, para que cada lado tenha o seu arquivo. Cada um leva grupo de concorrência próprio: compartilhá-lo faria um cancelar o outro, já que execução nova na mesma branch cancela a anterior.
+A validação de versão tem workflow próprio porque a versão é do repositório, não de um lado dele. Como passo do check do front ela dependia do recorte daquele job, e PR para a `main` que não tocasse o front nem o `package.json` a pulava em silêncio — que é exatamente o bump esquecido que ela existe para pegar.
+
+Cada check é um workflow, e não um job dentro de um arquivo só, para que cada assunto tenha o seu. Cada um leva grupo de concorrência próprio: compartilhá-lo faria um cancelar o outro, já que execução nova na mesma branch cancela a anterior.
 
 Os três jobs da release moram no mesmo workflow porque acontecem no mesmo evento: o push que a `main` recebe quando a release entra. A tag não depende de ninguém — falha ao marcá-la não impede a publicação nem a sincronização, e vice-versa. O back-merge, esse, espera a publicação terminar: o push que ele faz na `develop` é o que dispara a publicação de homologação, e as duas usam o mesmo checkout na VPS. Publicação reprovada não perde o back-merge, porque a correção entra na `main` e esse push refaz o workflow inteiro.
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ A validação consulta as tags no **remoto**. Consultar localmente aprovaria qua
 | ----------------- | --------------------------------------------- | --------------------------------------------------------------------------- |
 | `check-front.yml` | todo PR                                       | valida o front: versão, tipos, lint, testes, build e Sonar                   |
 | `check-api.yml`   | todo PR                                       | valida a API: compilação, testes e Sonar                                    |
-| `check-version.yml` | todo PR, age nos que miram a `main`         | reprova quando a versão da raiz já tem tag                                  |
+| `check-version.yml` | PR para a `main`                            | reprova quando a versão da raiz já tem tag                                  |
 | `deploy.yml`      | push na `develop`                             | publica em homologação                                                      |
 | `release.yml`     | push na `main`                                | cria a tag, publica em produção e devolve a `main` para a `develop`         |
 | `sonar-main.yml`  | push na `main`                                | analisa a `main` dos dois projetos, linha de base do código novo de cada PR |
 | `publish.yml`     | chamado pelos dois de publicação              | constrói o front e sobe um ambiente — os passos que homologação e produção compartilham |
 
-Os checks disparam em todo PR, e cada um decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. Mudança só de documentação não roda suíte nenhuma: nenhum `.md` é importado pelo código, então não há o que validar. `React front (Web)` e `.NET API` são exigidos para mergear, e um check que não teve o que fazer reporta verde do mesmo jeito.
+Os checks de front e de API disparam em todo PR, e cada um decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. Mudança só de documentação não roda suíte nenhuma: nenhum `.md` é importado pelo código, então não há o que validar. `React front (Web)` e `.NET API` são exigidos para mergear, e um check que não teve o que fazer reporta verde do mesmo jeito.
 
-A validação de versão tem workflow próprio porque a versão é do repositório, não de um lado dele. Como passo do check do front ela dependia do recorte daquele job, e PR para a `main` que não tocasse o front nem o `package.json` a pulava em silêncio — que é exatamente o bump esquecido que ela existe para pegar.
+A validação de versão tem workflow próprio porque a versão é do repositório, não de um lado dele. Como passo do check do front ela dependia do recorte daquele job, e PR para a `main` que não tocasse o front nem o `package.json` a pulava em silêncio — que é exatamente o bump esquecido que ela existe para pegar. Ela é a única que filtra pela branch de destino no próprio gatilho, porque é a única cuja condição é a branch: só aparece em PR para a `main`.
 
 Cada check é um workflow, e não um job dentro de um arquivo só, para que cada assunto tenha o seu. Cada um leva grupo de concorrência próprio: compartilhá-lo faria um cancelar o outro, já que execução nova na mesma branch cancela a anterior.
 

--- a/README.md
+++ b/README.md
@@ -58,21 +58,26 @@ A validação consulta as tags no **remoto**. Consultar localmente aprovaria qua
 
 | Workflow          | Quando                                        | O que faz                                                                   |
 | ----------------- | --------------------------------------------- | --------------------------------------------------------------------------- |
-| `check.yml`       | todo PR                                       | um job por lado: front (versão, tipos, lint, testes, build e Sonar) e API (testes)      |
+| `check-front.yml` | todo PR                                       | valida o front: versão, tipos, lint, testes, build e Sonar                   |
+| `check-api.yml`   | todo PR                                       | valida a API: compilação, testes e Sonar                                    |
 | `deploy.yml`      | push na `develop`                             | publica em homologação                                                      |
 | `release.yml`     | push na `main`                                | cria a tag, publica em produção e devolve a `main` para a `develop`         |
-| `sonar-main.yml`  | push na `main`                                | analisa a `main`, que é a linha de base do código novo de cada PR           |
+| `sonar-main.yml`  | push na `main`                                | analisa a `main` dos dois projetos, linha de base do código novo de cada PR |
 | `publish.yml`     | chamado pelos dois de publicação              | constrói o front e sobe um ambiente — os passos que homologação e produção compartilham |
 
-O `check.yml` dispara em todo PR, e cada job decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. O `package.json` da raiz entra no filtro do front por causa da validação de versão — mudança de versão não pode escapar dela. Só o job do front é exigido para mergear.
+Os dois checks disparam em todo PR, e cada um decide se tem o que fazer olhando os arquivos alterados: PR que só mexe no back-end não paga a suíte de front, nem o contrário. O `package.json` da raiz entra no filtro do front por causa da validação de versão — mudança de versão não pode escapar dela. Os dois são exigidos para mergear.
+
+São dois workflows, e não dois jobs num só, para que cada lado tenha o seu arquivo. Cada um leva grupo de concorrência próprio: compartilhá-lo faria um cancelar o outro, já que execução nova na mesma branch cancela a anterior.
 
 Os três jobs da release moram no mesmo workflow porque acontecem no mesmo evento: o push que a `main` recebe quando a release entra. A tag não depende de ninguém — falha ao marcá-la não impede a publicação nem a sincronização, e vice-versa. O back-merge, esse, espera a publicação terminar: o push que ele faz na `develop` é o que dispara a publicação de homologação, e as duas usam o mesmo checkout na VPS. Publicação reprovada não perde o back-merge, porque a correção entra na `main` e esse push refaz o workflow inteiro.
 
 O job de back-merge do `release.yml` empurra **direto na `develop`**, sem PR: a ruleset da `develop` concede bypass a uma **deploy key** de escrita, que o workflow usa no checkout, e a da `main` não concede a ninguém — a release continua exigindo PR e review. Bypass para o app GitHub Actions resolveria sem chave nenhuma, mas ele exige repositório de organização: em conta pessoal a API recusa o ator. O caminho comum é fast-forward, porque a `develop` normalmente não andou desde o corte da release. Quando andou, o job faz o merge de verdade; se conflitar, ele para e reporta, porque escolher qual lado vale é decisão humana.
 
+São **dois projetos no Sonar**, um por lado: um `projectKey` não se divide entre dois scanners, porque o front usa a action genérica e C# exige o SonarScanner for .NET em volta do `dotnet build`. Os gates diferem numa linha — o do front cobra cobertura de código novo, o da API ainda não.
+
 Quem reprova por cobertura é o **quality gate do Sonar**, que mede o código novo do PR, somado ao limite do Vitest dentro do `test:ci`. Não há envio para o Code Quality do GitHub: ele exige repositório de organização em plano Team ou Enterprise Cloud, e este é de conta pessoal.
 
-A análise da `main` existe para dar ao Sonar a **linha de base** — é contra ela que o código novo de cada PR é calculado. Ela declara a versão do `package.json` da raiz porque a definição de código novo do projeto é *previous_version*: sem versão declarada não há fronteira, nenhuma métrica de código novo é calculada, e o gate reprova por não ter o que avaliar.
+A análise da `main` existe para dar ao Sonar a **linha de base** da branch principal, sobre a qual o código novo da própria `main` é medido. Análise de PR não depende dela: o código novo de um PR é o diff dele contra a base, que o Sonar tira do git. Ela declara a versão do `package.json` da raiz porque a definição de código novo do projeto é *previous_version*: sem versão declarada não há fronteira, nenhuma métrica de código novo é calculada, e o gate reprova por não ter o que avaliar.
 
 ## Configuração do agente de código
 


### PR DESCRIPTION
## Objetivo

O Sonar analisava **só o front**: os dois workflows apontavam para `projectBaseDir: FateConnect/Web`, então todo o C# do projeto passava sem análise nenhuma. O único sinal sobre o back era o SonarLint na IDE, que não reprova nada e depende de alguém ter o arquivo aberto.

Junto vieram dois pedidos que moram no mesmo arquivo: um passo de compilação explícito no check da API, e a divisão do `check.yml` em um workflow por lado.

## Alterações

**Divisão do check em dois workflows** (`check-front.yml` e `check-api.yml`). Os corpos dos dois jobs saíram byte a byte idênticos ao original — é movimento, não reescrita. Os nomes dos jobs continuam `React front (Web)` e `.NET API`, que é o que as rulesets exigem: renomeá-los quebraria a proteção das branches em silêncio.

⚠️ Cada workflow ganhou **grupo de concorrência próprio**. Herdar o mesmo grupo faria um cancelar o outro, já que o `cancel-in-progress` é `true`.

**Compilação explícita.** O `dotnet build` da solução virou passo próprio e a suíte passou a rodar com `--no-build`. Antes o `dotnet test` compilava por dentro, e erro de compilação — com `TreatWarningsAsErrors` ligado, qualquer aviso vira um — chegava disfarçado de falha de teste, no passo errado.

**Análise do C#.** Um par `begin`/`end` do SonarScanner for .NET em volta da compilação, no próprio job `.NET API`. Não dá para usar a action genérica do front: ela não analisa C#, e o scanner de .NET precisa envolver o build porque lê o que o compilador produz. Ser um passo deste job, e não um job à parte, evita construir a solução duas vezes.

- Projeto próprio no Sonar, `fateconnect_FateConnect-api` — um `projectKey` não se divide entre dois scanners.
- O contexto do PR vai explícito (`sonar.pullrequest.key/branch/base`). A action do front recebe isso pronto do GitHub; na linha de comando, sem esses três valores a análise viraria análise de branch e o gate mediria o repositório inteiro em vez do que o PR mudou.
- `sonar.qualitygate.wait=true`, que é o que faz o passo reprovar — sem ele o scan publica no painel e sai verde.
- O checkout da API passou a ser completo (`fetch-depth: 0`): sem histórico o Sonar não sabe quem mudou o quê e perde a noção de código novo.

**Análise da `main`** (`sonar-main.yml`), num job irmão do que já existia, declarando `sonar.projectVersion` a partir do `package.json` da raiz. Sem versão declarada não há fronteira de código novo, nenhuma métrica `new_*` é calculada e o veredito sai `NONE` — o mesmo defeito que custou a `0.4.1`.

## O que já estava pronto, e foi conferido

| Item | Estado |
| --- | --- |
| Projeto `fateconnect_FateConnect-api` | existe, criado na organização `fateconnect` |
| Gate `Backend` | existe com as **cinco** condições da issue e **já associado** ao projeto |
| Projeto de teste reconhecido como teste | `<IsTestProject>true</IsTestProject>` já declarado — o scanner classifica sozinho, sem precisar de exclusão |

## A estreia da análise, e o que ela achou

O check da API não roda em PR que só toca `.github/` — o recorte o desliga. Para não mergear a fiação sem nunca tê-la executado, forcei os dois recortes com commits temporários, medi, e desfiz. **Os arquivos de workflow desta branch são byte a byte os que o CI aprovou verde.**

A primeira análise reprovou o gate com `new_security_rating` = **E**, por uma vulnerabilidade **BLOCKER no arquivo que este PR estava criando**:

> `github.head_ref` pode ser definido por um ator externo com um valor especialmente construído, permitindo injeção de script.

Nome de branch é escolhido por quem abre o PR, e `${{ }}` dentro do `run` cola esse texto no shell antes de o shell existir. O repositório já usava o padrão certo — `PR_NUMBER` por `env` no passo de recorte — e eu tinha quebrado o padrão. Os três valores passaram a chegar por `env`; o achado consta como `CLOSED/FIXED`.

Sobrou uma segunda, MAJOR: `yarn install` sem `--ignore-scripts`, que deixa o `postinstall` de qualquer pacote da árvore executar no runner com os segredos do job ao alcance. Antes de silenciar a regra eu testei se dava para **corrigi-la**: com `--ignore-scripts` o front instala, compila, passa no `tsc`, no ESLint e na suíte com cobertura — no macOS e depois no Linux do runner. Não era máscara, era correção, e ela entrou nos três pontos que instalam dependência.

Os dois gates agora saem `OK`, com rating **A** em confiabilidade, segurança e manutenibilidade nos dois projetos.

## Uma decisão da issue que a medição derrubou

A issue previa que a primeira análise sairia `NONE` — sem versão anterior não há fronteira de código novo — e por isso mandava semear a `main` **antes** de confiar no gate dos PRs. **Não foi o que aconteceu:** a análise deste PR avaliou as cinco condições e deu veredito real, sem nenhuma análise prévia da `main`. Análise de PR usa o próprio diff como código novo e não depende da linha de base.

A previsão foi feita medindo o projeto **antes de qualquer análise**, o que responde outra pergunta.

## O que falta

1. **Tornar `.NET API` check obrigatório** nas rulesets da `develop` e da `main`, onde hoje só `React front (Web)` é exigido. Tentei pela API e o gate de permissões do meu ambiente barrou a escrita em ruleset — precisa ser feito por você, em Settings → Rules.
2. **Disparar o `Sonar main` à mão** depois do merge chegar à `main`, para o painel ter a linha de base da branch principal.

## Uma premissa da issue que envelheceu

A #184 foi escrita quando existiam **duas** solutions .NET e planejava os dois `dotnet build` dentro do mesmo `begin`/`end`. A #44 já dissolveu a `FateConnect/Carona`, então sobrou uma solution e um build — a decisão de ter um projeto só no Sonar continua valendo, e é a que está implementada.

## Issue

- #184

Closes #184

## Evidências
