### PR TITLE
docs: add the c# code style and ef migration rules

### DIFF
--- a/.claude/rules/dotnet-code-style.md
+++ b/.claude/rules/dotnet-code-style.md
@@ -1,0 +1,40 @@
+---
+description: Como escrever C# novo aqui — o controller só orquestra, e condição que não se lê sozinha ganha nome antes do `if`
+paths:
+  - "FateConnect/FateConnect.Api/**"
+  - "FateConnect/FateConnect.Api.Tests/**"
+---
+
+# Escrita de C#
+
+## O controller só orquestra
+
+⛔ **Nada de método auxiliar no corpo do controller.** Ele recebe a requisição, chama o serviço e devolve o resultado. O que ele precisar além disso vira **extension** ou vai para o serviço.
+
+O sinal é um `private` dentro do controller. Quando o segundo controller precisar da mesma coisa, esse método é copiado — e a duplicação nasce antes de alguém notar.
+
+Cobrado no review do PR #201: o `RidesController` carregava um `private int GetCurrentUserId()` que lia o claim de identidade. Virou `ClaimsPrincipalExtensions.GetUserId()`, e as cinco chamadas passaram a ser `User.GetUserId()`.
+
+**A extension mora no módulo dono do conceito, não em `Common`.** `GetUserId` ficou em `Modules/Auth/Extensions/` porque é `Auth` quem escreve o claim, no `TokenService`, e quem declara a exceção que ela lança. Em `Common` ela faria o único módulo que não depende de ninguém passar a depender de `Auth`.
+
+## Condição que não se lê sozinha ganha nome
+
+⛔ **Condição que exige decifrar vira variável nomeada antes do `if`.** Vale principalmente para `TryParse` e parentes, em que o `out` no meio da expressão esconde o que está sendo testado.
+
+Assim:
+
+```csharp
+bool isValidUserId = int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId);
+
+if (!isValidUserId)
+    throw new UnidentifiedUserException();
+```
+
+Não assim:
+
+```csharp
+if (!int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId))
+    throw new UnidentifiedUserException();
+```
+
+⚠️ **Condição que já se lê não ganha linha.** `if (ride is null)` e `if (!isValidUserId)` ficam como estão — a regra é sobre expressão que esconde o teste, não sobre proibir condição no `if`.

--- a/.claude/rules/dotnet-migrations.md
+++ b/.claude/rules/dotnet-migrations.md
@@ -1,0 +1,58 @@
+---
+description: Migration do EF que renomeia — o `dotnet ef` gera dropar e recriar, que apaga produção; como reescrever e como provar que os dados sobrevivem
+paths:
+  - "FateConnect/FateConnect.Api/**"
+---
+
+# Migration que renomeia
+
+⛔ **O `dotnet ef migrations add` não gera rename.** Para uma tabela ou coluna que troca de nome ele emite `DropTable` e `CreateTable` — que em homologação e produção **apaga todas as linhas**. O aviso que ele imprime é uma frase fácil de passar batido:
+
+```
+An operation was scaffolded that may result in the loss of data.
+```
+
+**Leia o `Up()` gerado antes de qualquer outra coisa.** Havendo `DropTable`, `DropColumn` ou um `DropColumn` seguido de `AddColumn` para o mesmo campo, reescreva à mão com `RenameTable` e `RenameColumn`, que preservam o conteúdo.
+
+**O `Down()` também.** O gerado dropa tabela e, se a migration mexer em anotação de banco, pode dropar extensão junto — na #209 ele removia a `unaccent`, o que quebraria a busca de carona sem acento num rollback.
+
+## O que acompanha um rename de tabela
+
+Renomear a tabela **não** renomeia o que aponta para ela. Cada um destes precisa de linha própria, senão o banco fica com o nome velho enquanto o modelo espera o novo:
+
+- chave primária — `PK_Usuarios` vira `PK_Users`
+- chave estrangeira, **inclusive as de outros módulos** — `FK_rides_Usuarios_DriverId` vira `FK_rides_Users_DriverId`
+- índice — `RenameIndex`, não drop e create
+
+⚠️ **A de outro módulo é a que escapa.** Na #209 a `FK_rides_…` não estava no mapa da issue, porque o mapa descrevia o módulo de usuários; ela apareceu ao comparar o SQL gerado com o escrito à mão.
+
+## Provar que os dados sobrevivem
+
+⛔ **Suíte verde não prova nada aqui.** Os testes rodam em `Microsoft.EntityFrameworkCore.InMemory`, que não executa DDL nem gera SQL de Postgres. A prova é aplicar num Postgres de verdade, na versão que a VPS roda:
+
+```bash
+docker run -d --name mig-probe -e POSTGRES_HOST_AUTH_METHOD=trust -p 55432:5432 postgres:<versão da VPS>
+dotnet ef migrations script <migration anterior> <migration nova> --output up.sql
+```
+
+O roteiro, na ordem:
+
+1. Aplique as migrations **anteriores** e semeie linhas em toda tabela que a migration toca — inclusive as de outros módulos que apontam para ela.
+2. Tire uma impressão digital: `md5(string_agg(...))` por tabela, com `ORDER BY` explícito.
+3. Aplique o `up.sql` e confira que `grep -E "DROP TABLE|DELETE FROM|TRUNCATE"` não acha nada.
+4. Recalcule a impressão digital **pelos nomes novos**. Igual = nada perdido.
+5. Aplique o `down.sql` e recalcule pelos nomes velhos. Igual = rollback seguro.
+
+A versão do Postgres se descobre no servidor, não se presume: `psql --version` na VPS.
+
+## Depois de reescrever, confira o drift
+
+Reescrever o `Up()` à mão não mexe no `.Designer.cs` nem no `FateConnectDbContextModelSnapshot.cs`, e é fácil deixá-los descrevendo um modelo que não existe mais — sobretudo se a branch rebaseou depois de outra migration entrar na base.
+
+```bash
+dotnet ef migrations add _Drift && grep "migrationBuilder\." Infrastructure/Database/Migrations/*_Drift.cs
+```
+
+Saída vazia é o que se espera. Apague a `_Drift` depois — `dotnet ef migrations remove` nem sempre apaga o arquivo, então confira com `git status`.
+
+⚠️ **Migration gerada na base errada mente sem avisar.** Se a branch rebaseou, o `.Designer.cs` pode ser anterior à migration que entrou na base — ele compila, passa nos testes, e só o teste de drift acusa.


