### PR TITLE
chore: make the local gates catch what only the PR caught

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -59,6 +59,21 @@ Aconteceu três vezes no mesmo arquivo, em 2026-08-25, no `eslint.config.js` —
 
 ⛔ **Cobrança repetida do Victor**, a última em 2026-08-24 com os três PRs de achados e perdidos abertos: *"já falei um milhão de vezes, só colocar comentários quando for estritamente essencial… se o código precisa ser explicado é pq ele está mal escrito"*. A varredura tirou **90 linhas líquidas de comentário de 25 arquivos** nos três PRs, e nenhum teste caiu — nenhuma delas estava segurando nada.
 
+## Enxugar não muda o próximo arquivo que escrevo
+
+⛔ **Passar uma varredura de comentário não desliga o hábito.** O commit de limpeza mede o que já existe; o arquivo seguinte nasce do mesmo impulso de antes, e nasce denso.
+
+Aconteceu duas vezes no mesmo dia: enxuguei os sete workflows de 33% para 22% de comentário e, **dois commits depois**, escrevi um workflow novo com 33%. Quem viu foi o Victor: *"vc encheu o check-version de comentário de novo"*.
+
+**O gatilho é escrever arquivo novo logo após uma limpeza** — é ali que a régua ainda não pegou. Antes de commitar o arquivo novo, medir:
+
+```bash
+grep -c '^\s*#' <arquivo>   # comentários
+wc -l < <arquivo>            # linhas
+```
+
+Densidade acima da dos vizinhos é ordem de reler cada comentário pelo teste desta rule, não de aceitar porque "acabei de aprender a regra".
+
 ## Comentário órfão: a declaração some e ele fica
 
 Caso irmão do anterior e mais difícil de ver: o comentário não passou a descrever o vizinho errado por desatenção — **a declaração que ele documentava foi deletada**. O JSDoc sobrevive, pula a linha em branco e se cola ao próximo símbolo, que ele nunca descreveu.

--- a/.claude/rules/dotnet-code-quality.md
+++ b/.claude/rules/dotnet-code-quality.md
@@ -1,0 +1,20 @@
+---
+description: O analisador do Sonar no C# — ele roda dentro do `dotnet build` e reprova a compilação, e o que fazer com o que ele aponta
+paths:
+  - "FateConnect/FateConnect.Api/**"
+  - "FateConnect/FateConnect.Api.Tests/**"
+---
+
+# Qualidade do C# — o analisador roda no build
+
+Os dois projetos referenciam o `SonarAnalyzer.CSharp`, então as regras que o Sonar aplica no PR rodam também no `dotnet build`, na sua máquina e no CI.
+
+⛔ **Elas reprovam a compilação, não avisam.** O `.csproj` liga `TreatWarningsAsErrors`, e o que o analisador aponta vira **erro**. Build quebrado por `S6964` não é infraestrutura com defeito: é achado esperando correção.
+
+**Corrigir, não silenciar.** Achado improcedente se responde por escrito — `#pragma warning disable` com o motivo ao lado, ou a justificativa no corpo do PR. Adiar o primeiro é o que faz o segundo parecer normal.
+
+⚠️ **O conjunto do pacote não é idêntico ao da análise do PR.** O perfil de qualidade do projeto no SonarCloud liga e desliga regras, e parte do que ele mede — duplicação, cobertura, hotspot — nem é do analisador. Achado que aparece só no PR continua existindo; o build local encurta o laço, não o substitui.
+
+Foi assim que os nove primeiros apareceram, ao referenciar o pacote: seis de `S6964` (campo de tipo-valor sem `required`, que aceitava a omissão e virava o valor padrão), dois de `S1118` e um `WriteAsJsonAsync` sem `CancellationToken`.
+
+⚠️ **`Program` não pode virar `static`** para satisfazer o `S1118`: `WebApplicationFactory<Program>` a usa como argumento genérico, e classe estática não serve. O construtor privado resolve.

--- a/.claude/rules/dotnet-testing.md
+++ b/.claude/rules/dotnet-testing.md
@@ -1,11 +1,25 @@
 ---
-description: Como escrever teste na API .NET — projeto separado, nome em três partes, sem lógica e sem comentário, e o par positivo que impede a suíte de concordar com o defeito
+description: Os 90% de cobertura que escrevemos aqui — acima do gate de 33% de propósito — e como escrever teste na API .NET — projeto separado, nome em três partes, sem lógica e sem comentário, e o par positivo que impede a suíte de concordar com o defeito
 paths:
   - "FateConnect/FateConnect.Api/**"
   - "FateConnect/FateConnect.Api.Tests/**"
 ---
 
 # Teste na API .NET
+
+## Cobertura de 90% no que escrevemos aqui
+
+⛔ **Código novo escrito nesta sessão nasce com pelo menos 90% de cobertura**, o mesmo piso do front. Não é o número que o portão cobra — é o que a gente entrega.
+
+⚠️ **O gate `Backend` no SonarCloud reprova em 33%, e isso é de propósito.** Aquele é o piso do repositório, para quem escreve à mão sem agente ao lado; escrever teste tem um custo diferente para cada um. Os 90% são o nosso, e ficam **acima** do portão de propósito.
+
+⛔ **A consequência prática: gate verde não é entrega pronta.** Cobertura de código novo em 40% passa no portão e **não** cumpre esta regra. Calibrar pelo que o Sonar aceita é o erro que esta seção existe para impedir.
+
+O relatório sai do `dotnet test` em formato **OpenCover** (`--collect:"XPlat Code Coverage;Format=opencover"`); o Sonar **não lê Cobertura para C#**, que é o padrão do `dotnet test`. Migrations e `obj/` ficam de fora da conta.
+
+**Linha que não dá para cobrir se marca, não se ignora.** Construtor privado que existe só para impedir instanciação nunca é chamado: `[ExcludeFromCodeCoverage]` nele tira a linha do denominador e diz por quê. Baixar o alvo, não.
+
+⚠️ **Cobertura baixa costuma acusar teste que falta, não métrica injusta.** Na primeira medição o PR saiu com 25%: as propriedades de um DTO sem nenhum teste que criasse o recurso, e a linha do middleware de erro sem nenhum teste que disparasse exceção tratada. Um teste que criava carona com vagas fora da faixa cobriu as duas — e ainda passou a garantir a mensagem de erro, que nada verificava.
 
 ## O teste mora em projeto separado
 

--- a/.claude/rules/web-react-patterns.md
+++ b/.claude/rules/web-react-patterns.md
@@ -1,5 +1,5 @@
 ---
-description: Padrões React no front — handlers, efeitos, timers, refs e exports
+description: Padrões React no front — handlers, efeitos, timers, refs, exports e os idiomas de string que o ESLint deixa passar
 paths:
   - "FateConnect/Web/**"
 ---
@@ -71,6 +71,45 @@ Vale para `useQuery` e `useMutation`. Um teste que conte `getAllByRole('alert')`
 
 - `useRef` em componente funcional, nunca `createRef`.
 - **Apenas exports nomeados** — sem `export default`.
+
+## Constante de módulo mora no topo
+
+Depois dos imports, num bloco só, junto das que já existem — não encostada na função que a usa. Constante espalhada pelo arquivo esconde que o mesmo número já tinha nome três linhas acima.
+
+## Número solto vira nome que explica o significado
+
+O `no-magic-numbers` não abre exceção nem para `0`, `1` e `-1`: eram justamente eles que passavam despercebidos.
+
+⛔ **`ZERO`, `ONE`, `MINUS_ONE` não resolvem** — repetem o valor, que já estava lá. O nome tem de dizer o que aquele número **significa naquele lugar**: `JANUARY`, `SINGLE_PAGE`, `HASH_MARK_LENGTH`, `AFTER_DIGIT`, `ABSENT_CHANNEL`, `NAMES_PER_EDGE`.
+
+Antes de batizar, veja se dá para **remover o número**: `value.length === 0` é `value === ''` quando o valor é texto, e some a contagem.
+
+E se o mesmo número aparece com o mesmo sentido em vários arquivos, ele vira **uma função**, não uma constante repetida — foi o caso do `slice(0, N)` em oito arquivos, que virou `firstCharacters` e `firstItems` em `utils/sequence.ts`.
+
+## Método de string, não expressão regular
+
+⛔ **Padrão literal não vira regex.** `replaceAll('-', '+')` no lugar de `replace(/-/g, '+')`. A versão com string diz o que faz sem ninguém precisar ler regex, e o Sonar reprova a outra (`S7781`).
+
+⛔ **Quantificador colado numa âncora faz backtracking.** `/=+$/` para tirar o preenchimento de um base64 tem custo super-linear (`S8786`) — e `replaceAll('=', '')` resolve igual, porque `=` só aparece no fim.
+
+⛔ **Texto se lê por ponto de código.** `codePointAt` e `fromCodePoint`, nunca `charCodeAt` e `fromCharCode` (`S7758`). `codePointAt` devolve `number | undefined`, então costuma pedir um `?? 0` para o tipo fechar.
+
+As três **reprovam no `yarn lint`**: o `eslint-plugin-sonarjs` traz a `S8786` como `super-linear-regex`, e as outras duas vêm do `eslint-plugin-unicorn` (`prefer-code-point`, `prefer-string-replace-all`), ligadas a dedo na config. Elas chegaram aqui porque o Sonar as pegou primeiro, no PR — hoje o gate local pega antes.
+
+⚠️ **Nem toda regra do Sonar tem plugin ligado.** Achado novo aparecendo no PR sem o `yarn lint` ter reclamado não é para corrigir e seguir: **o README do `eslint-plugin-sonarjs` publica a tabela de mapeamento** de cada regra para o plugin que a implementa. Se a regra estiver lá, ligá-la fecha a classe inteira em vez de um caso.
+
+Aconteceu no PR #203: sete achados de uma vez, todos nas quinze linhas que decodificam o payload do JWT. O efeito colateral de corrigir foi bom — sumiram as quatro expressões regulares do arquivo.
+
+## Byte não é caractere
+
+Ao decodificar base64 com `atob`, o resultado é uma sequência de **bytes**, não texto: `JSON.parse` direto ali corrompe qualquer acento. O caminho é `TextDecoder`.
+
+```ts
+const bytes = Uint8Array.from(atob(base64), (character) => character.codePointAt(0) ?? 0);
+const json = new TextDecoder().decode(bytes);
+```
+
+O teste que protege isso precisa de um nome **com acento** — `João Ávila` passa, `Maria da Silva` não acusaria nada.
 
 ## TODO
 

