### PR TITLE
docs: record the C# query and mutation-testing rules

### DIFF
--- a/.claude/rules/dotnet-code-style.md
+++ b/.claude/rules/dotnet-code-style.md
@@ -74,3 +74,61 @@ git diff <base>..HEAD | grep -E "^\+" | grep -oE '"[^"]*<termo-novo>[^"]*"'   # 
 ⛔ **`[Route("[controller]")]`, nunca string literal.** É o que `RidesController`, `UsersController` e `AuthController` fazem, e é de onde saem `/Rides`, `/Users` e `/Auth`, com a inicial maiúscula.
 
 O roteamento do ASP.NET é case-insensitive, então `/users/signup` também resolve — o que muda é o endereço que o Swagger publica. Decidido em 30/08/2026, ao levar o controller de usuários para inglês: a issue tinha especificado `/users/signup` e ficou `/Users/signup`, pela simetria com `Rides`.
+
+## Exponha o comportamento, não o dado
+
+⛔ **Outra camada precisa de algo que está `private`? Exponha o método que responde à pergunta, não o campo.** Publicar o dado espalha o detalhe: quem consome passa a saber *como* a coisa é representada, e a conversão se repete em cada ponto que a usa.
+
+⛔ Cobrado na #172. O repositório precisava de "que horas são no fuso do produto" para descartar carona já partida, e o fuso era um `private static readonly TimeZoneInfo` na entidade `Ride`. Tornei o campo público — a saída de menor esforço, e a pior: o repositório passou a saber que existe um `TimeZoneInfo`, e a conversão ficou em dois lugares que se ignoram, cada um numa direção. A pergunta foi *"pq ProductTimeZone precisou se tornar público?"*.
+
+O que ficou:
+
+```csharp
+public static DateTime NowInProductTimeZone() =>
+    TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, ProductTimeZone);
+```
+
+`TimeZoneInfo` voltou a aparecer só dentro da entidade, e o repositório pergunta as horas em vez do fuso.
+
+**O tell é tornar público um `private` para atender um consumidor.** Antes de mudar o modificador, pergunte o que o consumidor realmente quer saber — quase sempre é uma resposta, não o dado bruto com que ela é calculada.
+
+## Predicado de consulta é `Expression`, não método
+
+⛔ **Dentro de `IQueryable`, condição composta que pede um nome vira `Expression<Func<T, bool>>`.** As duas formas naturais de dar nome não funcionam ali, e falham de maneiras diferentes:
+
+| Forma | O que acontece |
+| --- | --- |
+| variável `bool` dentro do lambda | **não compila** — expression tree não aceita corpo de bloco |
+| método `bool` comum | compila e **quebra em runtime**: `The LINQ expression could not be translated` |
+
+Medido na #172, com o provider do PostgreSQL. A forma correta gera SQL:
+
+```csharp
+private static Expression<Func<Ride, bool>> HasNotDeparted(DateOnly today, TimeOnly currentTime) =>
+    ride => ride.DepartureDate > today
+        || (ride.DepartureDate == today && ride.DepartureTime >= currentTime);
+```
+
+```sql
+WHERE r."DepartureDate" > @__today_0 OR (r."DepartureDate" = @__today_0 AND r."DepartureTime" >= @__currentTime_1)
+```
+
+E o `Where` passa a se ler sozinho: `.Where(HasNotDeparted(today, currentTime))`.
+
+⚠️ **Nomeie o conceito inteiro, não as metades.** `HasNotDeparted` diz o que a regra significa; quebrar em `isAfterToday || isTodayAndAfterNow` obriga quem lê a recompor o sentido a partir dos pedaços.
+
+⚠️ **O gate não protege isto.** A suíte roda no provider em memória, que executa LINQ em memória e aceita as duas formas — a que traduz e a que não. Para provar tradução, gere o SQL com `ToQueryString()` contra o `UseNpgsql`, que não precisa de banco no ar.
+
+## DTO de query: opcional é nullable, derivado é `[BindNever]`
+
+Dois apontamentos diferentes que aparecem no mesmo tipo de DTO — o que o controller recebe com `[FromQuery]`.
+
+⛔ **Tipo-valor cuja ausência é válida precisa ser nullable.** `int Page` num DTO de entrada reprova o build com `S6964`: quem omite o campo recebe o `default` em silêncio. Quando a omissão é intencional — e num filtro paginado ela é, o padrão está no contrato —, `int?` é o que declara isso. `required` também satisfaz o analisador, mas mente: torna o campo obrigatório.
+
+⛔ **Propriedade derivada precisa de `[BindNever]`, ou vira parâmetro público.** O Swashbuckle lista as propriedades do DTO como parâmetros de query, e não distingue as que existem só para normalizar. Na #172, `EffectivePage`, `EffectivePageSize` e `ItemsToSkip` foram publicadas no Swagger junto com `Page` e `PageSize`.
+
+**Isso só aparece lendo o JSON gerado** — o build fica verde e a aplicação funciona:
+
+```csharp
+string json = await factory.CreateClient().GetStringAsync("/swagger/v1/swagger.json");
+```

--- a/.claude/rules/dotnet-testing.md
+++ b/.claude/rules/dotnet-testing.md
@@ -113,6 +113,25 @@ O `ApiFactory` troca o provedor por `UseInMemoryDatabase`, e o `Program` só cha
 
 ⚠️ **O provedor em memória não é o Postgres.** Ele não avalia `unaccent` nem `ILike`, então filtro por destino não se prova ali: ou o teste evita esse caminho, ou a prova é gerar o SQL e lê-lo.
 
