### PR TITLE
feat(213): consume the english signup and login contract

### DIFF
--- a/.claude/rules/fateconnect-locale-code.md
+++ b/.claude/rules/fateconnect-locale-code.md
@@ -49,6 +49,8 @@ A API fala **inglês inteira** — caminho, query, corpo e resposta. Não há tr
 - **Login.** `POST /Auth/login` com `{ fatecEmail, password }`, resposta `{ token, fullName }`.
 - **Erro.** Qualquer status de erro devolve `{ "error": "..." }`, com a mensagem em pt-BR. O corpo sai do `ErrorResponseDto`, o mesmo tipo que o `ProducesResponseType` anuncia — documentação e resposta não conseguem divergir.
 
+⚠️ **A API publica com a inicial maiúscula e o front chama minúsculo.** `[Route("[controller]")]` gera `/Rides`, `/Users` e `/Auth`, que é o que o Swagger mostra; os serviços do front padronizam `/rides`, `/users/signup` e `/auth`, porque o roteamento do ASP.NET é case-insensitive. Não "corrija" nenhum dos dois lados — a divergência é deliberada.
+
 ## Referência no repositório
 
 - Feature de exemplo: [`FateConnect/Web/src/pages/Rides/`](FateConnect/Web/src/pages/Rides/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Passa a mostrar quem ofertou cada carona, com nome e contato reais, e a reconhecer as suas — com marcação própria e os botões de editar e excluir (#203) [Frontend]
 - Passa a responder os erros da API em português; validação de carona e de cadastro, formato de hora e o erro genérico vinham em inglês (#218) [Backend]
 - Passa a atender o cadastro e o login com o contrato em inglês: muda o endereço do cadastro e todas as chaves das duas chamadas, na requisição e na resposta (#222) [Backend]
+- Passa a enviar o cadastro e o login no contrato em inglês, acompanhando a API (#224) [Frontend]
 
 ### Fixed
 

--- a/FateConnect/Web/src/components/SessionExpiryGate/SessionExpiryGate.test.tsx
+++ b/FateConnect/Web/src/components/SessionExpiryGate/SessionExpiryGate.test.tsx
@@ -9,7 +9,7 @@ import { render, screen, waitFor } from '@app/test/testing-library';
 
 import { SESSION_EXPIRED_TITLE } from '../SessionExpiredScreen/constants';
 
-const RIDES_URL = 'https://api.fateconnect.test/Rides';
+const RIDES_URL = 'https://api.fateconnect.test/rides';
 
 function renderRides() {
   render(

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/LandingLoginCard.test.tsx
@@ -73,9 +73,7 @@ describe('LandingLoginCard', () => {
 
   it('should greet the user and go to the menu after a successful login', async () => {
     server.use(
-      http.post(LOGIN_URL, () =>
-        HttpResponse.json({ token: 'abc', nomeCompleto: 'Fulano de Tal' }),
-      ),
+      http.post(LOGIN_URL, () => HttpResponse.json({ token: 'abc', fullName: 'Fulano de Tal' })),
     );
     const router = renderCard();
     await preencher('aluno.teste@aluno.cps.sp.gov.br', 'segredo123');
@@ -117,7 +115,7 @@ describe('LandingLoginCard', () => {
       http.post(LOGIN_URL, async () => {
         await held;
 
-        return HttpResponse.json({ token: 'abc', nomeCompleto: 'Fulano' });
+        return HttpResponse.json({ token: 'abc', fullName: 'Fulano' });
       }),
     );
     renderCard();

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/index.tsx
@@ -45,7 +45,7 @@ export function LandingLoginCard() {
     // A mensagem depende do status; o aviso sai daqui, não do tratamento global.
     meta: { notifiesErrorItself: true },
     onSuccess: (response) => {
-      notifySuccess(C.welcomeMessage(response.nomeCompleto));
+      notifySuccess(C.welcomeMessage(response.fullName));
       navigate(RoutePathEnum.MENU);
     },
     onError: (error: ApiError) => {
@@ -61,7 +61,7 @@ export function LandingLoginCard() {
   const handleTogglePassword = useCallback(() => setPasswordHidden((hidden) => !hidden), []);
 
   const onSubmit = handleSubmit(({ email, password }) => {
-    mutate({ emailFatec: email, senha: password });
+    mutate({ fatecEmail: email, password });
   });
 
   const { ref: registerEmailRef, ...emailField } = register('email');

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -17,7 +17,7 @@ import { EDIT_MODE, OFFER_MODE, RIDE_FORM_LABELS } from './components/RideFormDi
 import * as C from './constants';
 import { Rides } from '.';
 
-const RIDES_URL = 'https://api.fateconnect.test/Rides';
+const RIDES_URL = 'https://api.fateconnect.test/rides';
 
 /** Cobre a tentativa inicial, os 2s de espera e a repetição. */
 const RETRY_WINDOW_MS = 5000;

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormDialog.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormDialog.test.tsx
@@ -9,7 +9,7 @@ import { toApiDate } from '@app/utils/apiDate';
 import { EDIT_MODE, OFFER_MODE, RIDE_FORM_LABELS } from './constants';
 import { RideFormDialog, type RideFormDialogProps } from '.';
 
-const RIDES_URL = 'https://api.fateconnect.test/Rides';
+const RIDES_URL = 'https://api.fateconnect.test/rides';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DAYS_AHEAD = 30;

--- a/FateConnect/Web/src/pages/Signup/Signup.test.tsx
+++ b/FateConnect/Web/src/pages/Signup/Signup.test.tsx
@@ -13,7 +13,7 @@ import { SIGNUP_MESSAGES } from './schema';
 import * as C from './constants';
 import { Signup } from '.';
 
-const SIGNUP_URL = 'https://api.fateconnect.test/usuario/cadastro';
+const SIGNUP_URL = 'https://api.fateconnect.test/users/signup';
 const ZIP_URL = 'https://viacep.com.br/ws/:zipCode/json/';
 
 const VALID_SIGNUP = {
@@ -272,8 +272,8 @@ describe('Signup', () => {
       http.post(SIGNUP_URL, () =>
         HttpResponse.json({
           id: 1,
-          emailFatec: VALID_SIGNUP.fatecEmail,
-          nomeCompleto: 'Maria Silva',
+          fatecEmail: VALID_SIGNUP.fatecEmail,
+          fullName: 'Maria Silva',
         }),
       ),
     );
@@ -293,7 +293,7 @@ describe('Signup', () => {
       http.post(SIGNUP_URL, async ({ request }) => {
         payload = await request.json();
 
-        return HttpResponse.json({ id: 1, emailFatec: '', nomeCompleto: 'Maria Silva' });
+        return HttpResponse.json({ id: 1, fatecEmail: '', fullName: 'Maria Silva' });
       }),
     );
     renderSignup();
@@ -302,22 +302,23 @@ describe('Signup', () => {
     await submit();
 
     await waitFor(() => expect(payload).toBeDefined());
-    expect(payload).toMatchObject({
-      nomeCompleto: VALID_SIGNUP.fullName,
-      emailFatec: VALID_SIGNUP.fatecEmail,
-      senha: VALID_SIGNUP.password,
-      genero: 'Female',
-      dataNascimento: '1999-05-22T00:00:00Z',
-      enderecos: [
+    expect(payload).toEqual({
+      fullName: VALID_SIGNUP.fullName,
+      fatecEmail: VALID_SIGNUP.fatecEmail,
+      password: VALID_SIGNUP.password,
+      gender: 'Female',
+      birthDate: '1999-05-22T00:00:00Z',
+      addresses: [
         {
-          cep: '18000-000',
-          logradouro: 'Rua das Flores',
-          numero: '100',
-          cidade: 'Sorocaba',
-          estado: 'SP',
+          zipCode: '18000-000',
+          street: 'Rua das Flores',
+          streetNumber: '100',
+          complement: '',
+          city: 'Sorocaba',
+          state: 'SP',
         },
       ],
-      contatos: [{ telefone: '11912345678', emailContato: VALID_SIGNUP.contactEmail }],
+      contacts: [{ phone: '11912345678', contactEmail: VALID_SIGNUP.contactEmail }],
     });
   });
 
@@ -347,7 +348,7 @@ describe('Signup', () => {
       http.post(SIGNUP_URL, async () => {
         await held;
 
-        return HttpResponse.json({ id: 1, emailFatec: '', nomeCompleto: 'Maria Silva' });
+        return HttpResponse.json({ id: 1, fatecEmail: '', fullName: 'Maria Silva' });
       }),
     );
     renderSignup();

--- a/FateConnect/Web/src/pages/Signup/helpers/mapper.test.ts
+++ b/FateConnect/Web/src/pages/Signup/helpers/mapper.test.ts
@@ -25,26 +25,26 @@ describe('toSignupRequest', () => {
   it('should translate the form into the backend contract', () => {
     const request = toSignupRequest(FILLED);
 
-    expect(request.nomeCompleto).toBe('Maria Silva');
-    expect(request.apelido).toBe('Mari');
-    expect(request.emailFatec).toBe('maria.silva@aluno.cps.sp.gov.br');
-    expect(request.dataNascimento).toContain('1999-05-22');
-    expect(request.genero).toBe(GenderValueEnum.FEMALE);
+    expect(request.fullName).toBe('Maria Silva');
+    expect(request.nickname).toBe('Mari');
+    expect(request.fatecEmail).toBe('maria.silva@aluno.cps.sp.gov.br');
+    expect(request.birthDate).toContain('1999-05-22');
+    expect(request.gender).toBe(GenderValueEnum.FEMALE);
   });
 
   // O backend prefere a ausência da chave a uma string vazia.
   it('should omit the optional nickname instead of sending it empty', () => {
     const request = toSignupRequest({ ...FILLED, nickname: '' });
 
-    expect(request.apelido).toBeUndefined();
+    expect(request.nickname).toBeUndefined();
   });
 
   // A API documenta o CEP com o hífen e o telefone só com dígitos.
   it('should keep the zip code masked and send the phone as digits', () => {
     const request = toSignupRequest(FILLED);
 
-    expect(request.enderecos[0]?.cep).toBe('18000-000');
-    expect(request.contatos[0]?.telefone).toBe('15999999999');
+    expect(request.addresses[0]?.zipCode).toBe('18000-000');
+    expect(request.contacts[0]?.phone).toBe('15999999999');
   });
 
   // `toISOString()` sobre a data local move o instante e, a leste de
@@ -52,12 +52,12 @@ describe('toSignupRequest', () => {
   it('should send the birth date as midnight in utc', () => {
     const request = toSignupRequest(FILLED);
 
-    expect(request.dataNascimento).toBe('1999-05-22T00:00:00Z');
+    expect(request.birthDate).toBe('1999-05-22T00:00:00Z');
   });
 
   it('should send an empty birth date when the typed one is not a date', () => {
     const request = toSignupRequest({ ...FILLED, birthDate: '99/99/9999' });
 
-    expect(request.dataNascimento).toBe('');
+    expect(request.birthDate).toBe('');
   });
 });

--- a/FateConnect/Web/src/pages/Signup/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/Signup/helpers/mapper.ts
@@ -19,29 +19,28 @@ function toApiBirthDateOrEmpty(value: string): string {
   return toApiBirthDate(parsed);
 }
 
-/** Traduz o formulário para o contrato do backend, que fala pt-BR. */
 export function toSignupRequest(values: SignupFormValues): SignupRequest {
   return {
-    nomeCompleto: values.fullName,
-    apelido: optionalText(values.nickname),
-    emailFatec: values.fatecEmail,
-    senha: values.password,
-    dataNascimento: toApiBirthDateOrEmpty(values.birthDate),
-    genero: values.gender,
-    enderecos: [
+    fullName: values.fullName,
+    nickname: optionalText(values.nickname),
+    fatecEmail: values.fatecEmail,
+    password: values.password,
+    birthDate: toApiBirthDateOrEmpty(values.birthDate),
+    gender: values.gender,
+    addresses: [
       {
-        cep: values.zipCode,
-        logradouro: values.street,
-        numero: values.streetNumber,
-        complemento: values.complement,
-        cidade: values.city,
-        estado: values.state,
+        zipCode: values.zipCode,
+        street: values.street,
+        streetNumber: values.streetNumber,
+        complement: values.complement,
+        city: values.city,
+        state: values.state,
       },
     ],
-    contatos: [
+    contacts: [
       {
-        telefone: onlyDigits(values.phone),
-        emailContato: values.contactEmail,
+        phone: onlyDigits(values.phone),
+        contactEmail: values.contactEmail,
       },
     ],
   };

--- a/FateConnect/Web/src/pages/Signup/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/index.tsx
@@ -39,7 +39,7 @@ export function Signup() {
     // A mensagem depende do status; o aviso sai daqui, não do tratamento global.
     meta: { notifiesErrorItself: true },
     onSuccess: (response) => {
-      notifySuccess(C.signupSuccessMessage(response.nomeCompleto));
+      notifySuccess(C.signupSuccessMessage(response.fullName));
       navigate(LOGIN_ANCHOR);
     },
     onError: (error: ApiError) => notifyError(errorMessageFor(error.status)),

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -22,7 +22,7 @@ describe('routeConfig', () => {
   // Caronas e achados e perdidos listam assim que montam.
   beforeEach(() => {
     server.use(
-      http.get('https://api.fateconnect.test/Rides', () => HttpResponse.json([])),
+      http.get('https://api.fateconnect.test/rides', () => HttpResponse.json([])),
       http.get('https://api.fateconnect.test/achado', () => HttpResponse.json([])),
     );
   });

--- a/FateConnect/Web/src/services/auth/authService.test.ts
+++ b/FateConnect/Web/src/services/auth/authService.test.ts
@@ -9,13 +9,11 @@ const LOGIN_URL = 'https://api.fateconnect.test/auth/login';
 
 describe('authService', () => {
   it('should store the session after a successful login', async () => {
-    server.use(
-      http.post(LOGIN_URL, () => HttpResponse.json({ token: 'abc', nomeCompleto: 'Fulano' })),
-    );
+    server.use(http.post(LOGIN_URL, () => HttpResponse.json({ token: 'abc', fullName: 'Fulano' })));
 
-    const response = await login({ emailFatec: 'a@fatec.sp.gov.br', senha: 'segredo123' });
+    const response = await login({ fatecEmail: 'a@fatec.sp.gov.br', password: 'segredo123' });
 
-    expect(response.nomeCompleto).toBe('Fulano');
+    expect(response.fullName).toBe('Fulano');
     expect(tokenStorage.getToken()).toBe('abc');
   });
 

--- a/FateConnect/Web/src/services/auth/types.ts
+++ b/FateConnect/Web/src/services/auth/types.ts
@@ -1,10 +1,9 @@
-/** Corpo esperado pelo endpoint de login (contrato do backend, em pt-BR). */
 export type LoginRequest = {
-  emailFatec: string;
-  senha: string;
+  fatecEmail: string;
+  password: string;
 };
 
 export type TokenResponse = {
   token: string;
-  nomeCompleto: string;
+  fullName: string;
 };

--- a/FateConnect/Web/src/services/rides/ridesService.test.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.test.ts
@@ -5,7 +5,7 @@ import { server } from '@app/mocks/server';
 import { createRide, deleteRide, listRides, updateRide } from './ridesService';
 import { RideTypeEnum, type RideInput } from './types';
 
-const RIDES_URL = 'https://api.fateconnect.test/Rides';
+const RIDES_URL = 'https://api.fateconnect.test/rides';
 
 const RIDE_INPUT: RideInput = {
   availableSeats: 3,

--- a/FateConnect/Web/src/services/rides/ridesService.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '../httpClient';
 import type { Ride, RideFilter, RideInput } from './types';
 
-const RIDES_PATH = '/Rides';
+const RIDES_PATH = '/rides';
 
 const INVALID_LIST_PAYLOAD_MESSAGE = 'A API de caronas respondeu algo que não é uma lista.';
 

--- a/FateConnect/Web/src/services/signup/signupService.test.ts
+++ b/FateConnect/Web/src/services/signup/signupService.test.ts
@@ -5,16 +5,16 @@ import { server } from '@app/mocks/server';
 import { signup } from './signupService';
 import type { SignupRequest } from './types';
 
-const SIGNUP_URL = 'https://api.fateconnect.test/usuario/cadastro';
+const SIGNUP_URL = 'https://api.fateconnect.test/users/signup';
 
 const PAYLOAD: SignupRequest = {
-  emailFatec: 'aluno.teste@aluno.cps.sp.gov.br',
-  senha: 'segredo123',
-  nomeCompleto: 'Fulano de Tal',
-  dataNascimento: '2000-01-01T00:00:00Z',
-  genero: 'Female',
-  enderecos: [],
-  contatos: [],
+  fatecEmail: 'aluno.teste@aluno.cps.sp.gov.br',
+  password: 'segredo123',
+  fullName: 'Fulano de Tal',
+  birthDate: '2000-01-01T00:00:00Z',
+  gender: 'Female',
+  addresses: [],
+  contacts: [],
 };
 
 describe('signupService', () => {
@@ -25,8 +25,8 @@ describe('signupService', () => {
         receivedBody = await request.json();
         return HttpResponse.json({
           id: 1,
-          emailFatec: PAYLOAD.emailFatec,
-          nomeCompleto: PAYLOAD.nomeCompleto,
+          fatecEmail: PAYLOAD.fatecEmail,
+          fullName: PAYLOAD.fullName,
         });
       }),
     );

--- a/FateConnect/Web/src/services/signup/signupService.ts
+++ b/FateConnect/Web/src/services/signup/signupService.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '../httpClient';
 import type { SignupRequest, SignupResponse } from './types';
 
-const SIGNUP_PATH = '/usuario/cadastro';
+const SIGNUP_PATH = '/users/signup';
 
 export async function signup(payload: SignupRequest): Promise<SignupResponse> {
   const { data } = await apiClient.post<SignupResponse>(SIGNUP_PATH, payload);

--- a/FateConnect/Web/src/services/signup/types.ts
+++ b/FateConnect/Web/src/services/signup/types.ts
@@ -1,31 +1,30 @@
-/** Contratos do endpoint de cadastro (nomes vindos do backend, em pt-BR). */
 export type SignupAddress = {
-  cep: string;
-  logradouro: string;
-  numero: string;
-  complemento: string;
-  cidade: string;
-  estado: string;
+  zipCode: string;
+  street: string;
+  streetNumber: string;
+  complement: string;
+  city: string;
+  state: string;
 };
 
 export type SignupContact = {
-  telefone: string;
-  emailContato: string;
+  phone: string;
+  contactEmail: string;
 };
 
 export type SignupRequest = {
-  emailFatec: string;
-  senha: string;
-  nomeCompleto: string;
-  apelido?: string;
-  dataNascimento: string;
-  genero: string;
-  enderecos: SignupAddress[];
-  contatos: SignupContact[];
+  fatecEmail: string;
+  password: string;
+  fullName: string;
+  nickname?: string;
+  birthDate: string;
+  gender: string;
+  addresses: SignupAddress[];
+  contacts: SignupContact[];
 };
 
 export type SignupResponse = {
   id: number;
-  emailFatec: string;
-  nomeCompleto: string;
+  fatecEmail: string;
+  fullName: string;
 };


### PR DESCRIPTION
## Objetivo

Fecha a árvore da #207. O back passou a falar inglês nos PRs anteriores; este é o lado do front — e é o que **reata cadastro e login em homologação**, quebrados desde o merge do #222 por decisão consciente da issue pai.

## Alterações

### O contrato

As chaves do cadastro e do login passam para inglês, e o caminho do cadastro vai de `/usuario/cadastro` para `/users/signup`. Os três JSDoc que afirmavam *"contrato do backend, em pt-BR"* saem — eram falsos desde o #222.

**O `toSignupRequest` encolheu de tradutor para montador.** Ele traduzia 14 chaves; agora não traduz nenhuma.

⚠️ **Mas ele não pôde deixar de existir**, como a issue supunha. O formulário é **plano** (`zipCode`, `street`, `city` no topo) e a requisição é **aninhada** (`addresses: [...]`, `contacts: [...]`). Além do agrupamento, ele ainda converte `nickname` vazio em ausência da chave, formata a data, tira a máscara do telefone — e **descarta `acceptTerms` e `acceptMarketing`**, que são do formulário e a API não recebe. Um pass-through vazaria dois campos de consentimento.

### Os caminhos, todos minúsculos

`ridesService` escrevia `/Rides` e `authService` escrevia `/auth` — divergência que ninguém via, porque o roteamento do ASP.NET é case-insensitive. Agora é `/rides`, `/auth` e `/users/signup`, com os stubs do MSW junto.

Registrado na rule de locale, com a proibição nos dois sentidos: a API publica com a inicial maiúscula, o front chama minúsculo, e nenhum dos dois lados deve ser "corrigido" para o outro.

### O teste passou a afirmar o contrato, não a saída do código

`toMatchObject` é subconjunto: um `acceptTerms` vazando passaria calado. Virou `toEqual`, e a asserção exata **revelou algo que a parcial escondia** — o cadastro envia `complement` como string vazia. Está correto, a coluna é NOT NULL no banco, mas ninguém tinha afirmado isso.

## Verificação

| Prova | Resultado |
| --- | --- |
| `yarn lint` e `yarn typecheck` | limpos |
| `yarn test:ci` | **440 testes**, cobertura de linhas em **99,3%** |
| Cada um dos três primeiros commits, isolado | `tsc` limpo e 440 testes em **cada ponto** do histórico |

O commit do contrato leva os testes junto de propósito: separados, o `tsc` reprova, porque os testes referenciam as chaves antigas.

### Um erro que os testes pegaram

O replace em lote errou nos **dois** sentidos: atingiu `cep` e `logradouro` no stub do **ViaCEP** — chaves de um provedor externo, que não são nossas — e ao mesmo tempo deixou passar `senha:` e `numero:` no payload do teste. É a mesma família da regra que entrou na `dotnet-code-style` pelo #223, do lado do front; vale uma rule equivalente depois, com o ViaCEP como âncora.

## Issue

- #213

Closes #213

## Evidências