--- a/.claude/rules/web-styling.md
+++ b/.claude/rules/web-styling.md
@@ -160,7 +160,7 @@ Para decidir em JS, `useMediaQuery(theme.breakpoints.up('md'))` — não meça `
 
 Uso de API marcada como `@deprecated` é **erro** (`@typescript-eslint/no-deprecated`, com informação de tipo via `projectService`). O recorte cobre `**/*.{js,ts,tsx}`, o que inclui o **próprio `eslint.config.js`** — e ele precisa de `projectService: { allowDefaultProject: ['eslint.config.js'] }`, porque é `.js` e fica fora do `include` do `tsconfig`. Sem isso o parser reprova com *"was not found by the project service"*; sem o `.js` no recorte, uma API deprecada dentro do próprio config passa despercebida — foi o que aconteceu com o `tseslint.config()`. Ao ligar, ela já pegou o `.email()` do zod nos dois schemas — trocado por `.pipe(z.email(...))`, que preserva a ordem "obrigatório antes de inválido".
 
-Número solto é **erro** (`@typescript-eslint/no-magic-numbers`): valor numérico com significado vira constante nomeada. Ficam de fora `0`, `1` e `-1` — que aparecem em comprimento, índice e contador sem esconder intenção —, os testes, e valores dentro de objeto (é o que permite tabelas de token como `spacingScale`).
+Número solto é **erro** (`@typescript-eslint/no-magic-numbers`): valor numérico com significado vira constante cujo nome diz o **significado**, não o valor — `JANUARY` e `SINGLE_PAGE`, nunca `ZERO`. **Não há exceção para `0`, `1` e `-1`**: eram justamente eles que passavam. Ficam de fora os testes e valores dentro de objeto (é o que permite tabelas de token como `spacingScale`).
 
 `console` solto é **erro** (`no-console`) — em qualquer arquivo, inclusive teste. Depuração não vai para produção, e o rastro de erro é responsabilidade de quem trata o erro, não de um `console.error` esquecido no componente. `vi.spyOn(console, 'error')` continua valendo em teste: a regra reprova o acesso a `console.<método>`, não passar `console` como argumento.
 
@@ -169,7 +169,7 @@ Estas proibições de **sintaxe** guardam as decisões de escala — todas com s
 | Proibido | Saída |
 | -------- | ----- |
 | número cru em `theme.space()`, `theme.radius()` e no helper livre | token de `spacingScale`/`radiusScale`, `none` para zero |
-| número cru em `gap`, `padding`, `margin` e variantes | idem — o `no-magic-numbers` ignora `0`, e era por ali que passava |
+| número cru em `gap`, `padding`, `margin` e variantes | idem — constante nomeada satisfaz o `no-magic-numbers` e ainda assim não é o token |
 | `theme.spacing(...)` | `theme.space()` |
 | chave de breakpoint que não seja `md` | `down('md')` e `up('md')`; só o tema fala `sm`, para desfazer o do MUI |
 | `@media` de largura escrito à mão | as duas consultas do tema |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrige o cadastro, que aceitava requisição sem data de nascimento e gravava `01/01/0001` no lugar de recusar (#205) [Backend]
+
 ## [0.5.0] - 2026-08-28
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ dotnet build FateConnect/FateConnect.Api/FateConnect.Api.sln
 dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build
 ```
 
-Erro reprova. Warning não.
+Aviso reprova nos dois lados: o lint do front roda com `--max-warnings=0`, e o `.csproj` da API liga `TreatWarningsAsErrors`.
 
 ## Mudança que o usuário percebe entra no CHANGELOG
 

--- a/FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
+++ b/FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.33.0.1635">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/FateConnect/FateConnect.Api.Tests/UnderPostingTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/UnderPostingTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace FateConnect.Api.Tests;
+
+public class UnderPostingTests : IClassFixture<ApiFactory>
+{
+    private readonly ApiFactory _factory;
+
+    public UnderPostingTests(ApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private static Dictionary<string, object> BaseSignup() => new()
+    {
+        ["emailFatec"] = $"sonda{Guid.NewGuid():N}@aluno.cps.sp.gov.br",
+        ["senha"] = "SenhaForte123!",
+        ["nomeCompleto"] = "Pessoa de Teste",
+        ["genero"] = "Male",
+        ["enderecos"] = new[]
+        {
+            new { cep = "18000-000", logradouro = "Rua A", numero = "1", complemento = "Casa", cidade = "Sorocaba", estado = "SP" },
+        },
+        ["contatos"] = new[] { new { telefone = "15999990000", emailContato = "pessoa@example.com" } },
+    };
+
+    [Fact]
+    public async Task Signup_WithoutTheBirthDate_IsRejected()
+    {
+        HttpResponseMessage response = await _factory.CreateClient()
+            .PostAsJsonAsync("/usuario/cadastro", BaseSignup());
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Signup_WithTheBirthDate_IsAccepted()
+    {
+        Dictionary<string, object> payload = BaseSignup();
+        payload["dataNascimento"] = "2000-01-01T00:00:00Z";
+
+        HttpResponseMessage response = await _factory.CreateClient()
+            .PostAsJsonAsync("/usuario/cadastro", payload);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateRide_WithSeatsOutOfRange_AnswersTheDomainMessage()
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", ApiFactory.IssueToken());
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/Rides", new
+        {
+            availableSeats = 99,
+            destination = "Fatec Sorocaba",
+            departureDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)).ToString("yyyy-MM-dd"),
+            departureTime = "08:30:00",
+            rideType = "Solidarity",
+        });
+
+        string body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("between 1 and 7", body, StringComparison.Ordinal);
+    }
+}

--- a/FateConnect/FateConnect.Api/FateConnect.Api.csproj
+++ b/FateConnect/FateConnect.Api/FateConnect.Api.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.33.0.1635">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />

--- a/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
@@ -57,7 +57,7 @@ public partial class GlobalExceptionMiddleware(
         context.Response.ContentType = "application/json";
         context.Response.StatusCode = (int)statusCode;
 
-        await context.Response.WriteAsJsonAsync(new { error = errorMessage });
+        await context.Response.WriteAsJsonAsync(new { error = errorMessage }, context.RequestAborted);
     }
 
     [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "Unhandled internal server error occurred.")]

--- a/FateConnect/FateConnect.Api/Modules/Common/Constants/RegexConstants.cs
+++ b/FateConnect/FateConnect.Api/Modules/Common/Constants/RegexConstants.cs
@@ -1,6 +1,6 @@
 namespace FateConnect.Api.Modules.Common.Constants;
 
-public class RegexConstants
+public static class RegexConstants
 {
     public const string EmailInstitucionalFatec = @"^([a-zA-Z0-9._%+-]+)@(aluno\.)?cps\.sp\.gov\.br$";
     public const string MensagemErroEmailFatec = "O email deve ser do domínio @aluno.cps.sp.gov.br ou @cps.sp.gov.br";

--- a/FateConnect/FateConnect.Api/Modules/Rides/DTOs/CreateRideDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/DTOs/CreateRideDto.cs
@@ -5,16 +5,16 @@ using FateConnect.Api.Modules.Rides.Enums;
 
 public record CreateRideDto
 {
-    public int AvailableSeats { get; init; }
+    public required int AvailableSeats { get; init; }
 
     [StringLength(100)]
     public required string Destination { get; init; }
 
-    public DateOnly DepartureDate { get; init; }
+    public required DateOnly DepartureDate { get; init; }
 
-    public TimeOnly DepartureTime { get; init; }
+    public required TimeOnly DepartureTime { get; init; }
 
-    public EnumRideType RideType { get; init; }
+    public required EnumRideType RideType { get; init; }
 
     [StringLength(300)]
     public string? Description { get; init; }

--- a/FateConnect/FateConnect.Api/Modules/Usuarios/DTOs/CreateUsuarioDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Usuarios/DTOs/CreateUsuarioDto.cs
@@ -31,12 +31,12 @@ public class CreateUsuarioDto
 
     [Required]
     [DefaultValue("2000-01-01T00:00:00Z")]
-    public DateTime DataNascimento { get; set; }
+    required public DateTime DataNascimento { get; set; }
 
     [Required]
     [DefaultValue(1)]
     [EnumDataType(typeof(EnumGender), ErrorMessage = "Invalid gender.")]
-    public EnumGender Genero { get; set; }
+    required public EnumGender Genero { get; set; }
 
     [Required]
     required public List<CreateEnderecoDto> Enderecos { get; set; } =

--- a/FateConnect/FateConnect.Api/Program.cs
+++ b/FateConnect/FateConnect.Api/Program.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 namespace FateConnect.Api;
 
 using System.Text;
@@ -25,6 +26,9 @@ using Microsoft.OpenApi.Models;
 
 public class Program
 {
+    [ExcludeFromCodeCoverage]
+    private Program() { }
+
     public static void Main(string[] args)
     {
         if (File.Exists(".env"))

--- a/FateConnect/Web/README.md
+++ b/FateConnect/Web/README.md
@@ -59,6 +59,8 @@ Dois aliases: `@design-system` para a UI (com `@design-system/icons` para ícone
 
 O lint aplica as principais; as demais estão nas regras do projeto.
 
+Ele carrega também as regras do Sonar — `eslint-plugin-sonarjs` e duas do `eslint-plugin-unicorn` que a análise toma emprestadas. Sem elas, esses achados só apareceriam depois, com o PR já aberto.
+
 ### Design system é a única porta
 
 A aplicação importa UI **somente** de `@design-system` — nunca de `@mui/*`, nunca de um caminho interno do design system. Precisa de um componente que o barrel não expõe? Adicione ao barrel.
@@ -105,6 +107,8 @@ Use o `render` de `@app/test/testing-library`, que já monta tema, rotas e cache
 | `pre-commit` | `lint-staged` sobre os arquivos preparados          | —         |
 | `pre-push`   | só os testes **relacionados** aos arquivos enviados | —         |
 | CI (no PR)   | tipos, lint, **suíte inteira**, build e Sonar        | mede      |
+
+⚠️ O hook roda com o Node do seu shell, não com o do `.nvmrc`. Num Node anterior ao 22 ele falha com `mapTypes.union is not a function`, que é uma regra de lint usando `Set.prototype.union` — a saída é `nvm use` antes de commitar.
 
 O `pre-push` usa `scripts/test-changed.sh`, que segue o grafo de imports com `vitest related`: mudar uma tela roda os testes que a alcançam, não a suíte inteira. Ele cai na suíte inteira quando a mudança sai de `src/` ou remove arquivo — nesses casos o grafo não alcança o efeito, e `vitest related vite.config.ts` sairia com sucesso sem rodar teste nenhum.
 

--- a/FateConnect/Web/design-system/components/Pagination/index.tsx
+++ b/FateConnect/Web/design-system/components/Pagination/index.tsx
@@ -2,6 +2,8 @@ import { useCallback, type ChangeEvent } from 'react';
 
 import * as S from './styles';
 
+const SINGLE_PAGE = 1;
+
 export type PaginationProps = Readonly<{
   /** Total de páginas. Com uma só o controle não se desenha. */
   count: number;
