### PR TITLE
feat(172): paginate the ride listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Passa a responder a listagem de caronas em páginas de 10, com o total e a quantidade de páginas, e aceita escolher a página e o tamanho dela até um teto de 50; antes devolvia todas as caronas ativas de uma vez (#236) [Backend]
+
+### Fixed
+
+- Corrige a listagem de caronas, que continuava exibindo — e no topo — as caronas cujo horário de partida já tinha passado (#236) [Backend]
+
 ## [0.6.0] - 2026-08-30
 
 ### Changed

--- a/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
+++ b/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
@@ -2,6 +2,8 @@ using System.Net.Http.Headers;
 using FateConnect.Api.Infrastructure.Database;
 using FateConnect.Api.Modules.Auth.Entities;
 using FateConnect.Api.Modules.Auth.Services;
+using FateConnect.Api.Modules.Rides.Entities;
+using FateConnect.Api.Modules.Rides.Enums;
 using FateConnect.Api.Modules.Users.Entities;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -91,6 +93,22 @@ public class ApiFactory : WebApplicationFactory<Program>
         context.SaveChanges();
 
         return (user.Id, user.FatecEmail);
+    }
+
+    public Guid SeedRide(int driverId, DateOnly departureDate, TimeOnly departureTime, string destination = "Sorocaba centro")
+    {
+        using IServiceScope scope = Services.CreateScope();
+        FateConnectDbContext context = scope.ServiceProvider.GetRequiredService<FateConnectDbContext>();
+
+        DateOnly acceptedDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30));
+        Ride ride = new(3, destination, acceptedDate, departureTime, EnumRideType.Solidarity, driverId);
+
+        context.Rides.Add(ride);
+        context.Entry(ride).Property(entity => entity.DepartureDate).CurrentValue = departureDate;
+        context.Entry(ride).Property(entity => entity.DepartureTime).CurrentValue = departureTime;
+        context.SaveChanges();
+
+        return ride.Id;
     }
 
     public HttpClient CreateClientFor(int userId)

