### PR TITLE
chore: gate the api in the local hooks and fix the node they run with

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,7 +48,7 @@ dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln
 git config core.hooksPath .githooks     # habilita os hooks deste clone
 ```
 
-O `pre-push` roda só os testes **relacionados** aos arquivos enviados (via `FateConnect/Web/scripts/test-changed.sh`); a suíte inteira com cobertura fica no CI.
+O `pre-commit` conserta o front com o Node do `.nvmrc` e compila a API; o `pre-push` roda os testes **relacionados** aos arquivos enviados (via `FateConnect/Web/scripts/test-changed.sh`) e a suíte da API. Cada bloco só roda se a mudança o alcança, e a suíte inteira com cobertura fica no CI.
 
 ## Stack do front
 

--- a/.claude/rules/dotnet-code-quality.md
+++ b/.claude/rules/dotnet-code-quality.md
@@ -7,7 +7,7 @@ paths:
 
 # Qualidade do C# — o analisador roda no build
 
-Os dois projetos referenciam o `SonarAnalyzer.CSharp`, então as regras que o Sonar aplica no PR rodam também no `dotnet build`, na sua máquina e no CI.
+Os dois projetos referenciam o `SonarAnalyzer.CSharp`, então as regras que o Sonar aplica no PR rodam também no `dotnet build`, na sua máquina e no CI. Na sua máquina isso acontece sem você pedir: o `pre-commit` roda essa build quando o commit toca a API.
 
 ⛔ **Elas reprovam a compilação, não avisam.** O `.csproj` liga `TreatWarningsAsErrors`, e o que o analisador aponta vira **erro**. Build quebrado por `S6964` não é infraestrutura com defeito: é achado esperando correção.
 

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -51,6 +51,13 @@ De `FateConnect/Web`, com o Node do `.nvmrc`:
 ./node_modules/.bin/vitest run <caminho afetado>
 ```
 
+Mexeu na API, da raiz do repositório:
+
+```bash
+dotnet build FateConnect/FateConnect.Api/FateConnect.Api.sln
+dotnet test FateConnect/FateConnect.Api/FateConnect.Api.sln --no-build
+```
+
 Erro reprova; warning se ignora. Não reporte como pronto com erro de pé.
 
 ## 6. Commit — peça confirmação antes

--- a/.claude/skills/write-review-comment/SKILL.md
+++ b/.claude/skills/write-review-comment/SKILL.md
@@ -77,7 +77,9 @@ Aconteceu **três vezes no mesmo PR**, o #186, sempre pelo mesmo gesto meu:
 
 ⛔ **Afirmação sobre dado, contagem, extensão ou configuração de ambiente exige medição.** Escrevi que uma migração deixaria as caronas órfãs e que a tela ficaria vazia em produção — os bancos não tinham uma linha. No mesmo review, medir transformou um achado hipotético sobre `unaccent` no defeito mais grave da rodada: o filtro por destino já respondia 500 em produção.
 
-⛔ **Meça no ambiente que o projeto usa, não no seu.** No PR #186 eu publiquei que a API não compilava, com a saída do `dotnet build` na mão. Ela compilava: o meu SDK era o 10 e o projeto tem como alvo o `net8.0`, cujo `sdk:8.0` é o que o Dockerfile e a esteira usam. A regra que reprovou nasceu no .NET 9, e o `AnalysisLevel=latest-recommended` liga os analisadores do **SDK instalado**. O autor corrigiu um defeito que não existia para ele.
+⛔ **Meça no ambiente que o projeto usa, não no seu.** No PR #186 publiquei que a API não compilava, com a saída do `dotnet build` na mão; ela compilava, e quem reprovava era um analisador do meu SDK, de outro major — o `AnalysisLevel=latest-recommended` liga os analisadores do **SDK instalado**. O autor corrigiu um defeito que não existia para ele.
+
+O `global.json` fecha essa porta: ele fixa a banda `8.0.x`, e numa máquina com o SDK 10 instalado o `dotnet --version` responde `8.0.424`. Segue derivando o que ele não fixa — ferramenta global, banco, variável de ambiente, versão do Node —, então diga em que ambiente mediu.
 
 **A pergunta antes de publicar:** esta saída viria igual na máquina de quem vai corrigir e no servidor que constrói? Toolchain, versão de runtime e variável de ambiente mudam o veredito, e a saída não avisa qual delas usou.
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,42 +1,62 @@
 #!/usr/bin/env bash
