### PR TITLE
fix(214): resolve the entityframeworkcore version conflict in the build

### DIFF
--- a/FateConnect/FateConnect.Api/FateConnect.Api.csproj
+++ b/FateConnect/FateConnect.Api/FateConnect.Api.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Objetivo

Zerar o `MSB3277` do build da API. Ele parecia ruído de resolução de referência, mas é um defeito real: **qualquer projeto que consuma o `FateConnect.Api.dll` quebra em runtime.**

```
System.IO.FileNotFoundException: Could not load file or assembly
'Microsoft.EntityFrameworkCore.Relational, Version=8.0.6.0'
```

O consumidor copia `Relational` 8.0.4 — que o `Npgsql` traz e o MSBuild elege por ser primária — enquanto o `FateConnect.Api.dll` foi compilado contra 8.0.6. A API não sofre, porque no build dela a 8.0.6 é a primária. **A suíte também não sofre, e é por isso que ninguém viu: ela roda em `InMemory`, que nunca carrega o `Relational`.** Bastaria um teste relacional para a falha aparecer.

A origem da assimetria é o `Microsoft.EntityFrameworkCore.Design`, única fonte da 8.0.6: ele tem `PrivateAssets=all`, então a exigência não flui para quem consome o projeto.

## Alterações

Uma linha em `FateConnect/FateConnect.Api/FateConnect.Api.csproj`:

```xml
<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
```

Referência direta **flui** para os consumidores, ao contrário do `Design`. Por isso a correção fica na API e não no `.csproj` de teste: vale para todo consumidor, inclusive os que ainda não existem.

## Verificação

Medido contra um **PostgreSQL 17.11**, a mesma versão que a VPS roda:

| O que | Resultado |
| --- | --- |
| `dotnet build --no-incremental` | `0 Warning(s)`, `0 Error(s)` — era `1 Warning(s)` |
| `dotnet test` | 13 testes, todos verdes |
| Versões resolvidas em produção | **inalteradas**: `Relational` 8.0.6, `Npgsql.EntityFrameworkCore.PostgreSQL` 8.0.4, `Npgsql` 8.0.3 |
| SQL das migrations | idêntico byte a byte |
| SQL de runtime das 5 consultas da aplicação | idêntico byte a byte |
| Schema aplicado num Postgres 17.11 | idêntico (`pg_dump --schema-only`) |
| Sonda consumindo o `.dll`, sem correção própria | passou a rodar; antes falhava com `FileNotFoundException` |

O binário publicado não muda: nenhuma versão resolvida na API é diferente da de hoje.

### Alternativas descartadas

| Opção | Por quê não |
| --- | --- |
| Descer a stack EF para 8.0.4 | Rebaixaria em produção o `Relational`, que participa da geração de SQL. Medido como seguro, mas troca binário de produção sem precisar |
| Declarar `Relational` só no `.csproj` de teste | Resolve para a suíte e deixa o próximo consumidor com o mesmo defeito |
| Subir o `Npgsql` | Troca quem gera o SQL — o maior risco dos quatro, e desnecessário aqui |

Sem entrada no `CHANGELOG.md`: nenhum artefato publicado muda de comportamento — o defeito vive no grafo de build e só alcança quem consome o assembly, hoje apenas a suíte.

### Fica em aberto, fora deste PR

A API roda `Npgsql` 8.0.4 sobre EF 8.0.6, par que o autor do `Npgsql` não declara no `nuspec`. Funciona e está medido, mas alinhar isso é subir o provedor do Postgres — merece issue própria, com teste contra o PG 17 real.

## Issue

- #214

Closes #214

## Evidências