@@ -16,7 +18,7 @@ export function Pagination({ count, page, onChange }: PaginationProps) {
     [onChange],
   );
 
-  if (count <= 1) return null;
+  if (count <= SINGLE_PAGE) return null;
 
   return <S.PaginationNav count={count} page={page} onChange={handleChange} />;
 }

--- a/FateConnect/Web/design-system/theme/contrast.ts
+++ b/FateConnect/Web/design-system/theme/contrast.ts
@@ -13,10 +13,10 @@ const GREEN_WEIGHT = 0.7152;
 const BLUE_WEIGHT = 0.0722;
 /** Evita divisão por zero quando uma das cores é preto puro. */
 const CONTRAST_OFFSET = 0.05;
-
 const HEX_RADIX = 16;
 const HEX_CHANNEL_LENGTH = 2;
 const RED_POSITION = 0;
+const ABSENT_CHANNEL = 0;
 const GREEN_POSITION = 1;
 const BLUE_POSITION = 2;
 const ALPHA_POSITION = 3;
@@ -65,9 +65,9 @@ function toRgb(color: string): Rgb {
   const values = toNumbers(channels);
 
   return {
-    red: values[RED_POSITION] ?? 0,
-    green: values[GREEN_POSITION] ?? 0,
-    blue: values[BLUE_POSITION] ?? 0,
+    red: values[RED_POSITION] ?? ABSENT_CHANNEL,
+    green: values[GREEN_POSITION] ?? ABSENT_CHANNEL,
+    blue: values[BLUE_POSITION] ?? ABSENT_CHANNEL,
   };
 }
 
@@ -86,9 +86,9 @@ function flatten(color: string, background: string): Rgb {
     value * alpha + backdropValue * (OPAQUE - alpha);
 
   return {
-    red: blend(values[RED_POSITION] ?? 0, backdrop.red),
-    green: blend(values[GREEN_POSITION] ?? 0, backdrop.green),
-    blue: blend(values[BLUE_POSITION] ?? 0, backdrop.blue),
+    red: blend(values[RED_POSITION] ?? ABSENT_CHANNEL, backdrop.red),
+    green: blend(values[GREEN_POSITION] ?? ABSENT_CHANNEL, backdrop.green),
+    blue: blend(values[BLUE_POSITION] ?? ABSENT_CHANNEL, backdrop.blue),
   };
 }
 

--- a/FateConnect/Web/eslint.config.js
+++ b/FateConnect/Web/eslint.config.js
@@ -5,6 +5,8 @@ import perfectionist from 'eslint-plugin-perfectionist';
 import prettierRecommended from 'eslint-plugin-prettier/recommended';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import sonarjs from 'eslint-plugin-sonarjs';
