### PR TITLE
fix(208): translate the api messages to pt-BR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Passa a devolver quem ofertou a carona, com nome e contato, e a indicar se ela é de quem consultou (#201) [Backend]
 - Passa a mostrar quem ofertou cada carona, com nome e contato reais, e a reconhecer as suas — com marcação própria e os botões de editar e excluir (#203) [Frontend]
+- Passa a responder os erros da API em português; validação de carona e de cadastro, formato de hora e o erro genérico vinham em inglês (#218) [Backend]
 
 ### Fixed
 

--- a/FateConnect/FateConnect.Api.Tests/GlobalExceptionMiddlewareTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/GlobalExceptionMiddlewareTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Text.Json;
+using FateConnect.Api.Infrastructure.Middlewares;
+using FateConnect.Api.Modules.Auth.Exceptions;
+using FateConnect.Api.Modules.Rides.Exceptions;
+using FateConnect.Api.Modules.Usuarios.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FateConnect.Api.Tests;
+
+public class GlobalExceptionMiddlewareTests
+{
+    private static async Task<(HttpStatusCode StatusCode, string Error)> AnswerFor(Exception thrown)
+    {
+        await using ServiceProvider services = new ServiceCollection().BuildServiceProvider();
+
+        DefaultHttpContext context = new() { RequestServices = services };
+
+        using MemoryStream body = new();
+        context.Response.Body = body;
+
+        GlobalExceptionMiddleware middleware = new(
+            _ => throw thrown,
+            NullLogger<GlobalExceptionMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        body.Position = 0;
+        using JsonDocument document = await JsonDocument.ParseAsync(body);
+
+        return ((HttpStatusCode)context.Response.StatusCode, document.RootElement.GetProperty("error").GetString()!);
+    }
+
+    [Fact]
+    public async Task AnUnmappedException_AnswersTheFallbackMessageInPortuguese()
+    {
+        (HttpStatusCode statusCode, string error) = await AnswerFor(new TimeoutException("connection dropped"));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, statusCode);
+        Assert.Equal("Algo deu errado. Tente novamente.", error);
+    }
+
+    [Fact]
+    public async Task ARideDomainException_AnswersBadRequestWithItsOwnMessage()
+    {
+        (HttpStatusCode statusCode, string error) = await AnswerFor(new InvalidRideTypeException());
+
+        Assert.Equal(HttpStatusCode.BadRequest, statusCode);
+        Assert.Equal("Tipo de carona inválido.", error);
+    }
+
+    [Fact]
+    public async Task ADuplicateEmail_AnswersConflictWithItsOwnMessage()
+    {
+        (HttpStatusCode statusCode, string error) =
+            await AnswerFor(new EmailJaCadastradoException("pessoa@aluno.cps.sp.gov.br"));
+
+        Assert.Equal(HttpStatusCode.Conflict, statusCode);
+        Assert.Equal("O e-mail 'pessoa@aluno.cps.sp.gov.br' já está em uso no sistema.", error);
+    }
+
+    [Fact]
+    public async Task InvalidCredentials_AnswerUnauthorizedWithTheirOwnMessage()
+    {
+        (HttpStatusCode statusCode, string error) = await AnswerFor(new CredenciaisInvalidasException());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, statusCode);
+        Assert.Equal("E-mail ou senha inválido.", error);
+    }
+
+    [Fact]
+    public async Task AMissingJwtSecret_AnswersInternalServerErrorWithItsOwnMessage()
+    {
+        (HttpStatusCode statusCode, string error) = await AnswerFor(new JwtNaoConfiguradoException());
+
+        Assert.Equal(HttpStatusCode.InternalServerError, statusCode);
+        Assert.Equal("JWT_SECRET não configurado.", error);
+    }
+
+    [Fact]
+    public async Task AnUnidentifiedUser_AnswersUnauthorizedInPortuguese()
+    {
+        (HttpStatusCode statusCode, string error) = await AnswerFor(new UnidentifiedUserException());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, statusCode);
+        Assert.Equal("Sessão expirada. Entre novamente para continuar.", error);
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/RideDomainMessagesTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/RideDomainMessagesTests.cs
@@ -1,0 +1,80 @@
+using FateConnect.Api.Modules.Rides.Entities;
+using FateConnect.Api.Modules.Rides.Enums;
+using FateConnect.Api.Modules.Rides.Exceptions;
+
+namespace FateConnect.Api.Tests;
+
+public class RideDomainMessagesTests
+{
+    private static readonly DateOnly FutureDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7));
+    private static readonly TimeOnly DepartureTime = new(8, 30);
+
+    private static Ride CreateRide(
+        int availableSeats = 3,
+        string destination = "Fatec Sorocaba",
+        DateOnly? departureDate = null,
+        EnumRideType rideType = EnumRideType.Solidarity,
+        int driverId = 1) =>
+        new(availableSeats, destination, departureDate ?? FutureDate, DepartureTime, rideType, driverId);
+
+    [Fact]
+    public void ARideInThePast_AnswersTheScheduleMessageInPortuguese()
+    {
+        DateOnly pastDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1));
+
+        InvalidDepartureScheduleException exception = Assert.Throws<InvalidDepartureScheduleException>(
+            () => CreateRide(departureDate: pastDate));
+
+        Assert.Equal("A carona deve ser em data e hora futuras.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(8)]
+    public void ARideWithSeatsOutOfRange_NamesTheReceivedAmountInPortuguese(int seats)
+    {
+        InvalidAvailableSeatsException exception = Assert.Throws<InvalidAvailableSeatsException>(
+            () => CreateRide(availableSeats: seats));
+
+        Assert.Equal($"A carona deve ter entre 1 e 7 vagas. Recebido: {seats}.", exception.Message);
+    }
+
+    [Fact]
+    public void ARideWithAShortDestination_AnswersTheDestinationMessageInPortuguese()
+    {
+        InvalidDestinationException exception = Assert.Throws<InvalidDestinationException>(
+            () => CreateRide(destination: "AB"));
+
+        Assert.Equal("O destino deve ter entre 3 e 100 caracteres.", exception.Message);
+    }
+
+    [Fact]
+    public void ARideWithAnUndefinedType_AnswersTheTypeMessageInPortuguese()
+    {
+        InvalidRideTypeException exception = Assert.Throws<InvalidRideTypeException>(
+            () => CreateRide(rideType: (EnumRideType)99));
+
+        Assert.Equal("Tipo de carona inválido.", exception.Message);
+    }
+
+    [Fact]
+    public void ARideWithoutADriver_AnswersTheDriverMessageInPortuguese()
+    {
+        InvalidRideDriverException exception = Assert.Throws<InvalidRideDriverException>(
+            () => CreateRide(driverId: 0));
+
+        Assert.Equal(
+            "Não foi possível identificar quem está ofertando a carona. Entre novamente.",
+            exception.Message);
+    }
+
+    [Fact]
+    public void ARideOfferedByAnotherPerson_AnswersTheOwnershipMessageInPortuguese()
+    {
+        RideNotDrivenByUserException exception = new();
+
+        Assert.Equal(
+            "Esta carona foi ofertada por outra pessoa. Só quem ofertou pode alterá-la.",
+            exception.Message);
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/TimeOnlyJsonConverterTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/TimeOnlyJsonConverterTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using FateConnect.Api.Infrastructure.Converters;
+
+namespace FateConnect.Api.Tests;
+
+public class TimeOnlyJsonConverterTests
+{
+    private static readonly JsonSerializerOptions Options = BuildOptions();
+
+    private static JsonSerializerOptions BuildOptions()
+    {
+        JsonSerializerOptions options = new();
+        options.Converters.Add(new TimeOnlyJsonConverter());
+
+        return options;
+    }
+
+    [Theory]
+    [InlineData("\"08:30\"", 8, 30, 0)]
+    [InlineData("\"08:30:45\"", 8, 30, 45)]
+    [InlineData("\"08:30:45.1234567\"", 8, 30, 45)]
+    public void Read_WithAnAcceptedFormat_ReturnsTheTime(string json, int hour, int minute, int second)
+    {
+        TimeOnly time = JsonSerializer.Deserialize<TimeOnly>(json, Options);
+
+        Assert.Equal(hour, time.Hour);
+        Assert.Equal(minute, time.Minute);
+        Assert.Equal(second, time.Second);
+    }
+
+    [Fact]
+    public void Read_WithANonStringToken_AsksForTextInPortuguese()
+    {
+        JsonException exception = Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<TimeOnly>("830", Options));
+
+        Assert.Contains(
+            "Formato de hora inválido. Informe a hora como texto, no formato HH:mm ou HH:mm:ss.",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Read_WithAnUnparseableString_NamesTheValueInPortuguese()
+    {
+        JsonException exception = Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<TimeOnly>("\"25:99\"", Options));
+
+        Assert.Contains(
+            "Formato de hora inválido: '25:99'. Informe a hora no formato HH:mm ou HH:mm:ss.",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Write_SerializesTheTimeWithSeconds()
+    {
+        string json = JsonSerializer.Serialize(new TimeOnly(8, 30), Options);
+
+        Assert.Equal("\"08:30:00\"", json);
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/UnderPostingTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/UnderPostingTests.cs
@@ -66,6 +66,6 @@ public class UnderPostingTests : IClassFixture<ApiFactory>
         string body = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Contains("between 1 and 7", body, StringComparison.Ordinal);
+        Assert.Contains("entre 1 e 7 vagas", body, StringComparison.Ordinal);
     }
 }

--- a/FateConnect/FateConnect.Api.Tests/ValidationMessagesTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/ValidationMessagesTests.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+using FateConnect.Api.Modules.Rides.DTOs;
+using FateConnect.Api.Modules.Rides.Enums;
+using FateConnect.Api.Modules.Usuarios.DTOs;
+using FateConnect.Api.Modules.Usuarios.Enums;
+
+namespace FateConnect.Api.Tests;
+
+public class ValidationMessagesTests
+{
+    private static List<ValidationResult> Validate(object model)
+    {
+        List<ValidationResult> results = [];
+        Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true);
+
+        return results;
+    }
+
+    [Fact]
+    public void AnUndefinedRideType_IsRejectedInPortuguese()
+    {
+        List<ValidationResult> results = Validate(new FilterRideDto { RideType = (EnumRideType)99 });
+
+        Assert.Contains(results, result => result.ErrorMessage == "Tipo de carona inválido");
+    }
+
+    [Fact]
+    public void AnUndefinedGender_IsRejectedInPortuguese()
+    {
+        List<ValidationResult> results = Validate(new CreateUsuarioDto
+        {
+            EmailFatec = "pessoa@aluno.cps.sp.gov.br",
+            Senha = "SenhaForte123!",
+            NomeCompleto = "Pessoa de Teste",
+            DataNascimento = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Genero = (EnumGender)99,
+            Enderecos = [],
+            Contatos = [],
+        });
+
+        Assert.Contains(results, result => result.ErrorMessage == "Gênero inválido");
+    }
+}

--- a/FateConnect/FateConnect.Api/Infrastructure/Converters/TimeOnlyJsonConverter.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Converters/TimeOnlyJsonConverter.cs
@@ -21,7 +21,7 @@ public class TimeOnlyJsonConverter : JsonConverter<TimeOnly>
 
         if (isInvalidTokenType)
         {
-            throw new JsonException("Invalid time format: Expected a string in HH:mm or HH:mm:ss format.");
+            throw new JsonException("Formato de hora inválido. Informe a hora como texto, no formato HH:mm ou HH:mm:ss.");
         }
 
         string? stringValue = reader.GetString();
@@ -38,7 +38,7 @@ public class TimeOnlyJsonConverter : JsonConverter<TimeOnly>
             return time;
 
 
-        throw new JsonException($"Invalid time format: '{stringValue}'. Expected HH:mm or HH:mm:ss.");
+        throw new JsonException($"Formato de hora inválido: '{stringValue}'. Informe a hora no formato HH:mm ou HH:mm:ss.");
     }
 
     public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options)

--- a/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
@@ -25,7 +25,7 @@ public partial class GlobalExceptionMiddleware(
     private async Task HandleExceptionAsync(HttpContext context, Exception exception)
     {
         var statusCode = HttpStatusCode.InternalServerError;
-        var errorMessage = "An internal server error occurred.";
+        var errorMessage = "Algo deu errado. Tente novamente.";
 
         switch (exception)
         {
@@ -58,7 +58,7 @@ public partial class GlobalExceptionMiddleware(
         if (statusCode is HttpStatusCode.InternalServerError)
             LogUnhandledError(logger, exception);
         else
-            LogBusinessWarning(logger, (int)statusCode, errorMessage);
+            LogBusinessWarning(logger, (int)statusCode, exception.GetType().Name);
 
         context.Response.ContentType = "application/json";
         context.Response.StatusCode = (int)statusCode;
@@ -69,6 +69,6 @@ public partial class GlobalExceptionMiddleware(
     [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "Unhandled internal server error occurred.")]
     private static partial void LogUnhandledError(ILogger logger, Exception exception);
 
-    [LoggerMessage(EventId = 2, Level = LogLevel.Warning, Message = "Handled error ({StatusCode}): {ErrorMessage}")]
-    private static partial void LogBusinessWarning(ILogger logger, int statusCode, string errorMessage);
+    [LoggerMessage(EventId = 2, Level = LogLevel.Warning, Message = "Handled error ({StatusCode}): {ExceptionType}")]
+    private static partial void LogBusinessWarning(ILogger logger, int statusCode, string exceptionType);
 }

--- a/FateConnect/FateConnect.Api/Modules/Auth/Exceptions/UnidentifiedUserException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Exceptions/UnidentifiedUserException.cs
@@ -1,4 +1,4 @@
 namespace FateConnect.Api.Modules.Auth.Exceptions;
 
 public class UnidentifiedUserException()
-    : Exception("The token does not identify a user.");
+    : Exception("Sessão expirada. Entre novamente para continuar.");

--- a/FateConnect/FateConnect.Api/Modules/Rides/DTOs/FilterRideDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/DTOs/FilterRideDto.cs
@@ -9,6 +9,6 @@ public record FilterRideDto
     public DateOnly? DepartureDate { get; init; }
     public TimeOnly? DepartureTime { get; init; }
 
-    [EnumDataType(typeof(EnumRideType), ErrorMessage = "Invalid ride type.")]
+    [EnumDataType(typeof(EnumRideType), ErrorMessage = "Tipo de carona inválido")]
     public EnumRideType? RideType { get; init; }
 }

--- a/FateConnect/FateConnect.Api/Modules/Rides/Exceptions/RideException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Exceptions/RideException.cs
@@ -3,19 +3,19 @@ namespace FateConnect.Api.Modules.Rides.Exceptions;
 public abstract class RideDomainException(string message) : Exception(message);
 
 public class InvalidDepartureScheduleException()
-    : RideDomainException("The departure date and time must be in the future.");
+    : RideDomainException("A carona deve ser em data e hora futuras.");
 
 public class InvalidAvailableSeatsException(int seats)
-    : RideDomainException($"The number of seats must be between 1 and 7. Received: {seats}.");
+    : RideDomainException($"A carona deve ter entre 1 e 7 vagas. Recebido: {seats}.");
 
 public class InvalidDestinationException()
-    : RideDomainException("The destination must contain between 3 and 100 characters.");
+    : RideDomainException("O destino deve ter entre 3 e 100 caracteres.");
 
 public class InvalidRideTypeException()
-    : RideDomainException("Invalid ride type.");
+    : RideDomainException("Tipo de carona inválido.");
 
 public class InvalidRideDriverException()
-    : RideDomainException("The ride must belong to an identified user.");
+    : RideDomainException("Não foi possível identificar quem está ofertando a carona. Entre novamente.");
 
-public class RideNotDrivenByUserException(Guid rideId)
-    : Exception($"The ride {rideId} was offered by another user.");
+public class RideNotDrivenByUserException()
+    : Exception("Esta carona foi ofertada por outra pessoa. Só quem ofertou pode alterá-la.");

--- a/FateConnect/FateConnect.Api/Modules/Rides/Services/RideService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Services/RideService.cs
@@ -114,7 +114,7 @@ public partial class RideService(
 
         LogRideChangeRefused(logger, currentUserId, ride.Id);
 
-        throw new RideNotDrivenByUserException(ride.Id);
+        throw new RideNotDrivenByUserException();
     }
 
     private static ReadRideDto MapToReadDto(Ride ride, int currentUserId) =>

--- a/FateConnect/FateConnect.Api/Modules/Usuarios/DTOs/CreateUsuarioDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Usuarios/DTOs/CreateUsuarioDto.cs
@@ -35,7 +35,7 @@ public class CreateUsuarioDto
 
     [Required]
     [DefaultValue(1)]
-    [EnumDataType(typeof(EnumGender), ErrorMessage = "Invalid gender.")]
+    [EnumDataType(typeof(EnumGender), ErrorMessage = "Gênero inválido")]
     required public EnumGender Genero { get; set; }
 
     [Required]


### PR DESCRIPTION
## Objetivo

Levar para pt-BR as 11 mensagens da API que estavam em inglês. É o contrário do resto da #207: identificador vai para inglês, mas **mensagem que uma pessoa lê é copy de produto e fica em português**. O módulo `Rides` nasceu com as dele em inglês e ficou destoando do cadastro, que já respondia em pt-BR.

⚠️ **Nenhuma delas chega à tela hoje.** O `Web/src/services/httpClient.ts` descarta o corpo do erro e devolve sempre uma de três frases fixas. Elas aparecem no Swagger e para quem consome a API direto — e apareceriam na tela no dia em que o front passasse a exibir o que a API manda.

## Alterações

As 11 mensagens, escritas pela skill `ux-writing` contra a rule `product-copy.md` e contra a copy que o front já usa:

| Onde | Antes | Depois |
| --- | --- | --- |
| Data e hora da carona | The departure date and time must be in the future. | A carona deve ser em data e hora futuras. |
| Vagas | The number of seats must be between 1 and 7. Received: {seats}. | A carona deve ter entre 1 e 7 vagas. Recebido: {seats}. |
| Destino | The destination must contain between 3 and 100 characters. | O destino deve ter entre 3 e 100 caracteres. |
| Tipo de carona (exceção e DTO) | Invalid ride type. | Tipo de carona inválido. |
| Carona sem dono | The ride must belong to an identified user. | Não foi possível identificar quem está ofertando a carona. Entre novamente. |
| Carona de outra pessoa | The ride {rideId} was offered by another user. | Esta carona foi ofertada por outra pessoa. Só quem ofertou pode alterá-la. |
| Gênero | Invalid gender. | Gênero inválido |
| Token sem identidade | The token does not identify a user. | Sessão expirada. Entre novamente para continuar. |
| 500 genérico | An internal server error occurred. | Algo deu errado. Tente novamente. |
| Formato de hora (2 ocorrências) | Invalid time format… | Formato de hora inválido… |

Três decisões de copy que valem revisão:

- **O texto não é tradução literal — é o que o front já diz.** "A carona deve ser em data e hora futuras" é palavra por palavra o `departureInPast` do `RideFormDialog`. "Sessão expirada. Entre novamente para continuar." é o `SESSION_EXPIRED_MESSAGE` do `httpClient`, e "Algo deu errado. Tente novamente." é o `GENERIC_ERROR_MESSAGE` — em vez de inventar um segundo nome para o mesmo estado.
- **O 500 não virou tradução literal, de propósito.** "Ocorreu um erro interno no servidor" é o jargão de servidor que a `product-copy.md` proíbe.
- **O identificador da carona saiu da mensagem.** Um GUID cru é jargão para quem lê, e diagnóstico é trabalho do log.

### O log deixa de carregar a copy

O middleware interpolava a mensagem no template, então o log saía com moldura em inglês e conteúdo em português — `Handled error (400): A carona deve ter entre 1 e 7 vagas.` Agora registra o **tipo da exceção**, que é inglês por natureza e identifica melhor que a frase traduzida. Fecha a decisão da #207 de que log fica em inglês.

## Verificação

`dotnet build`: `0 Warning(s)`, `0 Error(s)`. `dotnet test`: **42 testes**, contra 21 antes — 4 arquivos novos cobrem as mensagens de domínio, as rotas do middleware, o conversor de hora e as validações de DTO. O único teste que já afirmava uma dessas mensagens (`UnderPostingTests`) passou a afirmar a nova.

Cobertura dos arquivos tocados, medida por opencover: `TimeOnlyJsonConverter` e `GlobalExceptionMiddleware` foram de 76,9% e 71,4% para **100%**; `RideException`, de 40% para **100%**.

### O que não fecha aqui

`FilterRideDto` fica em 80%. A linha descoberta é o construtor de cópia que o compilador gera para todo `record`, alcançável só por expressão `with`, que nada na aplicação usa. As saídas seriam testar o compilador, excluir o record da análise ou trocá-lo por `class` — as três fora do escopo de trocar texto.

## Issue

- #208

Closes #208

## Evidências
