### PR TITLE
chore: address the static analysis findings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,16 +62,22 @@ jobs:
           SENTRY_RELEASE: v${{ steps.version.outputs.value }}
 
       - name: Load the deploy key
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           # Aceita a identidade do servidor na primeira conexão. Para fixá-la,
           # guarde a saída de `ssh-keyscan` num secret e escreva-a aqui.
-          ssh-keyscan -H "${{ secrets.DEPLOY_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
       - name: Send the front to the VPS
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           # Quem serve estes arquivos é o nginx do host; a pasta nasce no
           # install-site.sh, com dono no usuário do deploy.
@@ -80,18 +86,25 @@ jobs:
           rsync -az --delete \
             -e "ssh -i ~/.ssh/deploy_key -o BatchMode=yes" \
             FateConnect/Web/dist/ \
-            "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:$target/"
+            "$DEPLOY_USER@$DEPLOY_HOST:$target/"
 
       - name: Publish
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
         run: |
           ssh -i ~/.ssh/deploy_key -o BatchMode=yes \
-            "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
-            "cd '${{ secrets.DEPLOY_PATH }}/deploy' && ./deploy.sh '${{ inputs.environment }}'"
+            "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cd '$DEPLOY_PATH/deploy' && ./deploy.sh '${{ inputs.environment }}'"
 
       - name: Check that the containers stayed up
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           ssh -i ~/.ssh/deploy_key -o BatchMode=yes \
-            "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
+            "$DEPLOY_USER@$DEPLOY_HOST" \
             "docker ps --filter 'name=fateconnect-${{ inputs.environment }}' --filter 'status=running' --format '{{.Names}}'" \
             > containers.txt
           echo 'No ar:'; cat containers.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
           # Um ambiente é um contêiner, o da API: banco e servidor web são do
           # host e não aparecem aqui.
           total=$(grep -c . containers.txt || true)
-          if [ "$total" -lt 1 ]; then
+          if [[ "$total" -lt 1 ]]; then
             echo "ERRO: nenhum contêiner de pé; esperado 1." >&2
             exit 1
           fi

--- a/FateConnect/FateConnect.Api/Dockerfile
+++ b/FateConnect/FateConnect.Api/Dockerfile
@@ -14,4 +14,6 @@ COPY --from=build /app ./
 ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080
 
+USER $APP_UID
+
 ENTRYPOINT ["dotnet", "FateConnect.Api.dll"]

--- a/FateConnect/Web/design-system/components/FilterPanel/index.tsx
+++ b/FateConnect/Web/design-system/components/FilterPanel/index.tsx
@@ -14,7 +14,8 @@ export type FilterPanelProps = Readonly<{
   columns: number;
   /** Ponto ao lado do título enquanto a lista está filtrada. */
   active?: boolean;
-  onSubmit: (event: SubmitEvent<HTMLElement>) => void;
+  /** Chamado com o submit nativo já prevenido pelo painel. */
+  onSubmit: VoidFunction;
   children: ReactNode;
 }>;
 
