### PR TITLE
feat(105): give the ride a driver and restrict changes to them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Passa a devolver quem ofertou a carona, com nome e contato, e a indicar se ela é de quem consultou (#201) [Backend]
+
 ### Fixed
 
 - Corrige o cadastro, que aceitava requisição sem data de nascimento e gravava `01/01/0001` no lugar de recusar (#205) [Backend]
+
+### Security
+
+- Restringe editar e excluir carona a quem a ofertou; antes qualquer pessoa autenticada alterava a carona de outra (#201) [Backend]
 
 ## [0.5.0] - 2026-08-28
 

--- a/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
+++ b/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
@@ -1,6 +1,8 @@
+using System.Net.Http.Headers;
 using FateConnect.Api.Infrastructure.Database;
 using FateConnect.Api.Modules.Auth.Entities;
 using FateConnect.Api.Modules.Auth.Services;
+using FateConnect.Api.Modules.Common.Entities;
 using FateConnect.Api.Modules.Usuarios;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -13,6 +15,8 @@ namespace FateConnect.Api.Tests;
 public class ApiFactory : WebApplicationFactory<Program>
 {
     public const string FakeSecret = "fake-test-secret-with-no-value-outside-this-suite";
+
+    private readonly string _databaseName = $"fateconnect-tests-{Guid.NewGuid()}";
 
     public ApiFactory()
     {
@@ -29,11 +33,11 @@ public class ApiFactory : WebApplicationFactory<Program>
                 service => service.ServiceType == typeof(DbContextOptions<FateConnectDbContext>));
 
             services.Remove(registration);
-            services.AddDbContext<FateConnectDbContext>(options => options.UseInMemoryDatabase("fateconnect-tests"));
+            services.AddDbContext<FateConnectDbContext>(options => options.UseInMemoryDatabase(_databaseName));
         });
     }
 
-    public static string IssueToken()
+    public static string IssueToken(int userId = 1)
     {
         JwtOptions options = new()
         {
@@ -43,6 +47,37 @@ public class ApiFactory : WebApplicationFactory<Program>
         };
 
         return new TokenService(Options.Create(options))
-            .GerarJwtToken(new Usuario { Id = 1, EmailFatec = "pessoa@fatec.sp.gov.br" });
+            .GerarJwtToken(new Usuario { Id = userId, EmailFatec = "pessoa@fatec.sp.gov.br" });
+    }
+
+    public int SeedUser(string fullName, string phone, string contactEmail)
+    {
+        using IServiceScope scope = Services.CreateScope();
+        FateConnectDbContext context = scope.ServiceProvider.GetRequiredService<FateConnectDbContext>();
+
+        Usuario user = new()
+        {
+            NomeCompleto = fullName,
+            EmailFatec = $"{Guid.NewGuid():N}@fatec.sp.gov.br",
+            Senha = "hash-sem-valor-fora-desta-suite",
+            DataNascimento = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            DataCadastro = DateTime.UtcNow,
+            DataAtualizacao = DateTime.UtcNow,
+            Contatos = [new Contato { Telefone = phone, EmailContato = contactEmail }],
+        };
+
+        context.Usuarios.Add(user);
+        context.SaveChanges();
+
+        return user.Id;
+    }
+
+    public HttpClient CreateClientFor(int userId)
+    {
+        HttpClient client = CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", IssueToken(userId));
+
+        return client;
     }
 }