-# Roda lint-staged no front React (FateConnect/Web) sobre os arquivos staged.
+# Roda os gates locais sobre o que está preparado: lint-staged no front React e a
+# build da API .NET, que é quem carrega o SonarAnalyzer.
 # O repo usa core.hooksPath=.githooks (junto dos hooks do git-lfs), por isso não usamos husky:
 # instalar husky reaponta core.hooksPath para .husky e desliga os hooks de LFS.
 set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 WEB="$ROOT/FateConnect/Web"
-
-# Nada staged em Web/ => nada a fazer.
-if ! git diff --cached --name-only --diff-filter=ACMR | grep -q '^FateConnect/Web/.*\.tsx\?$'; then
-  exit 0
-fi
-
-if [[ ! -d "$WEB/node_modules" ]]; then
-  echo "pre-commit: dependências de FateConnect/Web ausentes — rode 'yarn' nessa pasta" >&2
-  exit 1
-fi
-
-cd "$WEB"
-
-NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
-if [[ -s "$NVM_SH" ]]; then
-  # `nvm.sh` não sobrevive a `set -eu`.
-  set +eu
-  # shellcheck source=/dev/null
-  . "$NVM_SH"
-  nvm use >/dev/null
-  set -eu
-fi
-
+API_SOLUTION="$ROOT/FateConnect/FateConnect.Api/FateConnect.Api.sln"
 MIN_NODE_MAJOR=22
-NODE_VERSION="$(node -v 2>/dev/null || true)"
-NODE_MAJOR="${NODE_VERSION#v}"
-NODE_MAJOR="${NODE_MAJOR%%.*}"
 
-if (( ${NODE_MAJOR:-0} < MIN_NODE_MAJOR )); then
-  echo "pre-commit: o ESLint precisa do Node $MIN_NODE_MAJOR ou maior; o ativo é ${NODE_VERSION:-nenhum} — rode 'nvm use' em FateConnect/Web" >&2
-  exit 1
+staged="$(git diff --cached --name-only --diff-filter=ACMR)"
+
+if grep -q '^FateConnect/Web/.*\.tsx\?$' <<< "$staged"; then
+  # Subshell: o `cd` e o estado que o `nvm` deixa não vazam para o gate da API.
+  (
+    if [[ ! -d "$WEB/node_modules" ]]; then
+      echo "pre-commit: dependências de FateConnect/Web ausentes — rode 'yarn' nessa pasta" >&2
+      exit 1
+    fi
+
+    cd "$WEB"
+
+    NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+    if [[ -s "$NVM_SH" ]]; then
+      # `nvm.sh` não sobrevive a `set -eu`.
+      set +eu
+      # shellcheck source=/dev/null
+      . "$NVM_SH"
+      nvm use >/dev/null
+      set -eu
+    fi
+
+    node_version="$(node -v 2>/dev/null || true)"
+    node_major="${node_version#v}"
+    node_major="${node_major%%.*}"
+
+    if (( ${node_major:-0} < MIN_NODE_MAJOR )); then
+      echo "pre-commit: o ESLint precisa do Node $MIN_NODE_MAJOR ou maior; o ativo é ${node_version:-nenhum} — rode 'nvm use' em FateConnect/Web" >&2
+      exit 1
+    fi
+
+    npx --no-install lint-staged
+  )
 fi
 
-npx --no-install lint-staged
+if grep -q '^FateConnect/FateConnect\.Api' <<< "$staged"; then
+  # Cobre as duas causas: dotnet fora do PATH e SDK que o global.json não aceita.
+  if ! dotnet --version >/dev/null 2>&1; then
+    echo "pre-commit: nenhum SDK .NET utilizável — confira o PATH e a versão que o global.json declara" >&2
+    exit 1
+  fi
+
+  # A build é ruidosa mesmo em `--verbosity quiet`: só interessa quando reprova.
+  if ! output="$(dotnet build "$API_SOLUTION" --nologo --verbosity quiet 2>&1)"; then
+    echo "$output" >&2
+    exit 1
+  fi
+
+  echo "pre-commit: API compila."
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,4 +18,25 @@ if [[ ! -d "$WEB/node_modules" ]]; then
 fi
 
 cd "$WEB"
