### PR TITLE
docs: record what the english back-end sequence taught

### DIFF
--- a/.claude/rules/dotnet-code-quality.md
+++ b/.claude/rules/dotnet-code-quality.md
@@ -18,3 +18,17 @@ Os dois projetos referenciam o `SonarAnalyzer.CSharp`, então as regras que o So
 Foi assim que os nove primeiros apareceram, ao referenciar o pacote: seis de `S6964` (campo de tipo-valor sem `required`, que aceitava a omissão e virava o valor padrão), dois de `S1118` e um `WriteAsJsonAsync` sem `CancellationToken`.
 
 ⚠️ **`Program` não pode virar `static`** para satisfazer o `S1118`: `WebApplicationFactory<Program>` a usa como argumento genérico, e classe estática não serve. O construtor privado resolve.
+
+## Regra `IDExxxx` é silenciosa até alguém declarar a severidade
+
+⛔ **`EnforceCodeStyleInBuild` e `TreatWarningsAsErrors` não bastam.** As regras de estilo do Roslyn nascem **abaixo de `warning`**, e o `TreatWarningsAsErrors` só promove o que já é warning — então elas rodam e não reprovam nada.
+
+Medido em 30/08/2026: o Sonar acusou quatro `IDE0028` que o `dotnet build` deixou passar, com as duas propriedades ligadas no `.csproj`. Declarada a severidade no `.editorconfig`, a mesma violação vira erro de build:
+
+```ini
+dotnet_style_prefer_collection_expression = true:warning
+```
+
+⚠️ **A prova de que o mecanismo funciona já estava no arquivo:** `csharp_style_namespace_declarations = file_scoped:warning` reprova de verdade — um namespace block-scoped plantado derruba a build com `IDE0161`. A diferença entre as duas é só o `:warning`.
+
+**A consequência prática:** a regra que você quer cobrada precisa estar escrita. Não existe "o analisador pega" — existe "o analisador pega o que foi declarado".

--- a/.claude/rules/parallelism-and-worktrees.md
+++ b/.claude/rules/parallelism-and-worktrees.md
@@ -33,6 +33,13 @@ Issue que declara "Depende de" só começa quando a base estiver **com o escopo 
 ## Mecânica de worktree
 
 - **A worktree não nasce na branch atual.** Na #123 ela nasceu 16 commits atrás, sem o commit do contrato. Conferir com `git log --oneline -1` e corrigir com `git merge --ff-only <branch-da-tarefa>` **antes** de escrever qualquer linha.
+- ⛔ **A worktree nasce rastreando a base, e um `git push` vai para ela.** `git worktree add -b <nova> <caminho> origin/develop` deixa a branch nova com `origin/develop` como upstream — e a `develop` não aceita commit direto. Desarmar logo depois de criar:
+
+  ```bash
+  git branch --unset-upstream <nova>
+  git rev-parse --abbrev-ref <nova>@{upstream}   # não pode responder nada
+  ```
+
 - **A worktree não tem `node_modules`.** Symlink para o do checkout principal, senão não há ESLint, `tsc` nem Vitest.
 - **`.claude/worktrees/` fica fora do versionamento** — a pasta é ignorada, porque worktree de agente dentro de pasta versionada aparece como arquivo não rastreado na raiz.
 - **Agente cai.** Nesta rodada um morreu em erro 403 de autenticação e outro travou depois de commitar. Quando cair: verificar o que já foi commitado na branch da worktree e assumir a fatia — relançar às cegas refaz trabalho que já existe.

--- a/.claude/rules/web-react-patterns.md
+++ b/.claude/rules/web-react-patterns.md
@@ -114,3 +114,13 @@ O teste que protege isso precisa de um nome **com acento** — `João Ávila` pa
 ## TODO
 
 Comentário `TODO` fora de bloco JSX, referenciando a issue que o resolve.