+⛔ **E o risco maior é o inverso: ele aceita o que o Postgres recusa.** O provedor em memória executa LINQ em memória, então uma consulta que o PostgreSQL não sabe traduzir passa verde aqui e quebra em produção. Trocar a `Expression` de um predicado por um método `bool` — ver `dotnet-code-style.md` — é a forma mais fácil de causar isso: a suíte inteira continua passando.
+
+**Enquanto for assim, tradução se prova gerando o SQL**, com `ToQueryString()` contra o `UseNpgsql`, que não precisa de banco no ar. A #237 troca o provedor por PostgreSQL real e **reescreve esta seção**.
+
+## Suíte verde não prova que ela pega o defeito
+
+⛔ **Quebre o código de propósito e confira que a suíte cai.** É a única forma de saber se o teste testa o que o nome dele diz — e o caso clássico é o teste que passa porque o cenário nunca se montou, não porque o código está certo.
+
+Na #172 foram seis mutações no que a paginação tem de arriscado — corte off-by-one, contar depois de cortar, ignorar o teto do `PageSize`, arredondar `TotalPages` para baixo, remover o filtro de carona partida e tirar o `- FirstPage` do salto. As seis derrubaram testes.
+
+⛔ **A armadilha é o build da mutação.** Se ele falhar, `dotnet test --no-build` roda a **DLL anterior** e tudo passa — o que se lê como "a mutação sobreviveu", quando ela nem chegou a existir. Aconteceu ali: remover um filtro deixou duas variáveis sem uso e, com `TreatWarningsAsErrors`, a compilação reprovou.
+
+```bash
+dotnet build <solução> -v q --nologo; echo "build da mutação exit=$?"   # 0, ou o resto não vale
+dotnet test <solução> --no-build
+```
+
+**Restaure a árvore ao fim de cada mutação** e confirme com `git status` que nada sobrou.
+
 ## Fixture usa dado plausível, e válido
 
 ⛔ **Nada de rótulo no lugar de dado.** `"Pessoa de Teste"`, `"Rua A"` e `"pessoa@example.com"` não são dados — são etiquetas dizendo "isto é um teste". Use nome, endereço e contato que poderiam existir: `"Mariana Alves Rocha"`, `"Rua Cesário Mota"`, `"mariana.rocha@gmail.com"`.


### PR DESCRIPTION
## Objetivo

Registrar as correções que você fez durante a #172, para que elas valham no próximo arquivo em vez de dependerem de eu lembrar. Três nasceram de perguntas suas no review; a quarta é um método de verificação que a issue me obrigou a inventar do zero.

Sem issue: mudança de harness dispensa a issue, não o PR.

## Alterações

### `dotnet-code-style.md` — três seções

**Exponha o comportamento, não o dado.** De *"pq ProductTimeZone precisou se tornar público?"*. Eu tinha publicado um `private static readonly TimeZoneInfo` para o repositório alcançá-lo — a saída de menor esforço, e a pior: o consumidor passou a saber *como* o fuso é representado, e a conversão ficou em dois lugares que se ignoram. A regra fixa o tell: **tornar público um `private` para atender um consumidor** é o momento de perguntar o que ele realmente quer saber.

**Predicado de consulta é `Expression`, não método.** De *"não da pra separar essas validações em constantes pra ficar mais legível?"*. As duas formas naturais de nomear falham dentro de `IQueryable`, e falham diferente:

| Forma | O que acontece |
| --- | --- |
| variável `bool` no lambda | **não compila** — expression tree não aceita corpo de bloco |
| método `bool` comum | compila e **quebra em runtime**: `could not be translated` |

A regra traz o SQL medido dos dois lados, para ninguém precisar redescobrir.

**DTO de query: opcional é nullable, derivado é `[BindNever]`.** Dois apontamentos que aparecem no mesmo tipo de DTO: `S6964` reprova o build quando um tipo-valor opcional não é nullable, e sem `[BindNever]` o Swashbuckle publica as propriedades derivadas como parâmetros de query — `EffectivePage`, `EffectivePageSize` e `ItemsToSkip` vazaram assim, com o build verde.

### `dotnet-testing.md` — uma seção nova e um acréscimo

**Suíte verde não prova que ela pega o defeito.** Na #172 foram seis mutações nos pontos arriscados da paginação; as seis derrubaram testes. A regra registra principalmente a armadilha: **se o build da mutação falha, `dotnet test --no-build` roda a DLL anterior e tudo passa** — o que se lê como "a mutação sobreviveu". Aconteceu comigo ali, e eu quase reportei o falso positivo.

**O risco inverso do banco em memória.** A seção já dizia que o provedor não avalia `unaccent` nem `ILike`. Faltava o mais perigoso: ele **aceita o que o PostgreSQL recusa**, então trocar aquela `Expression` por um método passa verde e quebra em produção.

## Issue

Harness não abre issue. Mas a #237 recebeu um item de escopo apontando de volta para cá:

> Reescrever a seção "Subir a aplicação sem banco" da `.claude/rules/dotnet-testing.md` — a rule aponta para esta issue de propósito; sem este item, ela vira texto correto descrevendo um mundo que não existe mais.

## Evidências

- `./scripts/check-harness-paths.sh` — nenhum caminho órfão
- Os símbolos citados (`NowInProductTimeZone`, `HasNotDeparted`, `EffectivePage`, `ItemsToSkip`, `BindNever`) foram conferidos na branch do **#236**, não nesta: eles chegam com aquele PR, e os dois mergeiam em sequência

⚠️ **Ordem de leitura, não de merge.** Este PR pode entrar antes ou depois do #236 — não há dependência de código. Mas as seções citam símbolos que só existem depois dele, então mergear este primeiro deixa exemplos apontando para código que ainda não chegou.
