### PR TITLE
chore: report the api test coverage to sonar

### DIFF
--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -78,8 +78,12 @@ jobs:
       # análise de branch e mediria o repositório inteiro.
       #
       # `qualitygate.wait` é o que faz o passo reprovar; sem ele o scan publica e
-      # sai verde. A exclusão mantém o front fora: ele tem projeto e gate
-      # próprios, e seria medido duas vezes, a segunda com o gate errado.
+      # sai verde.
+      #
+      # O scanner varre a pasta base inteira, não só o C#. A exclusão tira o
+      # front, que tem projeto e gate próprios e seria medido duas vezes com o
+      # gate errado, e as pastas das disciplinas, que não são código de produto —
+      # os `.sql` de LBD acionavam o analisador de PL/SQL.
       - name: Sonar begin
         if: steps.changes.outputs.api == 'true'
         run: >
@@ -89,7 +93,9 @@ jobs:
           /d:sonar.host.url=https://sonarcloud.io
           /d:sonar.token=$SONAR_TOKEN
           /d:sonar.qualitygate.wait=true
-          /d:sonar.exclusions=FateConnect/Web/**
+          /d:sonar.exclusions=FateConnect/Web/**,LBD/**,ESII/**,ESIII/**
+          /d:sonar.cs.opencover.reportsPaths=coverage/**/coverage.opencover.xml
+          /d:sonar.coverage.exclusions=**/Migrations/**,**/obj/**
           /d:sonar.pullrequest.key=$PR_NUMBER
           /d:sonar.pullrequest.branch=$HEAD_REF
           /d:sonar.pullrequest.base=$BASE_REF
@@ -107,9 +113,15 @@ jobs:
 
       # A suíte sobe a própria aplicação com banco em memória, então não há
       # Postgres a provisionar aqui.
+      #
+      # O formato é OpenCover porque o Sonar não lê Cobertura para C#, que é o
+      # que o `dotnet test` produz por padrão.
       - name: Tests
         if: steps.changes.outputs.api == 'true'
-        run: dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build
+        run: |
+          dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build \
+            --collect:"XPlat Code Coverage;Format=opencover" \
+            --results-directory coverage
 
       - name: Sonar end
         if: steps.changes.outputs.api == 'true'

--- a/.github/workflows/sonar-main.yml
+++ b/.github/workflows/sonar-main.yml
@@ -95,8 +95,6 @@ jobs:
         id: version
         run: echo "value=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
-      # A suíte não roda aqui: o gate `Backend` não tem condição de cobertura, e
-      # teste quebrado já foi reprovado no check do PR.
       - name: Sonar begin
         run: >
           dotnet sonarscanner begin
@@ -106,12 +104,23 @@ jobs:
           /d:sonar.host.url=https://sonarcloud.io
           /d:sonar.token=$SONAR_TOKEN
           /d:sonar.qualitygate.wait=true
-          /d:sonar.exclusions=FateConnect/Web/**
+          /d:sonar.exclusions=FateConnect/Web/**,LBD/**,ESII/**,ESIII/**
+          /d:sonar.cs.opencover.reportsPaths=coverage/**/coverage.opencover.xml
+          /d:sonar.coverage.exclusions=**/Migrations/**,**/obj/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Build
         run: dotnet build FateConnect/FateConnect.Api/FateConnect.Api.sln
+
+      # A suíte roda para produzir cobertura: sem ela a `main` reportaria 0% e o
+      # painel mentiria sobre o projeto. O formato é OpenCover porque o Sonar não
+      # lê Cobertura para C#.
+      - name: Tests
+        run: |
+          dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build \
+            --collect:"XPlat Code Coverage;Format=opencover" \
+            --results-directory coverage
 
       - name: Sonar end
         run: dotnet sonarscanner end /d:sonar.token=$SONAR_TOKEN


### PR DESCRIPTION
## Objetivo

O Sonar analisa o C# desde a #184, mas **sem cobertura**: o painel do projeto da API mostra o campo vazio, e não há como pôr um piso no gate enquanto não houver número para medir.

Este PR passa a publicar a cobertura. A condição no gate `Backend` entra **depois**, e a ordem importa — está explicada no fim.

## Alterações

- **A suíte passa a gerar relatório de cobertura**, nos dois workflows, em formato **OpenCover**. O Sonar **não lê Cobertura para C#**, que é justamente o que o `dotnet test` produz por padrão — ligar a cobertura sem trocar o formato daria um relatório que ninguém consome, em silêncio.
- **O scanner recebe o caminho do relatório** (`sonar.cs.opencover.reportsPaths`).
- **Código gerado sai da conta** (`sonar.coverage.exclusions=**/Migrations/**,**/obj/**`).
- **O job da `main` passa a rodar a suíte.** Ele só compilava, então a `main` reportaria 0% e o painel mentiria sobre o projeto.

## Quanto é a cobertura hoje

O `coverage` do Sonar **combina linha e condição** — não é só linha. Na `develop`, com os 10 testes que ela tem hoje:

| Medida | Sonar | Meu cálculo local |
| --- | --- | --- |
| `lines_to_cover` | 731 | 736 |
| Cobertura de linha | 40,8% | 40,5% |
| Cobertura combinada | **37,7%** | 37,4% |

Os dois só batem **excluindo as migrations e o `obj`** — é o que prova que a exclusão está valendo.

⚠️ **Isso sobe assim que o #201 mergear.** Aquele PR leva 8 testes novos, e com eles a cobertura de linha vai a **84,2%** e a combinada a **79,6%**. Os 37,7% de hoje são a foto de uma suíte com 10 testes, não o teto do projeto.

Com o piso em 33%, mesmo a foto de hoje passa — mas com folga pequena, e é bom saber disso antes de escolher o número.

## Duas armadilhas

⛔ **Sem excluir as migrations, todo PR de back-end reprovaria.** A condição do gate é sobre **código novo**, e um PR que traz migration traz centenas de linhas geradas com 0% de cobertura. A maioria dos PRs de back-end traz migration.

⛔ **O relatório precisa existir antes da condição.** Se a condição entrar primeiro, o Sonar não acha cobertura, lê 0% e reprova todo PR até o relatório aparecer.

## O que fazer depois do merge

1. Conferir no painel do projeto `fateconnect_FateConnect-api` que a cobertura aparece.
2. **Só então** adicionar a condição ao gate `Backend`: `Coverage on New Code` menor que **33%**.

O piso é folgado de propósito — o número real do código não gerado é 83,6%. O gate do front cobra 90%.

## Como foi verificado

Este PR só toca `.github/`, então o check da API pularia e a fiação iria para o merge sem nunca ter rodado. Forcei o recorte com um commit temporário — depois removido — e medi:

- **O relatório é consumido.** `Parsing the OpenCover report …`, `36 files, 36 main files with coverage`.
- **As exclusões valem.** `Excluded sources for coverage: **/Migrations/**, **/obj/**` e `Excluded sources: FateConnect/Web/**, LBD/**, ESII/**, ESIII/**`.
- **A cobertura de código novo é calculada.** Numa sonda com 5 linhas de C# sem teste: `new_lines_to_cover = 5`, `new_uncovered_lines = 5`, `new_coverage = 0%`. Com a condição no gate, essa sonda teria reprovado — hoje passou porque a condição ainda não existe.
- **Mudança de YAML não puxa a cobertura para baixo.** A mesma análise viu `new_lines = 37` e apenas 5 cobríveis: só C# entra na conta.

## Evidências