+
+NVM_SH="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+if [[ -s "$NVM_SH" ]]; then
+  # `nvm.sh` não sobrevive a `set -eu`.
+  set +eu
+  # shellcheck source=/dev/null
+  . "$NVM_SH"
+  nvm use >/dev/null
+  set -eu
+fi
+
+MIN_NODE_MAJOR=22
+NODE_VERSION="$(node -v 2>/dev/null || true)"
+NODE_MAJOR="${NODE_VERSION#v}"
+NODE_MAJOR="${NODE_MAJOR%%.*}"
+
+if (( ${NODE_MAJOR:-0} < MIN_NODE_MAJOR )); then
+  echo "pre-commit: o ESLint precisa do Node $MIN_NODE_MAJOR ou maior; o ativo é ${NODE_VERSION:-nenhum} — rode 'nvm use' em FateConnect/Web" >&2
+  exit 1
+fi
+
 npx --no-install lint-staged

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Roda os testes do front que estão relacionados ao que está sendo enviado.
+# Roda os testes do que está sendo enviado: o recorte do front React e a suíte da
+# API .NET.
 # Habilitar neste clone: git config core.hooksPath .githooks
 #
 # `scripts/test-changed.sh` segue o grafo de imports com `vitest related`, então
@@ -9,6 +10,7 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 WEB="$ROOT/FateConnect/Web"
+API_SOLUTION="$ROOT/FateConnect/FateConnect.Api/FateConnect.Api.sln"
 
 # Ref vazia (branch sendo deletada) vem como SHA de zeros.
 EMPTY_SHA="$(git hash-object --stdin </dev/null | tr '0-9a-f' '0')"
@@ -41,14 +43,34 @@ done
 
 sort -u -o "$changed" "$changed"
 
-if ! grep -q '^FateConnect/Web/' "$changed"; then
-  echo "pre-push: nada em FateConnect/Web — nada a testar."
-  exit 0
+tested=0
+
+if grep -q '^FateConnect/Web/' "$changed"; then
+  if [ ! -d "$WEB/node_modules" ]; then
+    echo "pre-push: dependências de FateConnect/Web ausentes — rode 'yarn' nessa pasta" >&2
+    exit 1
+  fi
+
+  grep '^FateConnect/Web/' "$changed" | tr '\n' '\0' | xargs -0 "$WEB/scripts/test-changed.sh"
+  tested=1
 fi
 
-if [ ! -d "$WEB/node_modules" ]; then
-  echo "pre-push: dependências de FateConnect/Web ausentes — rode 'yarn' nessa pasta" >&2
-  exit 1
+if grep -q '^FateConnect/FateConnect\.Api' "$changed"; then
+  # Cobre as duas causas: dotnet fora do PATH e SDK que o global.json não aceita.
+  if ! dotnet --version >/dev/null 2>&1; then
+    echo "pre-push: nenhum SDK .NET utilizável — confira o PATH e a versão que o global.json declara" >&2
+    exit 1
+  fi
+
+  if ! output="$(dotnet test "$API_SOLUTION" --nologo --verbosity quiet 2>&1)"; then
+    echo "$output" >&2
+    exit 1
+  fi
+
+  grep '^Passed!' <<< "$output" || echo "pre-push: API sem teste executado."
+  tested=1
 fi
 
-grep '^FateConnect/Web/' "$changed" | tr '\n' '\0' | xargs -0 "$WEB/scripts/test-changed.sh"
+if [ "$tested" -eq 0 ]; then
+  echo "pre-push: nada em FateConnect/Web nem na API — nada a testar."
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Os hooks locais **não vêm habilitados no clone** — o repositório usa `core.
 git config core.hooksPath .githooks
 ```
 
-O `pre-push` roda só os testes relacionados aos arquivos enviados. A suíte inteira com cobertura fica no CI.
+O `pre-commit` conserta o que dá no front — `eslint --fix` e `prettier --write` sobre o que está preparado — e compila a API quando a mudança a alcança, que é a build por onde entra o SonarAnalyzer. O `pre-push` roda o recorte de testes do front relacionado ao que está sendo enviado e a suíte da API. A suíte inteira com cobertura fica no CI.
 
 ## Branch e commit
 

--- a/FateConnect/Web/README.md
+++ b/FateConnect/Web/README.md
@@ -108,7 +108,7 @@ Use o `render` de `@app/test/testing-library`, que já monta tema, rotas e cache
 | `pre-push`   | só os testes **relacionados** aos arquivos enviados | —         |
 | CI (no PR)   | tipos, lint, **suíte inteira**, build e Sonar        | mede      |
 