--- a/FateConnect/FateConnect.Api.Tests/PagedContractTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/PagedContractTests.cs
@@ -1,0 +1,63 @@
+using FateConnect.Api.Modules.Common.DTOs;
+
+namespace FateConnect.Api.Tests;
+
+public class PagedContractTests
+{
+    [Theory]
+    [InlineData(0, 10, 0)]
+    [InlineData(1, 10, 1)]
+    [InlineData(10, 10, 1)]
+    [InlineData(11, 10, 2)]
+    [InlineData(97, 10, 10)]
+    [InlineData(100, 50, 2)]
+    public void TotalPages_RoundsTheTotalOverThePageSizeUp(int total, int pageSize, int expected)
+    {
+        PagedResultDto<string> page = new()
+        {
+            Items = [],
+            Page = 1,
+            PageSize = pageSize,
+            Total = total,
+        };
+
+        Assert.Equal(expected, page.TotalPages);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData(0, 1)]
+    [InlineData(-7, 1)]
+    [InlineData(3, 3)]
+    public void EffectivePage_NeverGoesBelowTheFirstPage(int? requested, int expected)
+    {
+        PagedFilterDto filter = new() { Page = requested };
+
+        Assert.Equal(expected, filter.EffectivePage);
+    }
+
+    [Theory]
+    [InlineData(null, 10)]
+    [InlineData(0, 10)]
+    [InlineData(-3, 10)]
+    [InlineData(25, 25)]
+    [InlineData(50, 50)]
+    [InlineData(100000, 50)]
+    public void EffectivePageSize_FallsBackToTheDefaultAndStopsAtTheCap(int? requested, int expected)
+    {
+        PagedFilterDto filter = new() { PageSize = requested };
+
+        Assert.Equal(expected, filter.EffectivePageSize);
+    }
+
+    [Theory]
+    [InlineData(1, 10, 0)]
+    [InlineData(2, 10, 10)]
+    [InlineData(3, 25, 50)]
+    public void ItemsToSkip_LeavesOutEveryPageBeforeTheRequestedOne(int page, int pageSize, int expected)
+    {
+        PagedFilterDto filter = new() { Page = page, PageSize = pageSize };
+
+        Assert.Equal(expected, filter.ItemsToSkip);
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/RidePaginationTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/RidePaginationTests.cs
@@ -1,0 +1,193 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace FateConnect.Api.Tests;
+
+public class RidePaginationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private sealed record ReadRide(Guid Id, string Destination);
+
+    private sealed record PagedRides(
+        IReadOnlyList<ReadRide> Items,
+        int Page,
+        int PageSize,
+        int Total,
+        int TotalPages);
+
+    private static int SeedRides(ApiFactory factory, int count)
+    {
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+
+        for (int index = 0; index < count; index++)
+            factory.SeedRide(driverId, tomorrow.AddDays(index), new TimeOnly(8, 30));
+
+        return driverId;
+    }
+
+    private static async Task<PagedRides> GetPageAsync(ApiFactory factory, int userId, string query = "")
+    {
+        PagedRides? page = await factory
+            .CreateClientFor(userId)
+            .GetFromJsonAsync<PagedRides>($"/Rides{query}", JsonOptions);
+
+        return page!;
+    }
+
+    [Fact]
+    public async Task GetRides_WithoutPagingParameters_ReturnsTheFirstTenRides()
+    {
+        using ApiFactory factory = new();
+        int driverId = SeedRides(factory, 23);
+
+        PagedRides page = await GetPageAsync(factory, driverId);
+
+        Assert.Equal(10, page.Items.Count);
+        Assert.Equal(1, page.Page);
+        Assert.Equal(10, page.PageSize);
+        Assert.Equal(23, page.Total);
+        Assert.Equal(3, page.TotalPages);
+    }
+
+    [Fact]
+    public async Task GetRides_WithASecondPage_ReturnsTheRidesThatFollowTheFirst()
+    {
+        using ApiFactory factory = new();
+        int driverId = SeedRides(factory, 23);
+
+        PagedRides first = await GetPageAsync(factory, driverId, "?Page=1");
+        PagedRides second = await GetPageAsync(factory, driverId, "?Page=2");
+
+        Assert.Equal(10, second.Items.Count);
+        Assert.Equal(2, second.Page);
+        Assert.Empty(first.Items.Select(ride => ride.Id).Intersect(second.Items.Select(ride => ride.Id)));
+    }
+
+    [Fact]
+    public async Task GetRides_WithAPageBeyondTheLast_ReturnsNoItemsAndKeepsTheTotal()
+    {
+        using ApiFactory factory = new();
+        int driverId = SeedRides(factory, 23);
+
+        PagedRides page = await GetPageAsync(factory, driverId, "?Page=99");
+
+        Assert.Empty(page.Items);
+        Assert.Equal(23, page.Total);
+        Assert.Equal(3, page.TotalPages);
+    }
+
+    [Theory]
+    [InlineData("?Page=0")]
+    [InlineData("?Page=-5")]
+    public async Task GetRides_WithAPageBelowTheFirst_FallsBackToTheFirstPage(string query)
+    {
+        using ApiFactory factory = new();
+        int driverId = SeedRides(factory, 12);
+
+        PagedRides page = await GetPageAsync(factory, driverId, query);
+
+        Assert.Equal(1, page.Page);
+        Assert.Equal(10, page.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetRides_WithAPageSizeAboveTheCap_FallsBackToTheCap()
+    {
+        using ApiFactory factory = new();
+        int driverId = SeedRides(factory, 55);
+
+        PagedRides page = await GetPageAsync(factory, driverId, "?PageSize=100000");
+
+        Assert.Equal(50, page.PageSize);
+        Assert.Equal(50, page.Items.Count);
+        Assert.Equal(55, page.Total);
+        Assert.Equal(2, page.TotalPages);
+    }
+
+    [Theory]
+    [InlineData("?PageSize=0")]
+    [InlineData("?PageSize=-3")]
+    public async Task GetRides_WithAPageSizeBelowOne_FallsBackToTheDefault(string query)
+    {
+        using ApiFactory factory = new();
+        int driverId = SeedRides(factory, 12);
+
+        PagedRides page = await GetPageAsync(factory, driverId, query);
+
+        Assert.Equal(10, page.PageSize);
+        Assert.Equal(10, page.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetRides_WithoutAnyResult_ReportsZeroTotalPages()
+    {
+        using ApiFactory factory = new();
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+
+        PagedRides page = await GetPageAsync(factory, driverId);
+
+        Assert.Empty(page.Items);
+        Assert.Equal(0, page.Total);
+        Assert.Equal(0, page.TotalPages);
+    }
+
+    [Fact]
+    public async Task GetRides_WithARideAlreadyDeparted_LeavesItOutAndOutOfTheTotal()
+    {
+        using ApiFactory factory = new();
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+
+        DateOnly yesterday = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1));
+        DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+        factory.SeedRide(driverId, yesterday, new TimeOnly(8, 30), "Carona vencida");
+        Guid upcoming = factory.SeedRide(driverId, tomorrow, new TimeOnly(8, 30), "Carona futura");
+
+        PagedRides page = await GetPageAsync(factory, driverId);
+
+        Assert.Equal(1, page.Total);
+        Assert.Equal(upcoming, Assert.Single(page.Items).Id);
+    }
+
+    [Fact]
+    public async Task GetRides_FilteredByDepartureTime_KeepsOnlyTheRidesThatLeaveAtThatHour()
+    {
+        using ApiFactory factory = new();
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+        factory.SeedRide(driverId, tomorrow, new TimeOnly(7, 0));
+        factory.SeedRide(driverId, tomorrow, new TimeOnly(22, 0));
+
+        PagedRides page = await GetPageAsync(factory, driverId, "?DepartureTime=07:00:00");
+
+        Assert.Equal(1, page.Total);
+    }
+
+    [Fact]
+    public async Task GetRides_FilteredByRideType_KeepsOnlyTheRidesOfThatType()
+    {
+        using ApiFactory factory = new();
+        int driverId = SeedRides(factory, 3);
+
+        PagedRides solidarity = await GetPageAsync(factory, driverId, "?RideType=Solidarity");
+        PagedRides egalitarian = await GetPageAsync(factory, driverId, "?RideType=Egalitarian");
+
+        Assert.Equal(3, solidarity.Total);
+        Assert.Equal(0, egalitarian.Total);
+    }
+
+    [Fact]
+    public async Task GetRides_WithAFilter_CountsTheTotalAfterFilteringAndBeforePaging()
+    {
+        using ApiFactory factory = new();
+        int driverId = SeedRides(factory, 23);
+        DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+
+        PagedRides page = await GetPageAsync(factory, driverId, $"?DepartureDate={tomorrow:yyyy-MM-dd}");
+
+        Assert.Equal(1, page.Total);
+        Assert.Equal(1, page.TotalPages);
+        Assert.Single(page.Items);
+    }
+}

--- a/FateConnect/FateConnect.Api/Modules/Common/DTOs/PagedFilterDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Common/DTOs/PagedFilterDto.cs
@@ -1,0 +1,33 @@
+namespace FateConnect.Api.Modules.Common.DTOs;
+
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+public record PagedFilterDto
+{
+    public const int FirstPage = 1;
+    public const int DefaultPageSize = 10;
+    public const int MaxPageSize = 50;
+
+    public int? Page { get; init; }
+    public int? PageSize { get; init; }
+
+    [BindNever]
+    public int EffectivePage => Math.Max(FirstPage, Page ?? FirstPage);
+
+    [BindNever]
+    public int ItemsToSkip => (EffectivePage - FirstPage) * EffectivePageSize;
+
+    [BindNever]
+    public int EffectivePageSize
+    {
+        get
+        {
+            int requested = PageSize ?? DefaultPageSize;
+
+            if (requested < FirstPage)
+                return DefaultPageSize;
+
+            return Math.Min(requested, MaxPageSize);
+        }
+    }
+}

--- a/FateConnect/FateConnect.Api/Modules/Common/DTOs/PagedResultDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Common/DTOs/PagedResultDto.cs
@@ -1,0 +1,11 @@
+namespace FateConnect.Api.Modules.Common.DTOs;
+
+public record PagedResultDto<T>
+{
+    public required IReadOnlyList<T> Items { get; init; }
+    public required int Page { get; init; }
+    public required int PageSize { get; init; }
+    public required int Total { get; init; }
+
+    public int TotalPages => (Total + PageSize - 1) / PageSize;
+}

--- a/FateConnect/FateConnect.Api/Modules/Rides/Controllers/RidesController.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Controllers/RidesController.cs
@@ -1,6 +1,7 @@
 namespace FateConnect.Api.Modules.Rides.Controllers;
 
 using FateConnect.Api.Modules.Auth.Extensions;
+using FateConnect.Api.Modules.Common.DTOs;
 using FateConnect.Api.Modules.Rides.DTOs;
 using FateConnect.Api.Modules.Rides.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -14,8 +15,8 @@ using Swashbuckle.AspNetCore.Annotations;
 public class RidesController(IRideService rideService) : ControllerBase
 {
     [HttpGet]
-    [SwaggerOperation(Summary = "Get active rides", Description = "Returns a list of all rides that are currently active based on optional filters.")]
-    public async Task<ActionResult<IEnumerable<ReadRideDto>>> GetAllAsync([FromQuery] FilterRideDto filters)
+    [SwaggerOperation(Summary = "Get active rides", Description = "Returns a page of active rides whose departure has not passed yet, matching the optional filters.")]
+    public async Task<ActionResult<PagedResultDto<ReadRideDto>>> GetAllAsync([FromQuery] FilterRideDto filters)
     {
         var rides = await rideService.GetAllAsync(filters, User.GetUserId());
         return Ok(rides);

--- a/FateConnect/FateConnect.Api/Modules/Rides/DTOs/FilterRideDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/DTOs/FilterRideDto.cs
@@ -1,9 +1,10 @@
 namespace FateConnect.Api.Modules.Rides.DTOs;
 
 using System.ComponentModel.DataAnnotations;
+using FateConnect.Api.Modules.Common.DTOs;
 using FateConnect.Api.Modules.Rides.Enums;
 
-public record FilterRideDto
+public record FilterRideDto : PagedFilterDto
 {
     public string? Destination { get; init; }
     public DateOnly? DepartureDate { get; init; }

--- a/FateConnect/FateConnect.Api/Modules/Rides/Entities/Ride.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Entities/Ride.cs
@@ -111,6 +111,9 @@ public class Ride
 
     }
 
+    public static DateTime NowInProductTimeZone() =>
+        TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, ProductTimeZone);
+
     private static void ValidateDepartureDateTime(DateOnly date, TimeOnly time)
     {
         DateTime departureUtc = TimeZoneInfo.ConvertTimeToUtc(date.ToDateTime(time), ProductTimeZone);

--- a/FateConnect/FateConnect.Api/Modules/Rides/Interfaces/IRideRepository.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Interfaces/IRideRepository.cs
@@ -5,7 +5,7 @@ using FateConnect.Api.Modules.Rides.Entities;
 
 public interface IRideRepository
 {
-    Task<IReadOnlyList<Ride>> GetAllAsync(FilterRideDto filter);
+    Task<(IReadOnlyList<Ride> Items, int Total)> GetAllAsync(FilterRideDto filter);
     Task<Ride?> GetByIdAsync(Guid id);
     Task<Ride> AddAsync(Ride ride);
     Task UpdateAsync(Ride ride);

--- a/FateConnect/FateConnect.Api/Modules/Rides/Interfaces/IRideService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Interfaces/IRideService.cs
@@ -1,11 +1,12 @@
 namespace FateConnect.Api.Modules.Rides.Interfaces;
 
+using FateConnect.Api.Modules.Common.DTOs;
 using FateConnect.Api.Modules.Rides.DTOs;
 
 public interface IRideService
 {
     Task<ReadRideDto> CreateAsync(CreateRideDto dto, int currentUserId);
-    Task<IEnumerable<ReadRideDto>> GetAllAsync(FilterRideDto filter, int currentUserId);
+    Task<PagedResultDto<ReadRideDto>> GetAllAsync(FilterRideDto filter, int currentUserId);
     Task<ReadRideDto?> GetByIdAsync(Guid id, int currentUserId);
     Task<ReadRideDto?> UpdateAsync(Guid id, UpdateRideDto dto, int currentUserId);
     Task<bool> DeleteAsync(Guid id, int currentUserId);

--- a/FateConnect/FateConnect.Api/Modules/Rides/Repositories/RideRepository.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Repositories/RideRepository.cs
@@ -1,5 +1,6 @@
 namespace FateConnect.Api.Modules.Rides.Repositories;
 
+using System.Linq.Expressions;
 using FateConnect.Api.Infrastructure.Database;
 using FateConnect.Api.Modules.Rides.DTOs;
 using FateConnect.Api.Modules.Rides.Entities;
@@ -8,13 +9,17 @@ using Microsoft.EntityFrameworkCore;
 
 public class RideRepository(FateConnectDbContext context) : IRideRepository
 {
-    public async Task<IReadOnlyList<Ride>> GetAllAsync(FilterRideDto filter)
+    public async Task<(IReadOnlyList<Ride> Items, int Total)> GetAllAsync(FilterRideDto filter)
     {
+        DateTime nowInProductTimeZone = Ride.NowInProductTimeZone();
+        DateOnly today = DateOnly.FromDateTime(nowInProductTimeZone);
+        TimeOnly currentTime = TimeOnly.FromDateTime(nowInProductTimeZone);
 
         IQueryable<Ride> query = context.Rides
             .AsNoTracking()
             .Include(r => r.Driver.Contacts)
-            .Where(r => r.IsActive);
+            .Where(r => r.IsActive)
+            .Where(HasNotDeparted(today, currentTime));
 
         if (filter.DepartureDate.HasValue)
             query = query.Where(r => r.DepartureDate == filter.DepartureDate.Value);
@@ -40,13 +45,22 @@ public class RideRepository(FateConnectDbContext context) : IRideRepository
         if (filter.RideType.HasValue)
             query = query.Where(r => r.RideType == filter.RideType.Value);
 
-        var orderedRidesQuery = query
+        int total = await query.CountAsync();
+
+        List<Ride> items = await query
             .OrderBy(r => r.DepartureDate)
             .ThenBy(r => r.DepartureTime)
-            .ThenBy(r => r.Id);
+            .ThenBy(r => r.Id)
+            .Skip(filter.ItemsToSkip)
+            .Take(filter.EffectivePageSize)
+            .ToListAsync();
 
-        return await orderedRidesQuery.ToListAsync();
+        return (items, total);
     }
+
+    private static Expression<Func<Ride, bool>> HasNotDeparted(DateOnly today, TimeOnly currentTime) =>
+        ride => ride.DepartureDate > today
+            || (ride.DepartureDate == today && ride.DepartureTime >= currentTime);
 
     public async Task<Ride?> GetByIdAsync(Guid id)
     {

--- a/FateConnect/FateConnect.Api/Modules/Rides/Services/RideService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Rides/Services/RideService.cs
@@ -1,5 +1,6 @@
 namespace FateConnect.Api.Modules.Rides.Services;
 
+using FateConnect.Api.Modules.Common.DTOs;
 using FateConnect.Api.Modules.Rides.DTOs;
 using FateConnect.Api.Modules.Rides.Entities;
 using FateConnect.Api.Modules.Rides.Exceptions;
@@ -31,13 +32,19 @@ public partial class RideService(
         return MapToReadDto(ride, currentUserId);
     }
 
-    public async Task<IEnumerable<ReadRideDto>> GetAllAsync(FilterRideDto filter, int currentUserId)
+    public async Task<PagedResultDto<ReadRideDto>> GetAllAsync(FilterRideDto filter, int currentUserId)
     {
-        var rides = await repository.GetAllAsync(filter);
+        (IReadOnlyList<Ride> rides, int total) = await repository.GetAllAsync(filter);
 
         LogRidesRetrieved(logger, rides.Count);
 
-        return rides.Select(ride => MapToReadDto(ride, currentUserId));
+        return new PagedResultDto<ReadRideDto>
+        {
+            Items = [.. rides.Select(ride => MapToReadDto(ride, currentUserId))],
+            Page = filter.EffectivePage,
+            PageSize = filter.EffectivePageSize,
+            Total = total,
+        };
     }
 
     public async Task<ReadRideDto?> GetByIdAsync(Guid id, int currentUserId)


### PR DESCRIPTION
## Objetivo

Paginar `GET /Rides`, que devolvia um array cru com **todas** as caronas ativas. A tela precisa da fatia e do total — e, para a primeira página ser útil, precisa também que carona já partida saia da lista.

## Alterações

### O contrato de paginação, compartilhado

Nasce em `Modules/Common/DTOs`, **inteiro** — entrada e saída —, para o achados e perdidos (#174) reaproveitar com uma linha (`LostItemFilterDto : PagedFilterDto`):

| | |
| --- | --- |
| `PagedFilterDto` | `Page` e `PageSize` com o padrão, o teto e o ajuste de valor inválido |
| `PagedResultDto<T>` | `items`, `page`, `pageSize`, `total`, `totalPages` |

O cálculo do salto mora no filtro, como `ItemsToSkip`. É de propósito: `(page - 1) * size` é onde o off-by-one de paginação nasce, e assim quem herda recebe a conta pronta em vez de reescrevê-la.

### A listagem de caronas

`FilterRideDto` passa a herdar o contrato; o repositório conta **antes** de cortar e descarta o que já partiu; o serviço monta o envelope; controller e Swagger acompanham.

```
GET /Rides?Page=2&PageSize=10   →   { items, page, pageSize, total, totalPages }
```

`Page` começa em 1 e valor inválido vale 1. `PageSize` tem padrão 10 e teto 50. `total` é contado depois dos filtros e antes do corte, `totalPages` arredonda para cima e é 0 sem resultado, e página além da última devolve `items` vazio com o total certo.

O corte de carona vencida usa o instante de partida no fuso do produto — o mesmo critério que a entidade já aplica ao criar e editar.

### Duas decisões de desenho

**O predicado é uma `Expression`, não um método.** `HasNotDeparted(today, currentTime)` dá nome à regra e sobrevive à tradução. Medido nas duas formas: a `Expression` gera

```sql
WHERE r."DepartureDate" > @p OR (r."DepartureDate" = @p AND r."DepartureTime" >= @q)
```

e a forma de método falha com `The LINQ expression could not be translated`.

**As propriedades derivadas levam `[BindNever]`.** Sem isso o Swashbuckle publicava `EffectivePage`, `EffectivePageSize` e `ItemsToSkip` como parâmetros de query — só apareceu ao conferir o JSON gerado.

## Issue

- #172

Closes #172

Sub-issue da #170.

⚠️ **Ordem de merge.** Esta é a metade de baixo de um contrato que o front consome. Mergear sozinha deixa a lista de caronas quebrada em homologação, porque o front ainda espera array cru. A #173 sai empilhada nesta.

## Evidências

| Verificação | Resultado |
| --- | --- |
| Build da solução | 0 erros |
| Suíte da API | **81 testes**, 0 falhas |
| Teste de mutação | **6 mutações, 6 mortas** |
| Swagger (JSON gerado) | query só com `Destination`, `DepartureDate`, `DepartureTime`, `RideType`, `Page`, `PageSize` |
| Cada commit isolado | compila e passa sozinho, verificado em worktree |

As seis mutações: corte off-by-one, contagem depois do corte, teto do `PageSize` ignorado, arredondamento de `TotalPages`, filtro de carona partida removido, e `ItemsToSkip` sem o `- FirstPage`. Todas derrubaram testes.

### Cobertura — o `coverage-changed.sh` reprova, e vale a leitura completa

A dívida é **preexistente, e este PR a reduziu**:

| arquivo | develop | aqui |
| --- | --- | --- |
| `RideRepository.cs` | 68,1% | **78,9%** |
| `RideService.cs` | 88,4% | 89,1% |
| `Ride.cs` | 82,6% | 82,8% |

O que sobra são duas coisas que teste nenhum deste PR resolve:

- **As 12 linhas do filtro `Destination`** usam `EF.Functions.ILike` e `Unaccent`, funções do PostgreSQL. O provider InMemory da suíte não as executa — medido: a chamada responde **HTTP 500**. Cobrir exige Postgres na suíte, o que é mudança de infraestrutura e merece issue própria.
- **A linha "descoberta" de cada `record`** é o construtor de cópia sintético que o compilador gera para a expressão `with`, que não usamos em lugar nenhum e não dá para marcar com `[ExcludeFromCodeCoverage]`. É por isso que o `FilterRideDto` já era 80% na `develop` sem ninguém ter tocado nele.

⚠️ Um risco que fica registrado: **a suíte roda no InMemory, que executa LINQ em memória e aceita o que o PostgreSQL recusa.** Se alguém trocar aquela `Expression` por um método C#, os 81 testes continuam passando e a listagem quebra em produção.

## Duas notas para o review

**Uma decisão foi minha, não da issue.** Ela especifica `Page` inválida → 1, mas não diz o que fazer com `PageSize` **zero ou negativo** — só define padrão 10 e teto 50. Adotei: inválido → o padrão 10. Se preferir 1, é uma linha.

**Um item do escopo já estava feito.** A issue diz que a ordenação "para na data", mas o repositório já ordenava por `DepartureDate` → `DepartureTime` → `Id`, os três níveis. Envelheceu entre a escrita da issue e agora; não toquei.