+import unicorn from 'eslint-plugin-unicorn';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
@@ -22,9 +24,10 @@ const styleConventions = [
       'Use o helper `spacing()` do design system. O `theme.spacing` é do MUI e sobrescrevê-lo encolhe os componentes dele (as gutters do Toolbar viraram 3px).',
   },
   {
-    // O `no-magic-numbers` ignora 0, 1 e -1, então era por ali que o `0` cru
-    // entrava no lugar do token `none`. Cobre as duas formas de chamada: a do
-    // tema e o helper livre do `theme/`, que foi por onde dois escaparam.
+    // Constante nomeada passa no `no-magic-numbers` e ainda assim não é o token:
+    // aqui o valor tem de vir de `spacingScale`/`radiusScale`. Cobre as duas
+    // formas de chamada — a do tema e o helper livre do `theme/`, que foi por
+    // onde dois escaparam.
     selector:
       "CallExpression[callee.object.name='theme'][callee.property.name=/^(space|radius)$/] > Literal, " +
       'CallExpression[callee.name=/^(spacing|radius)$/] > Literal',
@@ -32,9 +35,8 @@ const styleConventions = [
       'Sem número cru em `theme.space()` e `theme.radius()`: use o token de `spacingScale`/`radiusScale` — inclusive `none` para zero.',
   },
   {
-    // `padding: 0` e `margin: 0` também são espaçamento: viram o token `none`.
-    // O `no-magic-numbers` ignora 0 de propósito, então quem barra aqui é este
-    // seletor.
+    // `padding: 0` e `margin: 0` também são espaçamento: viram o token `none`,
+    // e não uma constante nomeada.
     selector: String.raw`Property[key.name=/^(gap|rowGap|columnGap|padding|padding[A-Z]\w*|margin|margin[A-Z]\w*)$/] > Literal[raw=/^-?[0-9]/]`,
     message:
       'Espaçamento nunca é número cru: use `theme.space()` com o token de `spacingScale` — `none` para zero.',
@@ -98,6 +100,38 @@ export default defineConfig([
   { ignores: ['dist', 'coverage'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
+  // As mesmas regras que o Sonar aplica no PR. Sem elas o gate local aprova
+  // código que a análise reprova depois, com o PR já aberto.
+  sonarjs.configs.recommended,
+  {
+    // A marcação de tarefa pendente é convenção daqui: o padrão exige a issue
+    // que a resolve ao lado, então ela é rastreio, não dívida esquecida.
+    rules: { 'sonarjs/todo-tag': 'off' },
+  },
+  {
+    // Componente React devolve `null` ou nós conforme o estado — a regra lê isso
+    // como retorno inconsistente, e obedecê-la pioraria o código.
+    files: ['**/*.tsx'],
+    rules: { 'sonarjs/function-return-type': 'off' },
+  },
+  {
+    // Senha de fixture não é segredo: ela existe para o formulário ter o que
+    // validar. Segredo de verdade não entra no repositório, versionado ou não.
+    files: ['**/*.test.{ts,tsx}'],
+    rules: { 'sonarjs/no-hardcoded-passwords': 'off' },
+  },
+  {
+    files: ['**/*.{js,ts,tsx}'],
+    plugins: { unicorn },
+    // Só estas duas do `unicorn`, porque são as que o Sonar toma emprestadas
+    // (`S7758` e `S7781`). A configuração recomendada dele traria 745 violações
+    // de opinião de estilo que este repo contraria de propósito — nome de
+    // arquivo em PascalCase e `null` no contrato da API, entre outras.
+    rules: {
+      'unicorn/prefer-code-point': 'error',
+      'unicorn/prefer-string-replace-all': 'error',
+    },
+  },
   {
     files: ['**/*.{js,ts,tsx}'],
     languageOptions: {
@@ -300,7 +334,6 @@ export default defineConfig([
       '@typescript-eslint/no-magic-numbers': [
         'error',
         {
-          ignore: [0, 1, -1],
           ignoreArrayIndexes: true,
           ignoreDefaultValues: true,
           ignoreEnums: true,

--- a/FateConnect/Web/package.json
+++ b/FateConnect/Web/package.json
@@ -56,6 +56,8 @@
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-sonarjs": "^4.2.0",
+    "eslint-plugin-unicorn": "^74.0.0",
     "globals": "^17.11.0",
     "jsdom": "^29.1.1",
     "lint-staged": "^17.3.0",

--- a/FateConnect/Web/src/hooks/useHashScroll.ts
+++ b/FateConnect/Web/src/hooks/useHashScroll.ts
@@ -3,6 +3,8 @@ import { useLocation } from 'react-router';
 
 import { scrollToSection } from '@app/utils/scrollToSection';
 
+const HASH_MARK_LENGTH = 1;
+
 /** Resolve o fragmento da URL sempre que ele muda — inclusive na primeira carga. */
 export function useHashScroll(): void {
   const { hash } = useLocation();
@@ -10,6 +12,6 @@ export function useHashScroll(): void {
   useEffect(() => {
     if (!hash) return;
 
-    return scrollToSection(hash.slice(1));
+    return scrollToSection(hash.slice(HASH_MARK_LENGTH));
   }, [hash]);
 }

--- a/FateConnect/Web/src/hooks/useMaskedField.ts
+++ b/FateConnect/Web/src/hooks/useMaskedField.ts
@@ -2,6 +2,7 @@ import { useCallback, type ChangeEvent } from 'react';
 import type { UseFormRegisterReturn } from 'react-hook-form';
 
 import { caretAfterDigitCount, countDigits } from '@app/utils/masks/caret';
+import { firstCharacters } from '@app/utils/sequence';
 
 type MaskFunction = (value: string) => string;
 
@@ -26,7 +27,7 @@ export function useMaskedField<Field extends UseFormRegisterReturn>(
 
       if (maskedValue !== input.value) {
         const caretIndex = input.selectionStart ?? input.value.length;
-        const digitsBeforeCaret = countDigits(input.value.slice(0, caretIndex));
+        const digitsBeforeCaret = countDigits(firstCharacters(input.value, caretIndex));
 
         input.value = maskedValue;
 

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/schema/index.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/schema/index.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 
 import { FATEC_EMAIL_MESSAGE, FATEC_EMAIL_PATTERN } from '@app/constants/fatecEmail';
 
+const REQUIRED_MIN_LENGTH = 1;
+
 export const LOGIN_MESSAGES = {
   emailRequired: 'Informe o e-mail',
   passwordRequired: 'Informe a senha',
@@ -10,9 +12,9 @@ export const LOGIN_MESSAGES = {
 export const loginSchema = z.object({
   email: z
     .string()
-    .min(1, LOGIN_MESSAGES.emailRequired)
+    .min(REQUIRED_MIN_LENGTH, LOGIN_MESSAGES.emailRequired)
     .regex(FATEC_EMAIL_PATTERN, FATEC_EMAIL_MESSAGE),
-  password: z.string().min(1, LOGIN_MESSAGES.passwordRequired),
+  password: z.string().min(REQUIRED_MIN_LENGTH, LOGIN_MESSAGES.passwordRequired),
 });
 
 export type LoginFormValues = z.infer<typeof loginSchema>;

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFilter/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFilter/index.tsx
@@ -13,10 +13,11 @@ import * as C from './constants';
 
 /** Células por linha no desktop: cinco campos e o botão quebram em duas. */
 const FILTER_COLUMNS = 3;
+const NO_FILTERS = 0;
 
 /** O mural já abre em Aberto, então isso sozinho não conta como filtro. */
 function isBeyondDefault({ status, ...rest }: LostItemFilterValues): boolean {
-  if (Object.keys(rest).length > 0) return true;
+  if (Object.keys(rest).length > NO_FILTERS) return true;
 
   return status !== LostItemStatusEnum.OPEN;
 }

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFormDialog/helpers/mapper.ts
@@ -1,4 +1,5 @@
 import type { LostItem, LostItemInput } from '@app/services/lostAndFound/types';
+import { firstCharacters } from '@app/utils/sequence';
 
 import { EMPTY_LOST_ITEM_FORM, type LostItemFormInput, type LostItemFormValues } from '../schema';
 
@@ -11,7 +12,7 @@ export function toFormValues(item: LostItem | undefined): LostItemFormInput {
     name: item.nome,
     kind: item.tipo,
     place: item.local,
-    occurredOn: item.dataOcorrido.slice(0, DATE_LENGTH),
+    occurredOn: firstCharacters(item.dataOcorrido, DATE_LENGTH),
     description: item.descricao ?? '',
     // O campo só lida com arquivo escolhido agora, não com a URL guardada.
     photo: null,

--- a/FateConnect/Web/src/pages/LostAndFound/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/index.tsx
@@ -20,6 +20,7 @@ import * as C from './constants';
 import * as S from './styles';
 
 const SPINNER_SIZE_PX = 60;
+const NO_ITEMS = 0;
 
 const INITIAL_FILTERS: LostItemFilterValues = { status: LostItemStatusEnum.OPEN };
 
@@ -92,7 +93,7 @@ export function LostAndFound() {
           </S.LoadingContainer>
         )}
 
-        {!isLoading && items.length === 0 && (
+        {!isLoading && items.length === NO_ITEMS && (
           <Typography variant="subtitle">{C.EMPTY_LIST_MESSAGE}</Typography>
         )}
 

--- a/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideCard/index.tsx
@@ -6,6 +6,7 @@ import * as C from '@app/pages/Rides/constants';
 import { isOwnRide, RIDE_DRIVER } from '@app/pages/Rides/helpers/rideDriver';
 import { rideTypeDisplayLabel, rideTypeTone } from '@app/pages/Rides/helpers/rideType';
 import type { Ride } from '@app/services/rides/types';
+import { firstCharacters } from '@app/utils/sequence';
 
 import { RideDriverContact } from './RideDriverContact';
 import { RideOwnerActions } from './RideOwnerActions';
@@ -51,7 +52,7 @@ export function RideCard({ ride, onEdit, onDelete }: RideCardProps) {
         <ListCard.InfoItem>
           <AccessTimeIcon />
           <Typography variant="caption" color="inherit">
-            {ride.departureTime.slice(0, TIME_LENGTH)}
+            {firstCharacters(ride.departureTime, TIME_LENGTH)}
           </Typography>
         </ListCard.InfoItem>
 

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
@@ -8,6 +8,7 @@ import * as C from './constants';
 
 /** Células por linha no desktop: quatro campos e o botão cabem em uma. */
 const FILTER_COLUMNS = 5;
+const NO_FILTERS = 0;
 
 type RideFilterProps = Readonly<{ onApply: (filters: RideFilterValues) => void }>;
 
@@ -42,7 +43,7 @@ export function RideFilter({ onApply }: RideFilterProps) {
       if (destination.trim()) filters.destination = destination.trim();
       if (rideType) filters.rideType = rideType as RideTypeEnum;
 
-      setIsFiltered(Object.keys(filters).length > 0);
+      setIsFiltered(Object.keys(filters).length > NO_FILTERS);
       onApply(filters);
     },
     [departureDate, departureTime, destination, rideType, onApply],

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/constants/index.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/constants/index.ts
@@ -56,13 +56,18 @@ export const RIDE_TYPE_SELECT_OPTIONS: readonly SelectOption[] = [
   ...RIDE_TYPE_OPTIONS,
 ];
 
+const INCLUSIVE_END = 1;
+
 export const SEAT_OPTIONS: readonly SelectOption[] = [
   EMPTY_CHOICE,
-  ...Array.from({ length: RIDE_LIMITS.maxSeats - RIDE_LIMITS.minSeats + 1 }, (_value, index) => {
-    const seats = RIDE_LIMITS.minSeats + index;
+  ...Array.from(
+    { length: RIDE_LIMITS.maxSeats - RIDE_LIMITS.minSeats + INCLUSIVE_END },
+    (_value, index) => {
+      const seats = RIDE_LIMITS.minSeats + index;
 
-    return { value: String(seats), label: seatsLabel(seats) };
-  }),
+      return { value: String(seats), label: seatsLabel(seats) };
+    },
+  ),
 ];
 
 export const RIDE_FORM_MESSAGES = {

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.ts
@@ -1,4 +1,5 @@
 import type { Ride, RideInput } from '@app/services/rides/types';
+import { firstCharacters } from '@app/utils/sequence';
 
 import { EMPTY_RIDE_FORM, type RideFormInput, type RideFormValues } from '../schema';
 
@@ -13,8 +14,8 @@ export function toFormValues(ride: Ride | undefined): RideFormInput {
 
   return {
     destination: ride.destination,
-    departureDate: ride.departureDate.slice(0, DATE_LENGTH),
-    departureTime: ride.departureTime.slice(0, TIME_LENGTH),
+    departureDate: firstCharacters(ride.departureDate, DATE_LENGTH),
+    departureTime: firstCharacters(ride.departureTime, TIME_LENGTH),
     rideType: ride.rideType,
     seats: String(ride.availableSeats),
     description: ride.description ?? '',

--- a/FateConnect/Web/src/pages/Rides/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/index.tsx
@@ -16,8 +16,8 @@ import * as C from './constants';
 import * as S from './styles';
 
 const SPINNER_SIZE_PX = 60;
+const NO_ITEMS = 0;
 
-/** Uma tela só: a lista com os filtros, e a aba de ofertar abrindo o diálogo. */
 export function Rides() {
   const queryClient = useQueryClient();
   const { notifySuccess } = useNotification();
@@ -97,7 +97,7 @@ export function Rides() {
           </S.LoadingContainer>
         )}
 
-        {!isLoading && rides.length === 0 && (
+        {!isLoading && rides.length === NO_ITEMS && (
           <Typography variant="subtitle">{C.EMPTY_LIST_MESSAGE}</Typography>
         )}
 

--- a/FateConnect/Web/src/pages/Signup/helpers/birthDate.ts
+++ b/FateConnect/Web/src/pages/Signup/helpers/birthDate.ts
@@ -4,9 +4,11 @@ const BIRTH_DATE_FORMAT = 'dd/MM/yyyy';
 const API_DATE_FORMAT = 'yyyy-MM-dd';
 const MINIMUM_AGE_YEARS = 18;
 const EARLIEST_BIRTH_YEAR = 1900;
+const JANUARY = 0;
+const FIRST_DAY_OF_MONTH = 1;
 
 /** Piso do seletor, igual ao do formulário anterior. */
-export const EARLIEST_BIRTH_DATE = new Date(EARLIEST_BIRTH_YEAR, 0, 1);
+export const EARLIEST_BIRTH_DATE = new Date(EARLIEST_BIRTH_YEAR, JANUARY, FIRST_DAY_OF_MONTH);
 
 /**
  * Última data de nascimento aceita — quem completa 18 anos hoje ainda pode se

--- a/FateConnect/Web/src/pages/Signup/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/Signup/helpers/mapper.ts
@@ -6,7 +6,7 @@ import { parseBirthDate, toApiBirthDate } from './birthDate';
 
 /** Campo opcional: o backend prefere a ausência da chave a uma string vazia. */
 function optionalText(value: string): string | undefined {
-  if (value.length === 0) return undefined;
+  if (value === '') return undefined;
 
   return value;
 }

--- a/FateConnect/Web/src/pages/Signup/schema/index.ts
+++ b/FateConnect/Web/src/pages/Signup/schema/index.ts
@@ -5,6 +5,7 @@ import { onlyDigits } from '@app/utils/masks/caret';
 
 import { EARLIEST_BIRTH_DATE, latestBirthDate, parseBirthDate } from '../helpers/birthDate';
 
+const REQUIRED_MIN_LENGTH = 1;
 const MIN_PASSWORD_LENGTH = 8;
 const MIN_PHONE_DIGITS = 10;
 const ZIP_CODE_DIGITS = 8;
@@ -35,7 +36,7 @@ export const SIGNUP_MESSAGES = {
 
 /** Data real e não anterior ao piso do seletor. */
 function isRealBirthDate(value: string): boolean {
-  if (value.length === 0) return true;
+  if (value === '') return true;
 
   const parsed = parseBirthDate(value);
   if (!parsed) return false;
@@ -56,44 +57,44 @@ function isCompleteZipCode(value: string): boolean {
 
 function hasBrazilianPhoneLength(value: string): boolean {
   const digits = onlyDigits(value);
-  if (digits.length === 0) return true;
+  if (digits === '') return true;
 
   return digits.length >= MIN_PHONE_DIGITS && digits.length <= MAX_PHONE_DIGITS;
 }
 
 export const signupSchema = z.object({
-  fullName: z.string().min(1, SIGNUP_MESSAGES.fullNameRequired),
+  fullName: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.fullNameRequired),
   nickname: z.string(),
   fatecEmail: z
     .string()
-    .min(1, SIGNUP_MESSAGES.fatecEmailRequired)
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.fatecEmailRequired)
     .regex(FATEC_EMAIL_PATTERN, FATEC_EMAIL_MESSAGE),
   birthDate: z
     .string()
-    .min(1, SIGNUP_MESSAGES.birthDateRequired)
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.birthDateRequired)
     .refine(isRealBirthDate, SIGNUP_MESSAGES.birthDateInvalid)
     .refine(isOldEnough, SIGNUP_MESSAGES.birthDateUnderage),
-  gender: z.string().min(1, SIGNUP_MESSAGES.genderRequired),
+  gender: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.genderRequired),
   password: z
     .string()
-    .min(1, SIGNUP_MESSAGES.passwordRequired)
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.passwordRequired)
     .min(MIN_PASSWORD_LENGTH, SIGNUP_MESSAGES.passwordTooShort),
   zipCode: z
     .string()
-    .min(1, SIGNUP_MESSAGES.zipCodeRequired)
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.zipCodeRequired)
     .refine(isCompleteZipCode, SIGNUP_MESSAGES.zipCodeIncomplete),
-  state: z.string().min(1, SIGNUP_MESSAGES.stateRequired),
-  city: z.string().min(1, SIGNUP_MESSAGES.cityRequired),
-  street: z.string().min(1, SIGNUP_MESSAGES.streetRequired),
-  streetNumber: z.string().min(1, SIGNUP_MESSAGES.streetNumberRequired),
+  state: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.stateRequired),
+  city: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.cityRequired),
+  street: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.streetRequired),
+  streetNumber: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.streetNumberRequired),
   complement: z.string(),
   phone: z
     .string()
-    .min(1, SIGNUP_MESSAGES.phoneRequired)
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.phoneRequired)
     .refine(hasBrazilianPhoneLength, SIGNUP_MESSAGES.phoneInvalid),
   contactEmail: z
     .string()
-    .min(1, SIGNUP_MESSAGES.contactEmailRequired)
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.contactEmailRequired)
     .pipe(z.email(SIGNUP_MESSAGES.emailInvalid)),
   acceptTerms: z.boolean().refine((accepted) => accepted, SIGNUP_MESSAGES.termsRequired),
   acceptMarketing: z.boolean(),

--- a/FateConnect/Web/src/utils/initials.ts
+++ b/FateConnect/Web/src/utils/initials.ts
@@ -1,11 +1,17 @@
+import { firstItems } from './sequence';
+
 /**
  * Partícula de nome não conta como sobrenome: "Maria da Silva" abrevia para MS,
  * não MD.
  */
 const NAME_PARTICLES: ReadonlySet<string> = new Set(['de', 'da', 'do', 'das', 'dos', 'e']);
+const FIRST_LETTER_POSITION = 0;
+const SINGLE_NAME = 1;
+const NAMES_PER_EDGE = 1;
+const NO_NAMES = 0;
 
 function firstLetter(namePart: string): string {
-  return namePart.charAt(0).toUpperCase();
+  return namePart.charAt(FIRST_LETTER_POSITION).toUpperCase();
 }
 
 /**
@@ -13,18 +19,20 @@ function firstLetter(namePart: string): string {
  * da mesma palavra inventaria um sobrenome que não existe.
  */
 function edgeInitials(names: readonly string[]): string {
-  if (names.length <= 1) return names.map(firstLetter).join('');
+  if (names.length <= SINGLE_NAME) return names.map(firstLetter).join('');
 
-  return [...names.slice(0, 1), ...names.slice(-1)].map(firstLetter).join('');
+  return [...firstItems(names, NAMES_PER_EDGE), ...names.slice(-NAMES_PER_EDGE)]
+    .map(firstLetter)
+    .join('');
 }
 
 /** Iniciais do primeiro e do último nome, em maiúsculas. */
 export function getInitials(fullName: string): string {
   const parts = fullName.trim().split(/\s+/).filter(Boolean);
   const names = parts.filter((part) => !NAME_PARTICLES.has(part.toLowerCase()));
-  if (names.length > 0) return edgeInitials(names);
+  if (names.length > NO_NAMES) return edgeInitials(names);
 
   // Sem nenhuma palavra que não seja partícula, não há primeiro e último a
   // distinguir — o que sobra é a primeira palavra do que veio.
-  return edgeInitials(parts.slice(0, 1));
+  return edgeInitials(firstItems(parts, NAMES_PER_EDGE));
 }

--- a/FateConnect/Web/src/utils/masks/birthDateMask.ts
+++ b/FateConnect/Web/src/utils/masks/birthDateMask.ts
@@ -1,3 +1,4 @@
+import { firstCharacters } from '../sequence';
 import { onlyDigits } from './caret';
 
 const MAX_DATE_DIGITS = 8;
@@ -6,10 +7,11 @@ const MONTH_END = 4;
 
 /** Formata `dd/mm/aaaa` progressivamente, descartando o que passar de 8 dígitos. */
 export function maskBirthDate(value: string): string {
-  const digits = onlyDigits(value).slice(0, MAX_DATE_DIGITS);
+  const digits = firstCharacters(onlyDigits(value), MAX_DATE_DIGITS);
 
   if (digits.length <= DAY_END) return digits;
-  if (digits.length <= MONTH_END) return `${digits.slice(0, DAY_END)}/${digits.slice(DAY_END)}`;
+  if (digits.length <= MONTH_END)
+    return `${firstCharacters(digits, DAY_END)}/${digits.slice(DAY_END)}`;
 
-  return `${digits.slice(0, DAY_END)}/${digits.slice(DAY_END, MONTH_END)}/${digits.slice(MONTH_END)}`;
+  return `${firstCharacters(digits, DAY_END)}/${digits.slice(DAY_END, MONTH_END)}/${digits.slice(MONTH_END)}`;
 }

--- a/FateConnect/Web/src/utils/masks/caret.ts
+++ b/FateConnect/Web/src/utils/masks/caret.ts
@@ -1,3 +1,7 @@
+const TEXT_START = 0;
+const NO_DIGITS = 0;
+const AFTER_DIGIT = 1;
+
 export function onlyDigits(text: string): string {
   return text.replaceAll(/\D/g, '');
 }
@@ -14,16 +18,16 @@ export function countDigits(text: string): number {
  * formatação e reencontra-se essa mesma fronteira no texto formatado.
  */
 export function caretAfterDigitCount(maskedValue: string, digitCount: number): number {
-  if (digitCount <= 0) return 0;
+  if (digitCount <= NO_DIGITS) return TEXT_START;
 
-  let digitsSeen = 0;
+  let digitsSeen = NO_DIGITS;
 
-  for (let index = 0; index < maskedValue.length; index++) {
+  for (let index = TEXT_START; index < maskedValue.length; index++) {
     const character = maskedValue[index];
     if (character === undefined || !/\d/.test(character)) continue;
 
     digitsSeen++;
-    if (digitsSeen >= digitCount) return index + 1;
+    if (digitsSeen >= digitCount) return index + AFTER_DIGIT;
   }
 
   return maskedValue.length;

--- a/FateConnect/Web/src/utils/masks/phoneMask.ts
+++ b/FateConnect/Web/src/utils/masks/phoneMask.ts
@@ -1,3 +1,4 @@
+import { firstCharacters } from '../sequence';
 import { onlyDigits } from './caret';
 
 const MAX_PHONE_DIGITS = 11;
@@ -12,18 +13,18 @@ function maskSubscriber(subscriber: string): string {
 
   // O traço muda de lugar quando o número passa a ter cara de celular.
   if (subscriber.length > LANDLINE_SUBSCRIBER_LENGTH) {
-    return `${subscriber.slice(0, MOBILE_PREFIX_LENGTH)}-${subscriber.slice(MOBILE_PREFIX_LENGTH)}`;
+    return `${firstCharacters(subscriber, MOBILE_PREFIX_LENGTH)}-${subscriber.slice(MOBILE_PREFIX_LENGTH)}`;
   }
 
-  return `${subscriber.slice(0, LANDLINE_PREFIX_LENGTH)}-${subscriber.slice(LANDLINE_PREFIX_LENGTH)}`;
+  return `${firstCharacters(subscriber, LANDLINE_PREFIX_LENGTH)}-${subscriber.slice(LANDLINE_PREFIX_LENGTH)}`;
 }
 
 /** Formata `(00) 0000-0000` ou `(00) 00000-0000`, conforme o comprimento. */
 export function maskPhone(value: string): string {
-  const digits = onlyDigits(value).slice(0, MAX_PHONE_DIGITS);
+  const digits = firstCharacters(onlyDigits(value), MAX_PHONE_DIGITS);
 
-  if (digits.length === 0) return '';
+  if (digits === '') return '';
   if (digits.length <= AREA_CODE_LENGTH) return `(${digits}`;
 
-  return `(${digits.slice(0, AREA_CODE_LENGTH)}) ${maskSubscriber(digits.slice(AREA_CODE_LENGTH))}`;
+  return `(${firstCharacters(digits, AREA_CODE_LENGTH)}) ${maskSubscriber(digits.slice(AREA_CODE_LENGTH))}`;
 }

--- a/FateConnect/Web/src/utils/masks/zipCodeMask.ts
+++ b/FateConnect/Web/src/utils/masks/zipCodeMask.ts
@@ -1,3 +1,4 @@
+import { firstCharacters } from '../sequence';
 import { onlyDigits } from './caret';
 
 const MAX_ZIP_DIGITS = 8;
@@ -5,9 +6,9 @@ const PREFIX_LENGTH = 5;
 
 /** Formata `00000-000`. */
 export function maskZipCode(value: string): string {
-  const digits = onlyDigits(value).slice(0, MAX_ZIP_DIGITS);
+  const digits = firstCharacters(onlyDigits(value), MAX_ZIP_DIGITS);
 
   if (digits.length <= PREFIX_LENGTH) return digits;
 
-  return `${digits.slice(0, PREFIX_LENGTH)}-${digits.slice(PREFIX_LENGTH)}`;
+  return `${firstCharacters(digits, PREFIX_LENGTH)}-${digits.slice(PREFIX_LENGTH)}`;
 }

--- a/FateConnect/Web/src/utils/sequence.ts
+++ b/FateConnect/Web/src/utils/sequence.ts
@@ -1,0 +1,9 @@
+const SEQUENCE_START = 0;
+
+export function firstCharacters(value: string, count: number): string {
+  return value.slice(SEQUENCE_START, count);
+}
+
+export function firstItems<Item>(list: readonly Item[], count: number): Item[] {
+  return list.slice(SEQUENCE_START, count);
+}

--- a/FateConnect/Web/src/utils/whatsapp.ts
+++ b/FateConnect/Web/src/utils/whatsapp.ts
@@ -14,7 +14,7 @@ const NON_DIGIT = /\D/g;
  * fora antes de montar o endereço.
  */
 export function whatsappConversationUrl(phone: string, message: string): string {
-  const digits = phone.replace(NON_DIGIT, '');
+  const digits = phone.replaceAll(NON_DIGIT, '');
   const text = encodeURIComponent(message);
 
   return `${CONVERSATION_URL}/${COUNTRY_CODE}${digits}?text=${text}`;

--- a/FateConnect/Web/yarn.lock
+++ b/FateConnect/Web/yarn.lock
@@ -367,14 +367,14 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
-"@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
+"@eslint-community/eslint-utils@^4.10.1", "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz#8911bd72b2c3640a543609e0400b8c4d2e7e7cb6"
   integrity sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
-"@eslint-community/regexpp@^4.12.1", "@eslint-community/regexpp@^4.12.2":
+"@eslint-community/regexpp@^4.12.1", "@eslint-community/regexpp@^4.12.2", "@eslint-community/regexpp@^4.8.0":
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
   integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
@@ -401,6 +401,14 @@
   integrity sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==
   dependencies:
     "@types/json-schema" "^7.0.15"
+
+"@eslint/css-tree@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@eslint/css-tree/-/css-tree-4.0.5.tgz#30a81ea6a4f65cbc4c4efd3efd45c77e23d5b77a"
+  integrity sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==
+  dependencies:
+    mdn-data "2.29.0"
+    source-map-js "^1.2.1"
 
 "@eslint/eslintrc@^3.3.6":
   version "3.3.6"
@@ -1622,7 +1630,7 @@ brace-expansion@^5.0.8:
   dependencies:
     balanced-match "^4.0.2"
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, browserslist@^4.28.7, browserslist@^4.28.8:
   version "4.28.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.8.tgz#a3c79ceb70028527e5da7dafc887f3200b5168c0"
   integrity sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==
@@ -1632,6 +1640,21 @@ browserslist@^4.24.0:
     electron-to-chromium "^1.5.402"
     node-releases "^2.0.53"
     update-browserslist-db "^1.3.0"
+
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
+
+builtin-modules@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-5.3.0.tgz#cfe8438bb14d799995ef5b20275f65e446fd0d7e"
+  integrity sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==
+
+bytes@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -1687,6 +1710,16 @@ chalk@^5.4.1:
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
+change-case@^5.4.4:
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-5.4.4.tgz#0d52b507d8fb8f204343432381d1a6d7bff97a02"
+  integrity sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==
+
+ci-info@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
+
 cli-width@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
@@ -1740,6 +1773,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+convert-hrtime@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/convert-hrtime/-/convert-hrtime-5.0.0.tgz#f2131236d4598b95de856926a67100a0a97e9fa3"
+  integrity sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==
+
 convert-source-map@^1.5.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
@@ -1759,6 +1797,13 @@ cookie@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
+
+core-js-compat@^3.50.0:
+  version "3.50.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.50.0.tgz#d5922c2a692ab1cba6078c920e7c5567421ae08e"
+  integrity sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==
+  dependencies:
+    browserslist "^4.28.7"
 
 cosmiconfig@^7.0.0:
   version "7.1.0"
@@ -1887,6 +1932,11 @@ dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-indent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-7.0.2.tgz#16c516bf75d4b2f759f68214554996d467c8d648"
+  integrity sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==
 
 detect-libc@^2.0.3:
   version "2.1.2"
@@ -2212,6 +2262,51 @@ eslint-plugin-react@^7.37.5:
     string.prototype.matchall "^4.0.12"
     string.prototype.repeat "^1.0.0"
 
+eslint-plugin-sonarjs@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz#34fb67be392c3f49875ce5405e02d62f2f860304"
+  integrity sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==
+  dependencies:
+    "@eslint-community/regexpp" "^4.12.2"
+    builtin-modules "^3.3.0"
+    bytes "^3.1.2"
+    functional-red-black-tree "^1.0.1"
+    globals "^17.7.0"
+    jsx-ast-utils-x "^0.1.0"
+    lodash.merge "^4.6.2"
+    minimatch "^10.2.5"
+    scslre "^0.3.0"
+    semver "^7.8.5"
+    ts-api-utils "^2.5.0"
+    typescript ">=5 <6.1.0"
+    yaml "^2.9.0"
+
+eslint-plugin-unicorn@^74.0.0:
+  version "74.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-74.0.0.tgz#9b423103108d404971f8730816c9fc14182a97ae"
+  integrity sha512-AGnsGi2SxHg1HEAXxn9nSnZfyjvTWkxm8E8hpd/9tD6dLjBUdcD7+D6ZN64HmmCXTSXlrwVyUqe20Uyb2CaurA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.10.1"
+    "@eslint/css-tree" "^4.0.5"
+    browserslist "^4.28.8"
+    change-case "^5.4.4"
+    ci-info "^4.4.0"
+    core-js-compat "^3.50.0"
+    detect-indent "^7.0.2"
+    entities "^8.0.0"
+    find-up-simple "^1.0.1"
+    globals "^17.11.0"
+    indent-string "^5.0.0"
+    is-builtin-module "^5.0.0"
+    is-identifier "^1.1.0"
+    pluralize "^8.0.0"
+    quote-js-string "^0.1.0"
+    regjsparser "^0.13.2"
+    reserved-identifiers "^1.2.0"
+    semver "^7.8.5"
+    strip-indent "^4.1.1"
+    yaml "^2.9.0"
+
 eslint-scope@^8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.4.0.tgz#88e646a207fad61436ffa39eb505147200655c82"
@@ -2376,6 +2471,11 @@ find-root@^1.1.0:
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
+find-up-simple@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/find-up-simple/-/find-up-simple-1.0.1.tgz#18fb90ad49e45252c4d7fca56baade04fa3fca1e"
+  integrity sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==
+
 find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -2430,6 +2530,11 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+function-timeout@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/function-timeout/-/function-timeout-1.0.2.tgz#e5a7b6ffa523756ff20e1231bbe37b5f373aadd5"
+  integrity sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==
+
 function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.2.0.tgz#758f3e84fa542672454bd5e14cb081a5ce07f70c"
@@ -2444,6 +2549,11 @@ function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
     hasown "^2.0.4"
     is-callable "^1.2.7"
     is-document.all "^1.0.0"
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
 
 functions-have-names@^1.2.3:
   version "1.2.3"
@@ -2526,7 +2636,7 @@ globals@^14.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-14.0.0.tgz#898d7413c29babcf6bafe56fcadded858ada724e"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
-globals@^17.11.0:
+globals@^17.11.0, globals@^17.7.0:
   version "17.11.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-17.11.0.tgz#d643485bb30220d7751e511cf4f68c73d3870d87"
   integrity sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==
@@ -2644,6 +2754,13 @@ https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
     agent-base "6"
     debug "4"
 
+identifier-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/identifier-regex/-/identifier-regex-1.1.0.tgz#042abfaf28db15223436661f3b9ec882649f6ef0"
+  integrity sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==
+  dependencies:
+    reserved-identifiers "^1.0.0"
+
 ignore@^5.2.0:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -2671,6 +2788,11 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 internal-slot@^1.1.0:
   version "1.1.0"
@@ -2720,6 +2842,13 @@ is-boolean-object@^1.2.1:
   dependencies:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
+
+is-builtin-module@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-5.0.0.tgz#19df4b9c7451149b68176b0e06d18646db6308dd"
+  integrity sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==
+  dependencies:
+    builtin-modules "^5.0.0"
 
 is-callable@^1.2.7:
   version "1.2.7"
@@ -2791,6 +2920,14 @@ is-glob@^4.0.0, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-identifier@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-identifier/-/is-identifier-1.1.0.tgz#6b406e15a429f7196f6496e09f8333bcb4b2db1b"
+  integrity sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==
+  dependencies:
+    identifier-regex "^1.1.0"
+    super-regex "^1.1.0"
 
 is-map@^2.0.3:
   version "2.0.3"
@@ -2974,7 +3111,7 @@ jsdom@^29.1.1:
     whatwg-url "^16.0.1"
     xml-name-validator "^5.0.0"
 
-jsesc@^3.0.2:
+jsesc@^3.0.2, jsesc@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
@@ -3003,6 +3140,11 @@ json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsx-ast-utils-x@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz#b0933d66a69e0aa1ae23f74fb87b079ec298652f"
+  integrity sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"
@@ -3183,6 +3325,15 @@ magicast@^0.5.2:
     "@babel/types" "^7.29.7"
     source-map-js "^1.2.1"
 
+make-asynchronous@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/make-asynchronous/-/make-asynchronous-1.1.0.tgz#6225f7f1ccaab9acaac5e2fcd0b075afefff19aa"
+  integrity sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==
+  dependencies:
+    p-event "^6.0.0"
+    type-fest "^4.6.0"
+    web-worker "^1.5.0"
+
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -3199,6 +3350,11 @@ mdn-data@2.27.1:
   version "2.27.1"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
   integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
+
+mdn-data@2.29.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.29.0.tgz#7f1ffe95753a1883e1146b2af9cee2772a793bc9"
+  integrity sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -3217,7 +3373,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^10.2.2, "minimatch@^9.0.3 || ^10.1.2":
+minimatch@^10.2.2, minimatch@^10.2.5, "minimatch@^9.0.3 || ^10.1.2":
   version "10.2.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
   integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
@@ -3409,6 +3565,13 @@ own-keys@^1.0.1:
     object-keys "^1.1.1"
     safe-push-apply "^1.0.0"
 
+p-event@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/p-event/-/p-event-6.0.1.tgz#8f62a1e3616d4bc01fce3abda127e0383ef4715b"
+  integrity sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==
+  dependencies:
+    p-timeout "^6.1.2"
+
 p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
@@ -3422,6 +3585,11 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-timeout@^6.1.2:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-6.1.4.tgz#418e1f4dd833fa96a2e3f532547dd2abdb08dbc2"
+  integrity sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -3495,6 +3663,11 @@ picomatch@^4.0.3, picomatch@^4.0.4, picomatch@^4.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 possible-typed-array-names@^1.0.0, possible-typed-array-names@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
@@ -3564,6 +3737,11 @@ punycode@^2.1.0, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
+quote-js-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/quote-js-string/-/quote-js-string-0.1.0.tgz#812aef957a2dfb31d32f0d9e9662fe558bc9842b"
+  integrity sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==
+
 react-dom@^19.2.8:
   version "19.2.8"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.8.tgz#3b46b9eeda877cdff2cf13d2770fff4ae36c2ec2"
@@ -3621,6 +3799,13 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+refa@^0.12.0, refa@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/refa/-/refa-0.12.1.tgz#dac13c4782dc22b6bae6cce81a2b863888ea39c6"
+  integrity sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==
+  dependencies:
+    "@eslint-community/regexpp" "^4.8.0"
+
 reflect.getprototypeof@^1.0.10, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz#c629219e78a3316d8b604c765ef68996964e7bf9"
@@ -3635,6 +3820,14 @@ reflect.getprototypeof@^1.0.10, reflect.getprototypeof@^1.0.9:
     get-proto "^1.0.1"
     which-builtin-type "^1.2.1"
 
+regexp-ast-analysis@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz#c0e24cb2a90f6eadd4cbaaba129317e29d29c482"
+  integrity sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==
+  dependencies:
+    "@eslint-community/regexpp" "^4.8.0"
+    refa "^0.12.1"
+
 regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
@@ -3646,6 +3839,13 @@ regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
     get-proto "^1.0.1"
     gopd "^1.2.0"
     set-function-name "^2.0.2"
+
+regjsparser@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.13.2.tgz#f654734b5c588b22ba3e21693b30523417180808"
+  integrity sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==
+  dependencies:
+    jsesc "~3.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -3661,6 +3861,11 @@ reselect@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.2.0.tgz#f380ef7664332d26ea06c1cba04bdbbdcaa955f1"
   integrity sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==
+
+reserved-identifiers@^1.0.0, reserved-identifiers@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz#d2982cd698e317dd3dced1ee1c52412dbd64fc64"
+  integrity sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -3763,12 +3968,21 @@ scheduler@^0.27.0:
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
+scslre@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/scslre/-/scslre-0.3.0.tgz#c3211e9bfc5547fc86b1eabaa34ed1a657060155"
+  integrity sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==
+  dependencies:
+    "@eslint-community/regexpp" "^4.8.0"
+    refa "^0.12.0"
+    regexp-ast-analysis "^0.7.0"
+
 semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.3, semver@^7.7.2, semver@^7.7.3:
+semver@^7.5.3, semver@^7.7.2, semver@^7.7.3, semver@^7.8.5:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -4011,6 +4225,11 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
+strip-indent@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-4.1.1.tgz#aba13de189d4ad9a17f6050e76554ac27585c7af"
+  integrity sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==
+
 strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -4020,6 +4239,15 @@ stylis@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
+
+super-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/super-regex/-/super-regex-1.1.0.tgz#14b69b6374f7b3338db52ecd511dae97c27acf75"
+  integrity sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==
+  dependencies:
+    function-timeout "^1.0.1"
+    make-asynchronous "^1.0.1"
+    time-span "^5.1.0"
 
 supports-color@^7.1.0:
   version "7.2.0"
@@ -4049,6 +4277,13 @@ tagged-tag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
   integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
+
+time-span@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/time-span/-/time-span-5.1.0.tgz#80c76cf5a0ca28e0842d3f10a4e99034ce94b90d"
+  integrity sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==
+  dependencies:
+    convert-hrtime "^5.0.0"
 
 tinybench@^2.9.0:
   version "2.9.0"
@@ -4121,6 +4356,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-fest@^4.6.0:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
 type-fest@^5.5.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-5.8.0.tgz#6d517998257c33159db4d4da6f18efa33bd47df3"
@@ -4183,7 +4423,7 @@ typescript-eslint@^8.67.0:
     "@typescript-eslint/typescript-estree" "8.67.0"
     "@typescript-eslint/utils" "8.67.0"
 
-typescript@^6.0.3:
+"typescript@>=5 <6.1.0", typescript@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
@@ -4320,6 +4560,11 @@ w3c-xmlserializer@^5.0.0:
   integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
   dependencies:
     xml-name-validator "^5.0.0"
+
+web-worker@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.5.0.tgz#71b2b0fbcc4293e8f0aa4f6b8a3ffebff733dcc5"
+  integrity sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Objetivo

Achado do Sonar aparecia **depois** de o PR estar aberto, porque nem o `yarn lint` nem o `dotnet build` conheciam as regras que a análise aplica. Este PR fecha essa distância nos dois lados e corrige o que a fiação nova acendeu.

Nasceu como um PR só de regras, e cresceu quando a pergunta "dá para pegar isso antes?" teve resposta medida.

## O front

**`eslint-plugin-sonarjs` recomendado + duas regras do `eslint-plugin-unicorn`** — as que o Sonar toma emprestadas (`S7758` e `S7781`). A configuração recomendada do unicorn ficou de fora com o motivo escrito na config: traria **745 violações** de opinião de estilo que este repo contraria de propósito, como nome de arquivo em PascalCase e `null` no contrato da API.

Dos 12 achados, **um era defeito** — `replace(/\D/g, …)` em `whatsapp.ts` — e onze eram atrito, cada um desligado no seu recorte e com o motivo ao lado: `todo-tag` (aqui `TODO` é convenção com a issue ao lado), `no-hardcoded-passwords` (só em teste — senha de fixture não é segredo) e `function-return-type` (só em `.tsx` — componente devolve `null` ou nós conforme o estado).

**`no-magic-numbers` perdeu o `ignore: [0, 1, -1]`.** Eram justamente eles que passavam. As 60 ocorrências se resolveram de três formas:

- **eliminando o número** — `value.length === 0` virou `value === ''`, que diz o mesmo sem contar caracteres;
- **centralizando** — o `slice(0, N)` aparecia em oito arquivos; uma constante em cada seria duplicação, então virou `utils/sequence.ts`, e o `0` existe **uma vez** em todo o front;
- **batizando** as 16 restantes com nomes que dizem o **significado**, não o valor: `JANUARY`, `SINGLE_PAGE`, `HASH_MARK_LENGTH`, `AFTER_DIGIT`, `ABSENT_CHANNEL`.

## O back

**`SonarAnalyzer.CSharp` referenciado pelos dois projetos.** Com `TreatWarningsAsErrors` ligado, o que o analisador aponta vira **erro de compilação** — ligar o pacote reprovou o build em **9 achados**, todos corrigidos aqui.

⚠️ **Um deles era defeito de verdade, e está no CHANGELOG:** seis eram `S6964`, *under-posting* — campo de tipo-valor sem `required`. No cadastro, **omitir `dataNascimento` respondia `201 Created`** e gravava `01/01/0001`. Agora responde 400.

Nas caronas o mesmo `required` **não muda comportamento**: o domínio já recusava vagas fora de 1–7, data no passado e tipo indefinido. Provei isso desfazendo a correção e rodando o teste — ele passava dos dois jeitos, então não serve de rede. O teste que ficou é o do cadastro, que **distingue**: com `required` dá 400, sem ele dá 201.

⚠️ **`Program` não pode virar `static`** para satisfazer o `S1118`: `WebApplicationFactory<Program>` a usa como argumento genérico. O construtor privado resolve.

**Custo no build:** +0,17s no mínimo de 5 compilações completas (0,94 → 1,11s). Num job de CI que leva minutos, some. É relógio, não instrumentação — a variação entre execuções é da mesma ordem.

## Regras e documentação

Três lições viraram rule — os idiomas de string que o lint deixava passar, o analisador do C#, e o hábito de encher de comentário logo depois de uma limpeza. Mais duas convenções que só existiam na sua cabeça até você corrigir as minhas edições: **constante de módulo mora no topo** e **o nome diz o significado, não o valor**.

A varredura da documentação achou quatro afirmações que esta rodada matou — duas em `web-styling.md` e **duas no próprio `eslint.config.js` que eu editei sem reler os comentários vizinhos**. E uma contradição anterior no `CONTRIBUTING.md`: "Erro reprova. Warning não", quatro linhas depois de dizer que a compilação reprova por aviso. Aviso reprova nos dois lados — `--max-warnings=0` no front, `TreatWarningsAsErrors` na API.

## Evidências