-⚠️ O hook roda com o Node do seu shell, não com o do `.nvmrc`. Num Node anterior ao 22 ele falha com `mapTypes.union is not a function`, que é uma regra de lint usando `Set.prototype.union` — a saída é `nvm use` antes de commitar.
+⚠️ O `pre-commit` carrega o Node do `.nvmrc` por conta própria, porque uma regra de lint usa `Set.prototype.union` e o ESLint quebra em qualquer Node anterior ao 22. Sem `nvm` na máquina ele não tem como trocar: aí reprova o commit dizendo qual versão está ativa.
 
 O `pre-push` usa `scripts/test-changed.sh`, que segue o grafo de imports com `vitest related`: mudar uma tela roda os testes que a alcançam, não a suíte inteira. Ele cai na suíte inteira quando a mudança sai de `src/` ou remove arquivo — nesses casos o grafo não alcança o efeito, e `vitest related vite.config.ts` sairia com sucesso sem rodar teste nenhum.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ FateConnect/
   FateConnect.Api.Tests/  suíte xUnit da API, pasta irmã e não filha
 .claude/                  contexto que um agente de código carrega ao trabalhar aqui
 .github/workflows/        validação de PR e criação da tag de release
-.githooks/                hooks locais de lint e teste
+.githooks/                hooks locais de lint, build e teste
 deploy/                   publicação em homologação e produção → deploy/README.md
 scripts/                  scripts de manutenção do repositório
 ESII/  ESIII/  LBD/       documentos das disciplinas, versionados por entrega


### PR DESCRIPTION
## Objetivo

Os hooks locais só olhavam para o front, e o do commit rodava com o Node do shell — num Node anterior ao 22 o ESLint quebrava em `mapTypes.union is not a function`, porque uma regra usa `Set.prototype.union`. Este PR conserta isso e estende os dois hooks à API .NET, para que erro de compilação e achado do SonarAnalyzer apareçam no commit, e não só na análise do PR.

## Alterações

**`pre-commit`**

- Carrega o Node do `.nvmrc` quando há `nvm` na máquina; sem `nvm`, reprova dizendo qual versão está ativa em vez de deixar o ESLint estourar.
- Roda `dotnet build` da solution quando o commit prepara arquivo sob `FateConnect/FateConnect.Api*`. Silencioso no verde; no vermelho, a saída inteira.

**`pre-push`**

- Roda `dotnet test` da solution quando o push leva arquivo dessas pastas, imprimindo só a linha `Passed!`. Sem cobertura — ela segue no CI.
- O bloco do front continua no recorte por `vitest related`.

Cada bloco só roda se a mudança o alcança. A pré-condição dos dois é `dotnet --version`, que cobre as duas causas de falha — `dotnet` fora do `PATH` e SDK que o `global.json` não aceita — sem deixar aparecer a mensagem crua da ferramenta.

**Documentação e harness**

- `README.md`, `CONTRIBUTING.md`, `FateConnect/Web/README.md` e `.claude/CLAUDE.md` passam a descrever os hooks nos dois lados.
- `.claude/rules/dotnet-code-quality.md` registra que a build local acontece no commit.
- `.claude/skills/resolve-pr-comments/SKILL.md` ganha o gate de C#, que faltava para review de PR da API.
- `.claude/skills/write-review-comment/SKILL.md` descrevia uma deriva de SDK que o `global.json` já fecha.

## Custo medido

| Comando | Tempo |
| --- | --- |
| `dotnet build` incremental | 1s |
| `dotnet build` frio | 5s |
| `dotnet test` | 2s |
| `dotnet --version` (pré-condição) | 99ms |

## Como foi verificado

Os hooks foram executados de verdade, no bash 3.2 do macOS, que é o que o `env bash` resolve aqui.

| Cenário | Resultado |
| --- | --- |
| C# válido preparado | `pre-commit: API compila.` |
| Variável local não usada | `error S1481` do SonarAnalyzer + `CS0219`, exit 1 |
| Front com o shell em Node 20 | ESLint e prettier rodam |
| Front sem `nvm` disponível | mensagem pedindo `nvm use`, exit 1 |
| SDK que o `global.json` não aceita | mensagem sobre `PATH` e `global.json`, exit 1 |
| Push só da API | `Passed!` |
| Push de front e API | os dois gates rodam |
| Push de nenhum dos dois | `nada a testar`, exit 0 |

O caso do `S1481` é o que justifica a build no commit: esse achado, antes, só aparecia na análise do PR.

## Ressalva

O `lint-staged` isola o índice antes de rodar, mas `dotnet build` e `dotnet test` compilam a **árvore de trabalho**. Com staging parcial, o gate da API mede um estado que não é o do commit. O `pre-push` do front já tinha essa propriedade.

## Evidências