--- a/FateConnect/FateConnect.Api.Tests/RideOwnershipTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/RideOwnershipTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace FateConnect.Api.Tests;
+
+public class RideOwnershipTests : IClassFixture<ApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private readonly ApiFactory _factory;
+
+    public RideOwnershipTests(ApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private sealed record RideDriver(string Name, string? Email, string? Phone);
+
+    private sealed record ReadRide(Guid Id, string Destination, RideDriver Driver, bool IsOwner);
+
+    private static object NewRidePayload(string destination) => new
+    {
+        availableSeats = 3,
+        destination,
+        departureDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)).ToString("yyyy-MM-dd"),
+        departureTime = "08:30:00",
+        rideType = "Solidarity",
+        description = "Vaga para quem sai do campus.",
+    };
+
+    private async Task<(ReadRide Ride, int DriverId, int OtherUserId)> OfferRideAsync(string destination)
+    {
+        int driverId = _factory.SeedUser("Ana Ofertante", "15999990000", "ana@example.com");
+        int otherUserId = _factory.SeedUser("Bruno Passageiro", "15988880000", "bruno@example.com");
+
+        HttpResponseMessage response = await _factory
+            .CreateClientFor(driverId)
+            .PostAsJsonAsync("/Rides", NewRidePayload(destination));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        ReadRide ride = (await response.Content.ReadFromJsonAsync<ReadRide>(JsonOptions))!;
+
+        return (ride, driverId, otherUserId);
+    }
+
+    [Fact]
+    public async Task CreateRide_RecordsTheAuthenticatedUserAsTheDriver()
+    {
+        (ReadRide ride, _, _) = await OfferRideAsync("Sorocaba centro");
+
+        Assert.Equal("Ana Ofertante", ride.Driver.Name);
+        Assert.Equal("ana@example.com", ride.Driver.Email);
+        Assert.Equal("15999990000", ride.Driver.Phone);
+        Assert.True(ride.IsOwner);
+    }
+
+    [Fact]
+    public async Task ReadRide_FlagsOwnershipForEachReader()
+    {
+        (ReadRide ride, int driverId, int otherUserId) = await OfferRideAsync("Votorantim");
+
+        ReadRide asDriver = (await _factory.CreateClientFor(driverId)
+            .GetFromJsonAsync<ReadRide>($"/Rides/{ride.Id}", JsonOptions))!;
+
+        ReadRide asOther = (await _factory.CreateClientFor(otherUserId)
+            .GetFromJsonAsync<ReadRide>($"/Rides/{ride.Id}", JsonOptions))!;
+
+        Assert.True(asDriver.IsOwner);
+        Assert.False(asOther.IsOwner);
+        Assert.Equal("Ana Ofertante", asOther.Driver.Name);
+    }
+
+    [Fact]
+    public async Task UpdateRide_ByAnotherUser_IsForbidden()
+    {
+        (ReadRide ride, _, int otherUserId) = await OfferRideAsync("Itu");
+
+        HttpResponseMessage response = await _factory.CreateClientFor(otherUserId)
+            .PutAsJsonAsync($"/Rides/{ride.Id}", new { availableSeats = 1 });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteRide_ByAnotherUser_IsForbidden()
+    {
+        (ReadRide ride, _, int otherUserId) = await OfferRideAsync("Salto");
+
+        HttpResponseMessage response = await _factory.CreateClientFor(otherUserId)
+            .DeleteAsync($"/Rides/{ride.Id}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateAndDeleteRide_ByTheDriver_Succeed()
+    {
+        (ReadRide ride, int driverId, _) = await OfferRideAsync("Piedade");
+        HttpClient driver = _factory.CreateClientFor(driverId);
+
+        HttpResponseMessage update = await driver
+            .PutAsJsonAsync($"/Rides/{ride.Id}", new { availableSeats = 1 });
+
+        HttpResponseMessage delete = await driver.DeleteAsync($"/Rides/{ride.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, update.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/SignupTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/SignupTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace FateConnect.Api.Tests;
+
+public class SignupTests : IClassFixture<ApiFactory>
+{
+    private readonly ApiFactory _factory;
+
+    public SignupTests(ApiFactory factory) => _factory = factory;
+
+    private static object SignupPayload(object contacts) => new
+    {
+        emailFatec = $"sonda{Guid.NewGuid():N}@aluno.cps.sp.gov.br",
+        senha = "SenhaForte123!",
+        nomeCompleto = "Pessoa de Teste",
+        dataNascimento = "2000-01-01T00:00:00Z",
+        genero = "Male",
+        enderecos = new[] { new { cep = "18000-000", logradouro = "Rua A", numero = "1", complemento = "Casa", cidade = "Sorocaba", estado = "SP" } },
+        contatos = contacts,
+    };
+
+    [Fact]
+    public async Task Signup_WithOneContact_IsAccepted()
+    {
+        HttpResponseMessage r = await _factory.CreateClient().PostAsJsonAsync(
+            "/usuario/cadastro",
+            SignupPayload(new[] { new { telefone = "15999990000", emailContato = "pessoa@example.com" } }));
+
+        string corpo = await r.Content.ReadAsStringAsync();
+
+        Assert.True(r.StatusCode == HttpStatusCode.Created, $"status={r.StatusCode} corpo={corpo}");
+    }
+
+    [Fact]
+    public async Task Signup_WithAnEmptyContactList_IsRejected()
+    {
+        HttpResponseMessage r = await _factory.CreateClient()
+            .PostAsJsonAsync("/usuario/cadastro", SignupPayload(Array.Empty<object>()));
+
+        Assert.Equal(HttpStatusCode.BadRequest, r.StatusCode);
+    }
+
+    [Fact]
+    public async Task Signup_WithoutTheContactField_IsRejected()
+    {
+        HttpResponseMessage r = await _factory.CreateClient().PostAsJsonAsync("/usuario/cadastro", new
+        {
+            emailFatec = $"sonda{Guid.NewGuid():N}@aluno.cps.sp.gov.br",
+            senha = "SenhaForte123!",
+            nomeCompleto = "Pessoa de Teste",
+            dataNascimento = "2000-01-01T00:00:00Z",
+            genero = "Male",
+            enderecos = new[] { new { cep = "18000-000", logradouro = "Rua A", numero = "1", complemento = "Casa", cidade = "Sorocaba", estado = "SP" } },
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, r.StatusCode);
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/TokenServiceTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/TokenServiceTests.cs
@@ -27,7 +27,12 @@ public class TokenServiceTests
         };
 
         string token = new TokenService(Options.Create(options))
-            .GerarJwtToken(new Usuario { Id = 7, EmailFatec = "pessoa@fatec.sp.gov.br" });
+            .GerarJwtToken(new Usuario
+            {
+                Id = 7,
+                NomeCompleto = "Pessoa de Teste",
+                EmailFatec = "pessoa@fatec.sp.gov.br",
+            });
 
         ClaimsPrincipal principal = new JwtSecurityTokenHandler().ValidateToken(
             token,
@@ -45,5 +50,6 @@ public class TokenServiceTests
             out SecurityToken _);
 
         Assert.Equal("7", principal.FindFirstValue(ClaimTypes.NameIdentifier));
+        Assert.Equal("Pessoa de Teste", principal.FindFirstValue(ClaimTypes.Name));
     }
 }

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260829170112_AddRideDriver.Designer.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260829170112_AddRideDriver.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FateConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FateConnect.Api.Infrastructure.Database.Migrations
 {
     [DbContext(typeof(FateConnectDbContext))]
-    partial class FateConnectDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260829170112_AddRideDriver")]
+    partial class AddRideDriver
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260829170112_AddRideDriver.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260829170112_AddRideDriver.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FateConnect.Api.Infrastructure.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRideDriver : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:unaccent", ",,");
+
+            migrationBuilder.Sql("DELETE FROM rides;");
+
+            migrationBuilder.AddColumn<int>(
+                name: "DriverId",
+                table: "rides",
+                type: "integer",
+                nullable: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_rides_DriverId",
+                table: "rides",
+                column: "DriverId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_rides_Usuarios_DriverId",
+                table: "rides",
+                column: "DriverId",
+                principalTable: "Usuarios",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_rides_Usuarios_DriverId",
+                table: "rides");
+
+            migrationBuilder.DropIndex(
+                name: "IX_rides_DriverId",
+                table: "rides");
+
+            migrationBuilder.DropColumn(
+                name: "DriverId",
+                table: "rides");
+
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:PostgresExtension:unaccent", ",,");
+        }
+    }
+}

--- a/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
@@ -1,6 +1,7 @@
 namespace FateConnect.Api.Infrastructure.Middlewares;
 
 using System.Net;
+using FateConnect.Api.Modules.Auth.Exceptions;
 using FateConnect.Api.Modules.Rides.Exceptions;
 using FateConnect.Api.Modules.Usuarios.Exceptions;
 using Microsoft.Extensions.Logging;
@@ -33,14 +34,19 @@ public partial class GlobalExceptionMiddleware(
                 errorMessage = ex.Message;
                 break;
 
+            case RideNotDrivenByUserException ex:
+                statusCode = HttpStatusCode.Forbidden;
+                errorMessage = ex.Message;
+                break;
+
             case EmailJaCadastradoException ex:
                 statusCode = HttpStatusCode.Conflict;
                 errorMessage = ex.Message;
                 break;
 
-            case CredenciaisInvalidasException ex:
+            case UnidentifiedUserException or CredenciaisInvalidasException:
                 statusCode = HttpStatusCode.Unauthorized;
-                errorMessage = ex.Message;
+                errorMessage = exception.Message;
                 break;
 
             case JwtNaoConfiguradoException ex:

--- a/FateConnect/FateConnect.Api/Modules/Auth/Exceptions/UnidentifiedUserException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Exceptions/UnidentifiedUserException.cs
@@ -1,0 +1,4 @@
+namespace FateConnect.Api.Modules.Auth.Exceptions;
+
+public class UnidentifiedUserException()
+    : Exception("The token does not identify a user.");

--- a/FateConnect/FateConnect.Api/Modules/Auth/Extensions/ClaimsPrincipalExtensions.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Extensions/ClaimsPrincipalExtensions.cs
@@ -10,7 +10,9 @@ public static class ClaimsPrincipalExtensions
     {
         string? identifier = user.FindFirstValue(ClaimTypes.NameIdentifier);
 
-        if (!int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId))
+        bool isValidUserId = int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId);
+
+        if (!isValidUserId)
             throw new UnidentifiedUserException();
 
         return userId;

--- a/FateConnect/FateConnect.Api/Modules/Auth/Extensions/ClaimsPrincipalExtensions.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,18 @@
+namespace FateConnect.Api.Modules.Auth.Extensions;
+
+using System.Globalization;
+using System.Security.Claims;
+using FateConnect.Api.Modules.Auth.Exceptions;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static int GetUserId(this ClaimsPrincipal user)
+    {
+        string? identifier = user.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (!int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId))
+            throw new UnidentifiedUserException();
+
+        return userId;
+    }
+}

--- a/FateConnect/FateConnect.Api/Modules/Auth/Services/TokenService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Services/TokenService.cs
@@ -47,6 +47,7 @@ public class TokenService : ITokenService
         Claim[] claims =
         [
             new Claim(ClaimTypes.NameIdentifier, usuario.Id.ToString(CultureInfo.InvariantCulture)),
+            new Claim(ClaimTypes.Name, usuario.NomeCompleto),
             new Claim(ClaimTypes.Email, usuario.EmailFatec),
             new Claim(ClaimTypes.Role, usuario.Perfil.ToString())
         ];

--- a/FateConnect/FateConnect.Api/Modules/Rides/Controllers/RidesController.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Controllers/RidesController.cs
@@ -1,8 +1,6 @@
 namespace FateConnect.Api.Modules.Rides.Controllers;
 
-using System.Globalization;
-using System.Security.Claims;
-using FateConnect.Api.Modules.Auth.Exceptions;
+using FateConnect.Api.Modules.Auth.Extensions;
 using FateConnect.Api.Modules.Rides.DTOs;
 using FateConnect.Api.Modules.Rides.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -15,21 +13,11 @@ using Swashbuckle.AspNetCore.Annotations;
 [SwaggerTag("Ride Management")]
 public class RidesController(IRideService rideService) : ControllerBase
 {
-    private int GetCurrentUserId()
-    {
-        string? identifier = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId))
-            throw new UnidentifiedUserException();
-
-        return userId;
-    }
-
     [HttpGet]
     [SwaggerOperation(Summary = "Get active rides", Description = "Returns a list of all rides that are currently active based on optional filters.")]
     public async Task<ActionResult<IEnumerable<ReadRideDto>>> GetAllAsync([FromQuery] FilterRideDto filters)
     {
-        var rides = await rideService.GetAllAsync(filters, GetCurrentUserId());
+        var rides = await rideService.GetAllAsync(filters, User.GetUserId());
         return Ok(rides);
     }
 