### PR DESCRIPTION
## Objetivo

Registrar em rule duas coisas que esta rodada custou para descobrir, para que o próximo código C# já nasça certo em vez de ser corrigido no review.

Sem issue: mudança de harness é dispensada da issue, não do PR. Vai em PR próprio porque nenhum dos PRs abertos é carregador natural de uma rule de C#.

## Alterações

### `.claude/rules/dotnet-code-style.md`

Nasce do review do PR #201, que apontou dois pontos:

- **O controller só orquestra** — nada de método auxiliar no corpo dele. O sinal é um `private` dentro do controller; quando o segundo controller precisar do mesmo, ele é copiado. A rule registra também **onde a extension mora**: no módulo dono do conceito, não em `Common`. O `GetUserId` ficou em `Modules/Auth/Extensions/` porque é `Auth` quem escreve o claim e quem declara a exceção que ela lança; em `Common` faria o único módulo sem dependência passar a depender de `Auth`.
- **Condição que não se lê sozinha ganha nome** antes do `if`, sobretudo em `TryParse`, onde o `out` no meio da expressão esconde o que está sendo testado. Com a exceção explícita de que `if (ride is null)` não ganha linha nenhuma.

### `.claude/rules/dotnet-migrations.md`

Nasce da migration da #209, e é a que teria evitado o pior:

- **O `dotnet ef migrations add` não gera rename** — para tabela ou coluna que troca de nome ele emite `DropTable` e `CreateTable`, que apaga produção. O aviso que ele imprime é uma linha fácil de passar batido.
- **O que acompanha um rename de tabela**: chave primária, índice e chave estrangeira — **inclusive as de outro módulo**. A `FK_rides_Usuarios_DriverId` não estava no mapa da issue, porque o mapa descrevia o módulo de usuários; só apareceu ao comparar o SQL gerado com o escrito à mão.
- **Como provar que os dados sobrevivem.** Suíte verde não prova: ela roda em `InMemory`, que não executa DDL. O roteiro é semear um Postgres na versão da VPS, tirar um `md5` por tabela, aplicar, e recalcular pelos nomes novos — e repetir na volta.
- **O teste de drift depois de reescrever à mão**, porque o `.Designer.cs` e o snapshot não acompanham a reescrita, e uma migration gerada na base errada compila e passa nos testes.

## Verificação

`./scripts/check-harness-paths.sh` sem caminho órfão. Nenhum inventário precisa mudar: o `CLAUDE.md` e o `README.md` enumeram **skills** e workflows, não rules — as rules são descritas pelo mecanismo (`paths:`), que é justamente o motivo de nunca terem divergido.

## Evidências