+
+## Rename em lote não sabe o que é nosso
+
+⛔ **Substituição mecânica atinge chave de contrato que não controlamos.** Antes de trocar um nome em vários arquivos, separe o que é **nosso** do que vem de fora.
+
+Aconteceu na #213, ao levar o cadastro para inglês: o replace `cep` → `zipCode` e `logradouro` → `street` acertou o **stub do ViaCEP**, cujo contrato é do provedor e não muda porque a nossa API mudou. Os testes de preenchimento por CEP quebraram com um erro que não menciona rename — *"Unable to find an element with the display value: Praça da Sé"*.
+
+**Os contratos de terceiro deste repo**, hoje: `services/cep/` (ViaCEP e OpenCEP, com `cep`, `logradouro`, `localidade`, `uf`) e `utils/whatsapp.ts`. A variável que recebe o valor segue as nossas regras de nome; a **chave** copia o provedor exatamente.
+
+⚠️ **O mesmo replace também erra por falta.** Na mesma rodada ele deixou passar `senha:` e `numero:` dentro do payload de um teste, porque a lista de pares não os previa. Errar por excesso e por falta ao mesmo tempo é o normal, não a exceção — por isso a conferência é ler o diff, não confiar na lista.

--- a/.claude/rules/web-testing-practices.md
+++ b/.claude/rules/web-testing-practices.md
@@ -41,3 +41,9 @@ O import saía de graça em 48 arquivos e ninguém percebia porque o teste passa
 
 - Não testar detalhe de implementação: nada de asserção sobre estado interno, nome de classe CSS ou ordem de chamada de hook.
 - Não duplicar no teste a lógica que ele verifica — valor esperado é literal, não recalculado.
+
+## Corpo de requisição se afirma inteiro
+
+⛔ **`toMatchObject` é subconjunto: chave a mais passa calada.** Para o payload que sai para a API, `toEqual` — ele reprova o que sobra, que é justamente o risco.
+
+Na #213 a troca revelou que o cadastro envia `complement` como string vazia, coisa que nenhum teste afirmava. E é ela que impede `acceptTerms` e `acceptMarketing` de vazarem: os dois são do formulário, a API não os recebe, e o `toMatchObject` aceitaria os dois sem reclamar.