@@ -30,6 +31,11 @@ function FilterPanel({
   onSubmit,
   children,
 }: FilterPanelProps) {
+  const handleSubmit = (event: SubmitEvent<HTMLElement>) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
   return (
     <S.PanelRoot defaultExpanded disableGutters>
       <S.PanelHeader expandIcon={<ChevronRightIcon />}>
@@ -42,7 +48,7 @@ function FilterPanel({
       </S.PanelHeader>
 
       <S.PanelBody>
-        <S.PanelForm component="form" onSubmit={onSubmit}>
+        <S.PanelForm component="form" onSubmit={handleSubmit}>
           <S.FieldsRow columns={columns}>
             {children}
 

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFilter/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFilter/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, type ChangeEvent, type SubmitEvent } from 'react';
+import { useCallback, useMemo, useState, type ChangeEvent } from 'react';
 import { FilterPanel, Input } from '@design-system';
 
 import { isLostItemKind } from '@app/pages/LostAndFound/helpers/lostItemKind';
@@ -51,23 +51,18 @@ export function LostItemFilter({ onApply }: LostItemFilterProps) {
     [],
   );
 
-  const handleSubmit = useCallback(
-    (event: SubmitEvent<HTMLElement>) => {
-      event.preventDefault();
+  const handleSubmit = useCallback(() => {
+    const filters: LostItemFilterValues = {};
 
-      const filters: LostItemFilterValues = {};
+    if (itemName.trim()) filters.name = itemName.trim();
+    if (occurredOn) filters.occurredOn = toApiDate(occurredOn);
+    if (isLostItemKind(kind)) filters.kind = kind;
+    if (owner === C.LostItemOwnerFilterEnum.MINE) filters.onlyMine = true;
+    if (isLostItemStatus(status)) filters.status = status;
 
-      if (itemName.trim()) filters.name = itemName.trim();
-      if (occurredOn) filters.occurredOn = toApiDate(occurredOn);
-      if (isLostItemKind(kind)) filters.kind = kind;
-      if (owner === C.LostItemOwnerFilterEnum.MINE) filters.onlyMine = true;
-      if (isLostItemStatus(status)) filters.status = status;
-
-      setIsFiltered(isBeyondDefault(filters));
-      onApply(filters);
-    },
-    [itemName, occurredOn, kind, owner, status, onApply],
-  );
+    setIsFiltered(isBeyondDefault(filters));
+    onApply(filters);
+  }, [itemName, occurredOn, kind, owner, status, onApply]);
 
   return (
     <FilterPanel

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ChangeEvent, type SubmitEvent } from 'react';
+import { useCallback, useState, type ChangeEvent } from 'react';
 import { FilterPanel, Input } from '@design-system';
 
 import type { RideFilter as RideFilterValues, RideTypeEnum } from '@app/services/rides/types';
@@ -32,22 +32,17 @@ export function RideFilter({ onApply }: RideFilterProps) {
     [],
   );
 
-  const handleSubmit = useCallback(
-    (event: SubmitEvent<HTMLElement>) => {
-      event.preventDefault();
+  const handleSubmit = useCallback(() => {
+    const filters: RideFilterValues = {};
 
-      const filters: RideFilterValues = {};
+    if (departureDate) filters.departureDate = toApiDate(departureDate);
+    if (departureTime) filters.departureTime = departureTime;
+    if (destination.trim()) filters.destination = destination.trim();
+    if (rideType) filters.rideType = rideType as RideTypeEnum;
 
-      if (departureDate) filters.departureDate = toApiDate(departureDate);
-      if (departureTime) filters.departureTime = departureTime;
-      if (destination.trim()) filters.destination = destination.trim();
-      if (rideType) filters.rideType = rideType as RideTypeEnum;
-
-      setIsFiltered(Object.keys(filters).length > NO_FILTERS);
-      onApply(filters);
-    },
-    [departureDate, departureTime, destination, rideType, onApply],
-  );
+    setIsFiltered(Object.keys(filters).length > NO_FILTERS);
+    onApply(filters);
+  }, [departureDate, departureTime, destination, rideType, onApply]);
 
   return (
     <FilterPanel

--- a/deploy/build-front.sh
+++ b/deploy/build-front.sh
@@ -15,7 +15,7 @@ case "$ENVIRONMENT" in
 esac
 
 ENV_FILE=".env.$ENVIRONMENT"
-if [ ! -f "$ENV_FILE" ]; then
+if [[ ! -f "$ENV_FILE" ]]; then
   echo "ERRO: falta deploy/$ENV_FILE." >&2
   exit 1
 fi
@@ -23,13 +23,13 @@ fi
 # shellcheck disable=SC1090
 set -a; . "./$ENV_FILE"; set +a
 
-if [ -z "${PUBLIC_URL:-}" ]; then
+if [[ -z "${PUBLIC_URL:-}" ]]; then
   echo "ERRO: PUBLIC_URL não está preenchido em deploy/$ENV_FILE." >&2
   exit 1
 fi
 
 TARGET="/var/www/fateconnect/$ENVIRONMENT"
-if [ ! -d "$TARGET" ]; then
+if [[ ! -d "$TARGET" ]]; then
   echo "ERRO: $TARGET não existe. Rode antes:  sudo ./install-site.sh $ENVIRONMENT" >&2
   exit 1
 fi

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -21,7 +21,7 @@ esac
 # valer também na execução manual, e vem antes do `git checkout` abaixo porque é
 # ele que ela protege — o `flock` a segura através do `exec`.
 LOCK_FILE=/var/lock/fateconnect-deploy
-if [ -z "${DEPLOY_LOCKED:-}" ]; then
+if [[ -z "${DEPLOY_LOCKED:-}" ]]; then
   if ! flock -n "$LOCK_FILE" true; then
     echo "==> Outra publicação está em andamento na VPS; esperando ela terminar"
   fi
@@ -32,11 +32,11 @@ fi
 # validação, um defeito nas linhas de cima travaria a publicação para sempre: o
 # script quebrado nunca alcança o `git pull` que traria a própria correção, e só
 # um acesso manual à máquina destrava.
-if [ -z "${DEPLOY_SELF_UPDATED:-}" ]; then
+if [[ -z "${DEPLOY_SELF_UPDATED:-}" ]]; then
   echo "==> Atualizando o código a partir da branch $BRANCH"
   # Avisar e seguir não adianta: o `git checkout` abaixo aborta sozinho e a
   # mensagem dele não diz o que fazer. Melhor parar aqui, explicando.
-  if [ -n "$(git -C .. status --porcelain)" ]; then
+  if [[ -n "$(git -C .. status --porcelain)" ]]; then
     echo "ERRO: há alterações não commitadas nesta cópia do repositório." >&2
     echo "Veja o que é com:  git -C '$(cd .. && pwd)' status" >&2
     exit 1
@@ -55,7 +55,7 @@ ENV_FILE=".env.$ENVIRONMENT"
 PROJECT="fateconnect-$ENVIRONMENT"
 WEB_ROOT="/var/www/fateconnect/$ENVIRONMENT"
 
-if [ ! -f "$ENV_FILE" ]; then
+if [[ ! -f "$ENV_FILE" ]]; then
   echo "ERRO: falta o arquivo deploy/$ENV_FILE." >&2
   echo "  cp .env.example $ENV_FILE && nano $ENV_FILE" >&2
   exit 1
@@ -67,17 +67,17 @@ set -a; . "./$ENV_FILE"; set +a
 missing=''
 for name in DOMAIN PUBLIC_URL API_PORT POSTGRES_DB POSTGRES_USER POSTGRES_PASSWORD JWT_SECRET; do
   eval "value=\${$name:-}"
-  if [ -z "$value" ]; then
+  if [[ -z "$value" ]]; then
     missing="$missing $name"
   fi
 done
 
-if [ -n "$missing" ]; then
+if [[ -n "$missing" ]]; then
   echo "ERRO: variáveis sem valor em deploy/$ENV_FILE:$missing" >&2
   exit 1
 fi
 
-if [ ! -f "$WEB_ROOT/index.html" ]; then
+if [[ ! -f "$WEB_ROOT/index.html" ]]; then
   echo "ERRO: falta o front em $WEB_ROOT." >&2
   echo "Pela pipeline ele é enviado pelo runner. Publicando à mão, gere antes:" >&2
   echo "  ./build-front.sh $ENVIRONMENT" >&2

--- a/deploy/install-site.sh
+++ b/deploy/install-site.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-if [ "$(id -u)" -ne 0 ]; then
+if [[ "$(id -u)" -ne 0 ]]; then
   echo "Rode com sudo: sudo ./install-site.sh hml|prod" >&2
   exit 1
 fi
@@ -19,7 +19,7 @@ case "$ENVIRONMENT" in
 esac
 
 ENV_FILE=".env.$ENVIRONMENT"
-if [ ! -f "$ENV_FILE" ]; then
+if [[ ! -f "$ENV_FILE" ]]; then
   echo "ERRO: falta deploy/$ENV_FILE." >&2
   exit 1
 fi
@@ -29,7 +29,7 @@ set -a; . "./$ENV_FILE"; set +a
 
 for name in DOMAIN API_PORT; do
   eval "value=\${$name:-}"
-  if [ -z "$value" ]; then
+  if [[ -z "$value" ]]; then
     echo "ERRO: $name não está preenchido em deploy/$ENV_FILE." >&2
     exit 1
   fi
@@ -57,7 +57,7 @@ systemctl reload nginx
 # O passo acima sobrescreve o arquivo inteiro, e o template só descreve a porta
 # 80 — então o bloco 443 que o certbot escreveu some a cada execução. Reaplicar
 # não reemite certificado: só devolve o TLS ao arquivo recém-gerado.
-if [ -d "/etc/letsencrypt/live/$DOMAIN" ]; then
+if [[ -d "/etc/letsencrypt/live/$DOMAIN" ]]; then
   echo "==> Devolvendo o HTTPS à configuração recém-gerada"
   certbot install --nginx --cert-name "$DOMAIN"
   nginx -t
@@ -66,7 +66,7 @@ fi
 
 echo
 echo "Pronto: $DOMAIN servido a partir de $TARGET"
-if [ ! -d "/etc/letsencrypt/live/$DOMAIN" ]; then
+if [[ ! -d "/etc/letsencrypt/live/$DOMAIN" ]]; then
   echo "Para ligar o HTTPS depois que o domínio estiver respondendo:"
   echo "  sudo certbot --nginx -d $DOMAIN"
 fi

--- a/deploy/vps-setup.sh
+++ b/deploy/vps-setup.sh
@@ -13,7 +13,7 @@
 # está listado no final como sugestão.
 set -euo pipefail
 
-if [ "$(id -u)" -ne 0 ]; then
+if [[ "$(id -u)" -ne 0 ]]; then
   echo "Rode com sudo: sudo ./vps-setup.sh" >&2
   exit 1
 fi
@@ -83,7 +83,7 @@ for environment in hml prod; do
   # `sudo -u` e não `su -`: o usuário postgres costuma ter /sbin/nologin como
   # shell, e aí o `su` falha sem conseguir sequer abrir a sessão.
   exists=$(sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='$database'")
-  if [ "$exists" = "1" ]; then
+  if [[ "$exists" = "1" ]]; then
     echo "    $database já existe; senha não alterada"
     continue
   fi

--- a/deploy/vps-setup.sh
+++ b/deploy/vps-setup.sh
@@ -36,7 +36,7 @@ echo "==> 2/5 Docker"
 if command -v docker >/dev/null 2>&1; then
   echo "    já instalado: $(docker --version)"
 else
-  curl -fsSL https://get.docker.com | sh
+  curl -fsSL --proto '=https' --tlsv1.2 https://get.docker.com | sh
 fi
 usermod -aG docker "$TARGET_USER"
 echo "    $TARGET_USER adicionado ao grupo docker (vale no próximo login)"

--- a/scripts/check-harness-paths.sh
+++ b/scripts/check-harness-paths.sh
@@ -32,7 +32,7 @@ conhecidos=$(mktemp)
 encontrados=0
 
 while IFS=: read -r arquivo linha citado; do
-  [ -z "${citado:-}" ] && continue
+  [[ -z "${citado:-}" ]] && continue
   citado="${citado%/}"
   grep -qxF "$citado" "$conhecidos" && continue
   echo "  $arquivo:$linha  →  $citado"
@@ -43,7 +43,7 @@ done < <(
 
 rm -f "$conhecidos"
 
-if [ "$encontrados" -gt 0 ]; then
+if [[ "$encontrados" -gt 0 ]]; then
   echo
   echo "$encontrados caminho(s) citado(s) em .claude/ não existem no repositório."
   echo "Atualize o texto — ou, se o caminho é de propósito, acrescente-o a 'ignorados'."

--- a/scripts/coverage-changed.sh
+++ b/scripts/coverage-changed.sh
@@ -24,7 +24,7 @@ dotnet test "$SOLUTION" --nologo \
   --results-directory "$saida" >/dev/null
 
 relatorio="$(find "$saida" -name coverage.opencover.xml | head -1)"
-if [ -z "$relatorio" ]; then
+if [[ -z "$relatorio" ]]; then
   echo "coverage-changed: a suíte não produziu relatório de cobertura" >&2
   exit 1
 fi


### PR DESCRIPTION
## Objetivo

Endereçar os 31 apontamentos da análise estática no projeto **FateConnect API** — 20 de Reliability e 11 de Security — e corrigir, junto, um defeito de altitude no `FilterPanel` que apareceu enquanto se investigava um aviso da suíte de testes.

Nenhuma das mudanças altera o comportamento do produto, então não há entrada de CHANGELOG.

## Alterações

### 1. `chore: use [[ for shell test conditionals`

As 20 ocorrências de `shelldre:S7688` (Reliability), em 6 scripts, mais a linha 101 do `publish.yml` — o mesmo padrão, num arquivo que este PR já toca. Todos os scripts declaram `#!/usr/bin/env bash` e nenhum é invocado com `sh`, então `[[` é seguro.

| Arquivo | Trocas |
| --- | --- |
| `deploy/deploy.sh` | 7 |
| `deploy/install-site.sh` | 5 |
| `deploy/build-front.sh` | 3 |
| `deploy/vps-setup.sh` | 2 |
| `scripts/check-harness-paths.sh` | 2 |
| `scripts/coverage-changed.sh` | 1 |
| `.github/workflows/publish.yml` | 1 |

### 2. `fix: address the security findings in the deploy pipeline`

As 11 de Security, em três regras distintas:

- **`githubactions:S7636` (9×)** — `DEPLOY_SSH_KEY`, `DEPLOY_HOST`, `DEPLOY_USER` e `DEPLOY_PATH` eram interpolados como `${{ secrets.X }}` dentro dos blocos `run`, o que insere o valor no script **antes** de o shell existir. Agora entram por `env:` no step e o shell lê `$VAR`.
- **`docker:S6471` (1×)** — o container da API rodava como `root`. Passa a `USER $APP_UID`, o usuário não-privilegiado que a imagem `dotnet/aspnet:8.0` já traz.
- **`shell:S6506` (1×)** — o `curl -fsSL` que instala o Docker segue redirects e poderia cair em HTTP. Ganhou `--proto '=https' --tlsv1.2`.

### 3. `refactor: prevent the filter form submit inside the panel`

O `FilterPanel` renderiza um `<form>` que nunca deve fazer submit nativo, mas deixava a cada consumidor a obrigação de lembrar disso. Os dois que existem acertavam; um terceiro que esquecesse recarregaria a página com os filtros virando query string — falha silenciosa.

Agora o painel chama `event.preventDefault()` por dentro e a prop `onSubmit` vira `VoidFunction`. `RideFilter` e `LostItemFilter` deixam de repetir a prevenção — nos dois, o `event` só existia para isso.

De quebra, some o aviso `Not implemented: HTMLFormElement's requestSubmit()` que aparecia na suíte: o jsdom dispara o evento normalmente e só avisa quando **ninguém cancela** o submit.

## Evidências

| Verificação | Resultado |
| --- | --- |
| API — build e testes | 0 erros · 49 testes |
| Front — ESLint / `tsc` | 0 / 0 |
| Front — suíte e cobertura | 449 testes · 98.45 / 92.28 / 98.02 / 99.32 |
| Aviso `requestSubmit` na suíte | 1 → **0** |
| `bash -n` nos 6 scripts | limpo |
| `[` vs `[[` — 29 condições sob os mesmos valores | **0 divergências** |
| `check-harness-paths.sh` e `coverage-changed.sh`, antes vs depois | saída **idêntica**, exit 0 |
| `publish.yml` — YAML e os 8 blocos `run` | parse OK · 0 erros de sintaxe |
| Credenciais no diff | nenhum valor; só referências `${{ secrets.X }}` |

### O container não-root, testado de verdade

A API foi publicada, empacotada numa imagem com o `USER $APP_UID` deste PR e subida contra um PostgreSQL — com a **mesma imagem sem o `USER` como controle**:

| | não-root | root (controle) |
| --- | --- | --- |
| identidade do processo | `uid=1654(app)` | `uid=0(root)` |
| container | de pé, 0 erros no log | de pé |
| `GET /Auth/session` sem token | **401** | 401 |
| `/swagger/v1/swagger.json` | **200** | 200 |
| migrations no startup | 5 tabelas criadas | — |

Os dois são indistinguíveis em comportamento. Também foi confirmado, na imagem base, que `APP_UID=1654` existe, que o usuário `app` lê os arquivos copiados como root (`-rw-r--r--`), e que `ip_unprivileged_port_start=0` — a porta 8080 não exige privilégio.

ℹ️ **`${{ inputs.environment }}` segue interpolado nos `run`, de propósito.** O Sonar não o aponta (a regra é sobre segredos) e o valor vem dos nossos próprios workflows, não de entrada externa.