@@ -37,7 +25,7 @@ public class RidesController(IRideService rideService) : ControllerBase
     [SwaggerOperation(Summary = "Get ride by ID", Description = "Returns a specific ride by its ID, provided it is active.")]
     public async Task<ActionResult<ReadRideDto>> GetByIdAsync(Guid id)
     {
-        var ride = await rideService.GetByIdAsync(id, GetCurrentUserId());
+        var ride = await rideService.GetByIdAsync(id, User.GetUserId());
 
         if (ride is null)
             return NotFound();
@@ -49,7 +37,7 @@ public class RidesController(IRideService rideService) : ControllerBase
     [SwaggerOperation(Summary = "Create a new ride", Description = "Registers a new ride in the system, offered by the authenticated user.")]
     public async Task<ActionResult<ReadRideDto>> CreateAsync(CreateRideDto dto)
     {
-        var newRide = await rideService.CreateAsync(dto, GetCurrentUserId());
+        var newRide = await rideService.CreateAsync(dto, User.GetUserId());
 
         return CreatedAtRoute(
             routeName: "GetRideById",
@@ -62,7 +50,7 @@ public class RidesController(IRideService rideService) : ControllerBase
     [SwaggerOperation(Summary = "Update an existing ride", Description = "Updates ride details such as available seats, destination, or departure time. Only the user who offered the ride can change it.")]
     public async Task<ActionResult<ReadRideDto>> UpdateAsync(Guid id, UpdateRideDto dto)
     {
-        var updatedRide = await rideService.UpdateAsync(id, dto, GetCurrentUserId());
+        var updatedRide = await rideService.UpdateAsync(id, dto, User.GetUserId());
 
         if (updatedRide is null)
             return NotFound();
@@ -74,7 +62,7 @@ public class RidesController(IRideService rideService) : ControllerBase
     [SwaggerOperation(Summary = "Deactivate a ride", Description = "Sets the ride active status to false. Only the user who offered the ride can do it.")]
     public async Task<IActionResult> DeleteAsync(Guid id)
     {
-        var isDeactivated = await rideService.DeleteAsync(id, GetCurrentUserId());
+        var isDeactivated = await rideService.DeleteAsync(id, User.GetUserId());
 
         if (!isDeactivated)
             return NotFound();

--- a/FateConnect/FateConnect.Api/Modules/Rides/Controllers/RidesController.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Controllers/RidesController.cs
@@ -1,5 +1,8 @@
 namespace FateConnect.Api.Modules.Rides.Controllers;
 
+using System.Globalization;
+using System.Security.Claims;
+using FateConnect.Api.Modules.Auth.Exceptions;
 using FateConnect.Api.Modules.Rides.DTOs;
 using FateConnect.Api.Modules.Rides.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -12,11 +15,21 @@ using Swashbuckle.AspNetCore.Annotations;
 [SwaggerTag("Ride Management")]
 public class RidesController(IRideService rideService) : ControllerBase
 {
+    private int GetCurrentUserId()
+    {
+        string? identifier = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (!int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId))
+            throw new UnidentifiedUserException();
+
+        return userId;
+    }
+
     [HttpGet]
     [SwaggerOperation(Summary = "Get active rides", Description = "Returns a list of all rides that are currently active based on optional filters.")]
     public async Task<ActionResult<IEnumerable<ReadRideDto>>> GetAllAsync([FromQuery] FilterRideDto filters)
     {
-        var rides = await rideService.GetAllAsync(filters);
+        var rides = await rideService.GetAllAsync(filters, GetCurrentUserId());
         return Ok(rides);
     }
 
@@ -24,7 +37,7 @@ public class RidesController(IRideService rideService) : ControllerBase
     [SwaggerOperation(Summary = "Get ride by ID", Description = "Returns a specific ride by its ID, provided it is active.")]
     public async Task<ActionResult<ReadRideDto>> GetByIdAsync(Guid id)
     {
-        var ride = await rideService.GetByIdAsync(id);
+        var ride = await rideService.GetByIdAsync(id, GetCurrentUserId());
 
         if (ride is null)
             return NotFound();
@@ -33,10 +46,10 @@ public class RidesController(IRideService rideService) : ControllerBase
     }
 
     [HttpPost]
-    [SwaggerOperation(Summary = "Create a new ride", Description = "Registers a new ride in the system.")]
+    [SwaggerOperation(Summary = "Create a new ride", Description = "Registers a new ride in the system, offered by the authenticated user.")]
     public async Task<ActionResult<ReadRideDto>> CreateAsync(CreateRideDto dto)
     {
-        var newRide = await rideService.CreateAsync(dto);
+        var newRide = await rideService.CreateAsync(dto, GetCurrentUserId());
 
         return CreatedAtRoute(
             routeName: "GetRideById",
@@ -46,10 +59,10 @@ public class RidesController(IRideService rideService) : ControllerBase
     }
 
     [HttpPut("{id:guid}")]
-    [SwaggerOperation(Summary = "Update an existing ride", Description = "Updates ride details such as available seats, destination, or departure time.")]
+    [SwaggerOperation(Summary = "Update an existing ride", Description = "Updates ride details such as available seats, destination, or departure time. Only the user who offered the ride can change it.")]
     public async Task<ActionResult<ReadRideDto>> UpdateAsync(Guid id, UpdateRideDto dto)
     {
-        var updatedRide = await rideService.UpdateAsync(id, dto);
+        var updatedRide = await rideService.UpdateAsync(id, dto, GetCurrentUserId());
 
         if (updatedRide is null)
             return NotFound();
@@ -58,10 +71,10 @@ public class RidesController(IRideService rideService) : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
-    [SwaggerOperation(Summary = "Deactivate a ride", Description = "Sets the ride active status to false.")]
+    [SwaggerOperation(Summary = "Deactivate a ride", Description = "Sets the ride active status to false. Only the user who offered the ride can do it.")]
     public async Task<IActionResult> DeleteAsync(Guid id)
     {
-        var isDeactivated = await rideService.DeleteAsync(id);
+        var isDeactivated = await rideService.DeleteAsync(id, GetCurrentUserId());
 
         if (!isDeactivated)
             return NotFound();

--- a/FateConnect/FateConnect.Api/Modules/Rides/DTOs/ReadRideDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/DTOs/ReadRideDto.cs
@@ -10,5 +10,7 @@ public record ReadRideDto(
     TimeOnly DepartureTime,
     DateTime CreatedAt,
     EnumRideType RideType,
-    string? Description
+    string? Description,
+    RideDriverDto Driver,
+    bool IsOwner
 );

--- a/FateConnect/FateConnect.Api/Modules/Rides/DTOs/RideDriverDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/DTOs/RideDriverDto.cs
@@ -1,0 +1,7 @@
+namespace FateConnect.Api.Modules.Rides.DTOs;
+
+public record RideDriverDto(
+    string Name,
+    string Email,
+    string Phone
+);

--- a/FateConnect/FateConnect.Api/Modules/Rides/Entities/Ride.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Entities/Ride.cs
@@ -2,6 +2,7 @@ namespace FateConnect.Api.Modules.Rides.Entities;
 
 using FateConnect.Api.Modules.Rides.Enums;
 using FateConnect.Api.Modules.Rides.Exceptions;
+using FateConnect.Api.Modules.Usuarios;
 
 public class Ride
 {
@@ -17,6 +18,8 @@ public class Ride
     public EnumRideType RideType { get; private set; }
     public string? Description { get; private set; }
     public bool IsActive { get; private set; }
+    public int DriverId { get; private set; }
+    public Usuario Driver { get; private set; } = null!;
 
     private Ride() { }
 
@@ -26,14 +29,17 @@ public class Ride
         DateOnly departureDate,
         TimeOnly departureTime,
         EnumRideType rideType,
+        int driverId,
         string? description = null)
     {
         ValidateAvailableSeats(availableSeats);
         ValidateDestination(destination);
         ValidateDepartureDateTime(departureDate, departureTime);
         ValidateRideType(rideType);
+        ValidateDriver(driverId);
 
         Id = Guid.NewGuid();
+        DriverId = driverId;
         AvailableSeats = availableSeats;
         Destination = destination.Trim();
         DepartureDate = departureDate;
@@ -86,6 +92,14 @@ public class Ride
     public void Deactivate()
     {
         IsActive = false;
+    }
+
+    public bool IsDrivenBy(int userId) => DriverId == userId;
+
+    private static void ValidateDriver(int driverId)
+    {
+        if (driverId < 1)
+            throw new InvalidRideDriverException();
     }
 
     private static void ValidateRideType(EnumRideType rideType)

--- a/FateConnect/FateConnect.Api/Modules/Rides/Exceptions/RideException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Exceptions/RideException.cs
@@ -13,3 +13,9 @@ public class InvalidDestinationException()
 
 public class InvalidRideTypeException()
     : RideDomainException("Invalid ride type.");
+
+public class InvalidRideDriverException()
+    : RideDomainException("The ride must belong to an identified user.");
+
+public class RideNotDrivenByUserException(Guid rideId)
+    : Exception($"The ride {rideId} was offered by another user.");

--- a/FateConnect/FateConnect.Api/Modules/Rides/Infrastructure/RideConfiguration.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Infrastructure/RideConfiguration.cs
@@ -36,5 +36,13 @@ public class RideConfiguration : IEntityTypeConfiguration<Ride>
 
         builder.Property(r => r.IsActive)
               .IsRequired();
+
+        builder.Property(r => r.DriverId)
+              .IsRequired();
+
+        builder.HasOne(r => r.Driver)
+              .WithMany()
+              .HasForeignKey(r => r.DriverId)
+              .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/FateConnect/FateConnect.Api/Modules/Rides/Interfaces/IRideService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Interfaces/IRideService.cs
@@ -4,9 +4,9 @@ using FateConnect.Api.Modules.Rides.DTOs;
 
 public interface IRideService
 {
-    Task<ReadRideDto> CreateAsync(CreateRideDto dto);
-    Task<IEnumerable<ReadRideDto>> GetAllAsync(FilterRideDto filter);
-    Task<ReadRideDto?> GetByIdAsync(Guid id);
-    Task<ReadRideDto?> UpdateAsync(Guid id, UpdateRideDto dto);
-    Task<bool> DeleteAsync(Guid id);
+    Task<ReadRideDto> CreateAsync(CreateRideDto dto, int currentUserId);
+    Task<IEnumerable<ReadRideDto>> GetAllAsync(FilterRideDto filter, int currentUserId);
+    Task<ReadRideDto?> GetByIdAsync(Guid id, int currentUserId);
+    Task<ReadRideDto?> UpdateAsync(Guid id, UpdateRideDto dto, int currentUserId);
+    Task<bool> DeleteAsync(Guid id, int currentUserId);
 }

--- a/FateConnect/FateConnect.Api/Modules/Rides/Repositories/RideRepository.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Repositories/RideRepository.cs
@@ -11,7 +11,10 @@ public class RideRepository(FateConnectDbContext context) : IRideRepository
     public async Task<IReadOnlyList<Ride>> GetAllAsync(FilterRideDto filter)
     {
 
-        IQueryable<Ride> query = context.Rides.AsNoTracking().Where(r => r.IsActive);
+        IQueryable<Ride> query = context.Rides
+            .AsNoTracking()
+            .Include(r => r.Driver.Contatos)
+            .Where(r => r.IsActive);
 
         if (filter.DepartureDate.HasValue)
             query = query.Where(r => r.DepartureDate == filter.DepartureDate.Value);
@@ -48,6 +51,7 @@ public class RideRepository(FateConnectDbContext context) : IRideRepository
     public async Task<Ride?> GetByIdAsync(Guid id)
     {
         return await context.Rides
+            .Include(r => r.Driver.Contatos)
             .FirstOrDefaultAsync(r => r.Id == id && r.IsActive);
     }
 
@@ -55,6 +59,9 @@ public class RideRepository(FateConnectDbContext context) : IRideRepository
     {
         context.Rides.Add(ride);
         await context.SaveChangesAsync();
+
+        await context.Entry(ride).Reference(r => r.Driver).LoadAsync();
+        await context.Entry(ride.Driver).Collection(driver => driver.Contatos).LoadAsync();
 
         return ride;
     }

--- a/FateConnect/FateConnect.Api/Modules/Rides/Services/RideService.Logs.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Services/RideService.Logs.cs
@@ -24,4 +24,7 @@ public partial class RideService
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Ride {RideId} was already deactivated or not found.")]
     private static partial void LogRideDeactivationFailed(ILogger logger, Guid rideId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "User {UserId} tried to change ride {RideId}, offered by another user.")]
+    private static partial void LogRideChangeRefused(ILogger logger, int userId, Guid rideId);
 }

--- a/FateConnect/FateConnect.Api/Modules/Rides/Services/RideService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Services/RideService.cs
@@ -1,8 +1,11 @@
 namespace FateConnect.Api.Modules.Rides.Services;
 
+using FateConnect.Api.Modules.Common.Entities;
 using FateConnect.Api.Modules.Rides.DTOs;
 using FateConnect.Api.Modules.Rides.Entities;
+using FateConnect.Api.Modules.Rides.Exceptions;
 using FateConnect.Api.Modules.Rides.Interfaces;
+using FateConnect.Api.Modules.Usuarios;
 using Microsoft.Extensions.Logging;
 
 public partial class RideService(
@@ -10,7 +13,7 @@ public partial class RideService(
     ILogger<RideService> logger
 ) : IRideService
 {
-    public async Task<ReadRideDto> CreateAsync(CreateRideDto dto)
+    public async Task<ReadRideDto> CreateAsync(CreateRideDto dto, int currentUserId)
     {
         var ride = new Ride(
             dto.AvailableSeats,
@@ -18,6 +21,7 @@ public partial class RideService(
             dto.DepartureDate,
             dto.DepartureTime,
             dto.RideType,
+            currentUserId,
             dto.Description
         );
 
@@ -25,19 +29,19 @@ public partial class RideService(
 
         LogRideCreated(logger, ride.Id);
 
-        return MapToReadDto(ride);
+        return MapToReadDto(ride, currentUserId);
     }
 
-    public async Task<IEnumerable<ReadRideDto>> GetAllAsync(FilterRideDto filter)
+    public async Task<IEnumerable<ReadRideDto>> GetAllAsync(FilterRideDto filter, int currentUserId)
     {
         var rides = await repository.GetAllAsync(filter);
 
         LogRidesRetrieved(logger, rides.Count);
 
-        return rides.Select(MapToReadDto);
+        return rides.Select(ride => MapToReadDto(ride, currentUserId));
     }
 
-    public async Task<ReadRideDto?> GetByIdAsync(Guid id)
+    public async Task<ReadRideDto?> GetByIdAsync(Guid id, int currentUserId)
     {
         var ride = await repository.GetByIdAsync(id);
 
@@ -49,10 +53,10 @@ public partial class RideService(
 
         LogRideFound(logger, id);
 
-        return MapToReadDto(ride);
+        return MapToReadDto(ride, currentUserId);
     }
 
-    public async Task<ReadRideDto?> UpdateAsync(Guid id, UpdateRideDto dto)
+    public async Task<ReadRideDto?> UpdateAsync(Guid id, UpdateRideDto dto, int currentUserId)
     {
         var ride = await repository.GetByIdAsync(id);
 
@@ -61,6 +65,8 @@ public partial class RideService(
             LogRideNotFound(logger, id);
             return null;
         }
+
+        EnsureRideIsDrivenBy(ride, currentUserId);
 
         ride.UpdateBasicAttributes(
             dto.AvailableSeats,
@@ -78,10 +84,10 @@ public partial class RideService(
 
         LogRideUpdated(logger, id);
 
-        return MapToReadDto(ride);
+        return MapToReadDto(ride, currentUserId);
     }
 
-    public async Task<bool> DeleteAsync(Guid id)
+    public async Task<bool> DeleteAsync(Guid id, int currentUserId)
     {
         var ride = await repository.GetByIdAsync(id);
 
@@ -91,6 +97,8 @@ public partial class RideService(
             return false;
         }
 
+        EnsureRideIsDrivenBy(ride, currentUserId);
+
         ride.Deactivate();
 
         await repository.UpdateAsync(ride);
@@ -99,7 +107,17 @@ public partial class RideService(
         return true;
     }
 
-    private static ReadRideDto MapToReadDto(Ride ride) =>
+    private void EnsureRideIsDrivenBy(Ride ride, int currentUserId)
+    {
+        if (ride.IsDrivenBy(currentUserId))
+            return;
+
+        LogRideChangeRefused(logger, currentUserId, ride.Id);
+
+        throw new RideNotDrivenByUserException(ride.Id);
+    }
+
+    private static ReadRideDto MapToReadDto(Ride ride, int currentUserId) =>
         new(
             ride.Id,
             ride.AvailableSeats,
@@ -108,7 +126,16 @@ public partial class RideService(
             ride.DepartureTime,
             ride.CreatedAt,
             ride.RideType,
-            ride.Description
+            ride.Description,
+            MapDriverToDto(ride.Driver),
+            ride.IsDrivenBy(currentUserId)
         );
+
+    private static RideDriverDto MapDriverToDto(Usuario driver)
+    {
+        Contato contact = driver.Contatos.First();
+
+        return new RideDriverDto(driver.NomeCompleto, contact.EmailContato, contact.Telefone);
+    }
 
 }

--- a/FateConnect/FateConnect.Api/Modules/Usuarios/DTOs/CreateUsuarioDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Usuarios/DTOs/CreateUsuarioDto.cs
@@ -43,6 +43,7 @@ public class CreateUsuarioDto
     [];
 
     [Required]
+    [MinLength(1, ErrorMessage = "É obrigatório informar ao menos um contato")]
     required public List<CreateContatoDto> Contatos { get; set; } =
     [];
 }


### PR DESCRIPTION
## Objetivo

A carona não tinha dono: a entidade guardava vagas, destino, data, hora, tipo e descrição, e nada dizia quem ofertou. Duas consequências — o cartão do front exibe um motorista fictício, igual para toda carona, e **qualquer pessoa autenticada podia editar ou excluir a carona de qualquer outra**.

Este PR fecha os quatro itens de API da #105. O quinto, a ponta do front, sai em PR próprio: só agora existe o que ler.

## Alterações

- **A carona pertence a um usuário.** `Ride` ganhou `DriverId` e a navegação para `Usuario`, com chave estrangeira e índice. O dono é obrigatório no domínio e no banco.
- **O dono vem do token.** O controller lê o `NameIdentifier` que o `TokenService` já emitia e o passa ao serviço; o corpo da requisição não escolhe dono. Token sem esse claim responde 401 em vez de estourar.
- **A leitura devolve o motorista** — nome e o primeiro contato (telefone e e-mail) — e um `isOwner` calculado para quem perguntou.
- **Editar e excluir são só do dono.** Quem não ofertou recebe **403**, com o caso registrado em log.

## Decisões

| Assunto | Decisão | Motivo |
| --- | --- | --- |
| Como o front sabe que a carona é dele | `isOwner` calculado no servidor | O front não precisa conhecer o próprio id, e a regra de quem é dono fica num lugar só. Em troca, a resposta depende de quem perguntou |
| Caronas sem dono já existentes | Apagadas na migração | O dono é obrigatório, e não havia como inventar um. Homologação tinha 3; produção, nenhuma |
| Contato do motorista | O primeiro da lista | É o que o cartão mostra. O cadastro do front envia um só |
| Contato pode faltar | Não pode — o cadastro passou a exigir | Medido: `"contatos": []` era aceito e criava usuário sem contato. Em vez de enfraquecer a leitura, o cadastro ganhou `MinLength(1)` e o contrato de leitura promete nome, telefone e e-mail |
| Carona de outra pessoa | 403, não 404 | A listagem já é visível a qualquer pessoa autenticada; esconder a existência não protegeria nada e confundiria o diagnóstico |

⚠️ **A migração apaga as caronas existentes.** Elas não têm como receber dono, e o dono é obrigatório. O alcance é conhecido e medido: **3 linhas em homologação, 0 em produção**.

## Como foi verificado

**A suíte:** 15 testes passando, 5 deles novos — criação grava o motorista autenticado, a leitura marca `isOwner` diferente para cada leitor, editar e excluir carona alheia dão 403, e o dono consegue as duas coisas. Os testes passaram a usar um banco em memória por instância da fábrica: as classes rodam em paralelo e antes compartilhavam o mesmo.

**A migração, contra o banco real de homologação.** Os testes rodam em memória e não executam migração nenhuma, então o passo destrutivo ficaria sem prova. Gerei o SQL com `dotnet ef migrations script` e o executei no banco de homologação dentro de uma transação desfeita no fim:

```
DELETE 3
ALTER TABLE
CREATE INDEX
ALTER TABLE
--- dentro da transação ---
 rides_restantes: 0
 colunas: AvailableSeats, CreatedAt, ..., DriverId, Id, IsActive, RideType
 chave_estrangeira: FK_rides_Usuarios_DriverId
ROLLBACK
--- depois do rollback, o banco real ---
 rides: 3
 tem_coluna_driverid: 0
```

As três linhas apagadas são exatamente as três órfãs, a coluna e a chave estrangeira nascem, e o `ROLLBACK` devolveu o banco intacto.

**O contato obrigatório, antes e depois.** `"contatos": []` passava pela validação e criava usuário sem contato nenhum — medido com um controle ao lado, porque a primeira sonda deu 400 por outro campo do payload e não provava nada. Com `MinLength(1)` o mesmo corpo responde 400, e os três testes de cadastro fixam os três casos. Nenhum usuário existente está sem contato: os 3 de homologação têm um cada, e produção não tem usuário.

⚠️ **O `defaultValue: 0` que o EF gerou teria quebrado a migração.** A coluna nasceria com zero nas três linhas existentes, e a chave estrangeira recusaria — nenhum usuário tem id 0. Por isso a exclusão vem antes, e a coluna é criada sem default.

## O que fica para o próximo PR

A #105 continua aberta até a ponta do front: trocar o `RIDE_DRIVER` fictício pela leitura real e a comparação por nome em `isOwnRide` pelo `isOwner` que a API passou a devolver.

## Issue

- #105

Este PR entrega os quatro itens de API. A issue fecha no PR seguinte, com o front.

## Evidências