--- a/.claude/skills/spec-issue/SKILL.md
+++ b/.claude/skills/spec-issue/SKILL.md
@@ -108,7 +108,24 @@ Os `id` saem de `gh api graphql -f query='{repository(owner:"...",name:"..."){is
 
 Antes de dizer que acabou, cruzar **cada** coisa conversada contra o que entrou. Cada item termina em um de três estados ditos em voz alta: **coberto** (por qual sub-issue), **fora de escopo por decisão** (com o motivo), ou **aberto** (com quem destrava). Item conversado que evapora é o defeito clássico desta skill.
 
-## 7. Fechar o pai é manual, e ninguém avisa
+## 7. Cada merge envelhece as irmãs
+
+⛔ **Ao mergear uma sub-issue, releia as que sobraram.** Uma árvore de sub-issues é escrita de uma vez, com o repositório de um instante — e cada PR que entra invalida um pedaço do que as outras dizem. Nada avisa: o texto continua sintaticamente perfeito.
+
+Quatro vezes na árvore da #207:
+
+| O que ficou falso | Depois de |
+| --- | --- |
+| a #210 mandava renomear serviços e interfaces | a #209 já os ter renomeado no review |
+| a #211 mandava renomear `GerarHashDaSenha`, que deixou de existir | a #209 remover o wrapper |
+| a #212 tinha um checkbox aberto para uma decisão já tomada | o #221 unificar os `.editorconfig` |
+| a #213 escrevia a rota em minúscula e não citava um JSDoc já falso | o #222 publicar `/Users/signup` |
+
+⚠️ **A terceira foi o Victor quem pegou**, perguntando *"editorconfig já foi arrumado, tá lá ainda?"* — depois de eu ter editado aquela seção **antes** do merge e não ter voltado nela.
+
+**O gatilho é o merge, não o fim da árvore.** Ao fechar uma sub-issue, abra as irmãs abertas e procure: escopo que outro PR já entregou, símbolo que deixou de existir, e decisão que mudou. Item entregue vira `[x]` com a nota de onde saiu; item morto sai.
+
+## 8. Fechar o pai é manual, e ninguém avisa
 
 ⛔ **Nada fecha sozinho aqui.** Duas mecânicas somadas deixam a árvore aberta com tudo entregue:
 


### PR DESCRIPTION
## Objetivo

Registrar o que a sequência da #207 ensinou e ainda não estava escrito em lugar nenhum. Cada uma das cinco entradas descreve um erro **cometido nesta milestone**, com o caso concreto ancorado — e três delas passaram por gate verde sem serem pegas.

Sem issue: mudança de harness dispensa a issue, não o PR. Nenhum arquivo de código foi tocado.

## Alterações

### `web-react-patterns.md` — rename em lote não sabe o que é nosso

O replace `cep` → `zipCode` acertou o **stub do ViaCEP**, cujo contrato é do provedor e não muda porque a nossa API mudou. O erro que apareceu não menciona rename: *"Unable to find an element with the display value: Praça da Sé"*.

A rule nomeia os contratos de terceiro que existem hoje — `services/cep/` e `utils/whatsapp.ts` — e registra que o mesmo replace **também erra por falta**: deixou passar `senha:` e `numero:` no payload de um teste. Errar por excesso e por falta ao mesmo tempo é o normal.

### `spec-issue/SKILL.md` — cada merge envelhece as irmãs

Uma árvore de sub-issues é escrita de uma vez, com o repositório de um instante, e cada PR invalida um pedaço do que as outras dizem. **Aconteceu quatro vezes** na #207, e a rule traz a tabela: o que ficou falso, depois de qual PR.

Uma delas foi pega pelo Victor — *"editorconfig já foi arrumado, tá lá ainda?"* —, depois de eu ter editado aquela seção **antes** do merge e não ter voltado nela.

### `dotnet-code-quality.md` — regra `IDExxxx` é silenciosa até declararem a severidade

⛔ `EnforceCodeStyleInBuild` e `TreatWarningsAsErrors` **não bastam**: as regras de estilo nascem abaixo de `warning`, e o segundo só promove o que já é warning. Foi assim que o Sonar acusou quatro `IDE0028` que a build deixou passar com as duas propriedades ligadas.

A prova de que o mecanismo funcionava já estava no mesmo arquivo: `csharp_style_namespace_declarations = file_scoped:warning` reprova de verdade. A diferença entre as duas era só o `:warning`.

### `web-testing-practices.md` — corpo de requisição se afirma inteiro

`toMatchObject` é subconjunto: chave a mais passa calada. A troca por `toEqual` revelou que o cadastro envia `complement` como string vazia — e é ela que impede `acceptTerms` e `acceptMarketing` de vazarem para a API, coisa que o `toMatchObject` aceitaria.

### `parallelism-and-worktrees.md` — a worktree nasce rastreando a base

⛔ `git worktree add -b <nova> <caminho> origin/develop` deixa a branch nova com **`origin/develop` como upstream**. Um `git push` distraído vai para a `develop`, que o repo proíbe em absoluto.

Eu desarmei isso no dia por ter olhado a saída do comando, não por saber que era assim. Agora está escrito, com o comando que confere.

## Verificação

`./scripts/check-harness-paths.sh` sem caminho órfão. `git diff --name-only origin/develop HEAD` devolve **apenas** arquivos de `.claude/` — nenhum código, nenhum teste, nenhum gate afetado.

Sem entrada no `CHANGELOG.md`: harness não muda comportamento de produto.

## Evidências
