### PR TITLE
feat(173): paginate the ride list screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Passa a responder a listagem de caronas em páginas de 10, com o total e a quantidade de páginas, e aceita escolher a página e o tamanho dela até um teto de 50; antes devolvia todas as caronas ativas de uma vez (#236) [Backend]
+- Passa a mostrar a lista de caronas em páginas de 10, com a busca guardada no endereço: copiar a URL e abrir noutra aba devolve a mesma página, com os mesmos filtros preenchidos; enquanto a lista carrega, o lugar dos cartões fica marcado em vez de um indicador girando (#239) [Frontend]
 
 ### Fixed
 

--- a/FateConnect/Web/src/hooks/useSearchQuery.ts
+++ b/FateConnect/Web/src/hooks/useSearchQuery.ts
@@ -1,0 +1,32 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
+
+export type SearchQueryCodec<T> = Readonly<{
+  fromParams: (params: URLSearchParams) => T;
+  toParams: (value: T) => Record<string, string>;
+}>;
+
+export type SearchQueryResult<T> = Readonly<{
+  value: T;
+  replace: (next: T) => void;
+}>;
+
+/**
+ * Guarda a busca da tela na barra de endereço, para o link levar junto o que a
+ * pessoa escolheu. O `codec` precisa ser estável entre renders — declare-o fora
+ * do componente, ou cada render remonta a leitura.
+ */
+export function useSearchQuery<T>(codec: SearchQueryCodec<T>): SearchQueryResult<T> {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const value = useMemo(() => codec.fromParams(searchParams), [codec, searchParams]);
+
+  // `replace`: paginar e filtrar refazem a mesma tela, então o botão voltar do
+  // navegador deve sair dela em vez de desfazer escolha por escolha.
+  const replace = useCallback(
+    (next: T) => setSearchParams(codec.toParams(next), { replace: true }),
+    [codec, setSearchParams],
+  );
+
+  return { value, replace };
+}

--- a/FateConnect/Web/src/pages/Rides/Rides.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/Rides.test.tsx
@@ -18,6 +18,9 @@ import * as C from './constants';
 import { Rides } from '.';
 
 const RIDES_URL = 'https://api.fateconnect.test/rides';
+const SECOND_PAGE_LABEL = 'Ir para a página 2';
+const FIRST_PAGE = 1;
+const PAGE_SIZE = 10;
 
 /** Cobre a tentativa inicial, os 2s de espera e a repetição. */
 const RETRY_WINDOW_MS = 5000;
@@ -44,23 +47,34 @@ const RIDE: Ride = {
 /** A posse vem calculada pela API; o cartão só a lê. */
 const OWN_RIDE: Ride = { ...RIDE, isOwner: true };
 
+/** A API responde uma página; o total acompanha o que o caso semeou. */
+function pageOf(rides: Ride[], total = rides.length) {
+  return {
+    items: rides,
+    page: FIRST_PAGE,
+    pageSize: PAGE_SIZE,
+    total,
+    totalPages: Math.ceil(total / PAGE_SIZE),
+  };
+}
+
 function listReturning(rides: Ride[], onRequest?: (url: URL) => void) {
   server.use(
     http.get(RIDES_URL, ({ request }) => {
       onRequest?.(new URL(request.url));
 
-      return HttpResponse.json(rides);
+      return HttpResponse.json(pageOf(rides));
     }),
   );
 }
 
-function renderComponent() {
+function renderComponent(search = '') {
   const router = createMemoryRouter(
     [
       { path: RoutePathEnum.RIDES, element: <Rides /> },
       { path: RoutePathEnum.MENU, element: <div>menu</div> },
     ],
-    { initialEntries: [RoutePathEnum.RIDES] },
+    { initialEntries: [`${RoutePathEnum.RIDES}${search}`] },
   );
   render(<RouterProvider router={router} />);
 
@@ -229,7 +243,7 @@ describe('Rides', () => {
   it('should delete the ride once the removal is confirmed', async () => {
     let deleted = false;
     server.use(
-      http.get(RIDES_URL, () => HttpResponse.json(deleted ? [] : [OWN_RIDE])),
+      http.get(RIDES_URL, () => HttpResponse.json(pageOf(deleted ? [] : [OWN_RIDE]))),
       http.delete(`${RIDES_URL}/:rideId`, () => {
         deleted = true;
 
@@ -383,5 +397,77 @@ describe('Rides', () => {
       'aria-selected',
       'false',
     );
+  });
+
+  describe('paginação e busca na URL', () => {
+    function listPage(items: Ride[], total: number, onRequest?: (url: URL) => void) {
+      server.use(
+        http.get(RIDES_URL, ({ request }) => {
+          onRequest?.(new URL(request.url));
+
+          return HttpResponse.json({
+            items,
+            page: FIRST_PAGE,
+            pageSize: PAGE_SIZE,
+            total,
+            totalPages: Math.ceil(total / PAGE_SIZE),
+          });
+        }),
+      );
+    }
+
+    it('should open with the fields already filled from the url', async () => {
+      listReturning([RIDE]);
+
+      renderComponent('?destino=Sorocaba&hora=07:30&tipo=solidaria');
+
+      expect(await screen.findByDisplayValue('Sorocaba')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('07:30')).toBeInTheDocument();
+    });
+
+    it('should ask the api for the page the url names', async () => {
+      let asked: URL | null = null;
+      listPage([RIDE], 30, (url) => {
+        asked = url;
+      });
+
+      renderComponent('?pagina=3');
+
+      await waitFor(() => expect(asked!.searchParams.get('page')).toBe('3'));
+    });
+
+    it('should put the chosen page in the url and leave the first one out', async () => {
+      listPage([RIDE], 30);
+      const router = renderComponent();
+
+      await userEvent.click(await screen.findByRole('button', { name: SECOND_PAGE_LABEL }));
+
+      await waitFor(() => expect(router.state.location.search).toBe('?pagina=2'));
+    });
+
+    it('should go back to the first page when a filter is applied', async () => {
+      listPage([RIDE], 30);
+      const router = renderComponent('?pagina=3');
+
+      await userEvent.type(await screen.findByLabelText(FILTER_LABELS.destination), 'Votorantim');
+      await userEvent.click(screen.getByRole('button', { name: FILTER_SUBMIT_LABEL }));
+
+      await waitFor(() => expect(router.state.location.search).toBe('?destino=Votorantim'));
+    });
+
+    it('should fall back to the last page when the url asks beyond it', async () => {
+      listPage([RIDE], 12);
+      const router = renderComponent('?pagina=9');
+
+      await waitFor(() => expect(router.state.location.search).toBe('?pagina=2'));
+    });
+
+    it('should hide the control while a single page answers', async () => {
+      listPage([RIDE], 4);
+      renderComponent();
+
+      expect(await screen.findByText(RIDE.destination)).toBeInTheDocument();
+      expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+    });
   });
 });

--- a/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFilter/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState, type ChangeEvent } from 'react';
 import { FilterPanel, Input } from '@design-system';
 
 import type { RideFilter as RideFilterValues, RideTypeEnum } from '@app/services/rides/types';
-import { toApiDate } from '@app/utils/apiDate';
+import { fromFormDate, toApiDate } from '@app/utils/apiDate';
 
 import * as C from './constants';
 
@@ -10,14 +10,31 @@ import * as C from './constants';
 const FILTER_COLUMNS = 5;
 const NO_FILTERS = 0;
 
-type RideFilterProps = Readonly<{ onApply: (filters: RideFilterValues) => void }>;
+/** Paginação não conta: o ponto ao lado do título é sobre escolha de busca. */
+function hasAnyFilter({
+  destination,
+  departureDate,
+  departureTime,
+  rideType,
+}: RideFilterValues): boolean {
+  return Boolean(destination || departureDate || departureTime || rideType);
+}
 
-export function RideFilter({ onApply }: RideFilterProps) {
-  const [departureDate, setDepartureDate] = useState<Date | null>(null);
-  const [departureTime, setDepartureTime] = useState('');
-  const [destination, setDestination] = useState('');
-  const [rideType, setRideType] = useState<string>(C.RideTypeFilterEnum.ALL);
-  const [isFiltered, setIsFiltered] = useState(false);
+type RideFilterProps = Readonly<{
+  initialFilters: RideFilterValues;
+  onApply: (filters: RideFilterValues) => void;
+}>;
+
+export function RideFilter({ initialFilters, onApply }: RideFilterProps) {
+  const [departureDate, setDepartureDate] = useState<Date | null>(() =>
+    fromFormDate(initialFilters.departureDate ?? ''),
+  );
+  const [departureTime, setDepartureTime] = useState(initialFilters.departureTime ?? '');
+  const [destination, setDestination] = useState(initialFilters.destination ?? '');
+  const [rideType, setRideType] = useState<string>(
+    initialFilters.rideType ?? C.RideTypeFilterEnum.ALL,
+  );
+  const [isFiltered, setIsFiltered] = useState(() => hasAnyFilter(initialFilters));
 
   const handleTimeChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => setDepartureTime(event.target.value),

--- a/FateConnect/Web/src/pages/Rides/helpers/rideType.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/rideType.ts
@@ -5,6 +5,14 @@ import { RideTypeEnum } from '@app/services/rides/types';
 const LOWERCASE_TO_RIDE_TYPE: Readonly<Record<string, RideTypeEnum>> = {
   solidarity: RideTypeEnum.SOLIDARITY,
   egalitarian: RideTypeEnum.EGALITARIAN,
+  solidaria: RideTypeEnum.SOLIDARITY,
+  igualitaria: RideTypeEnum.EGALITARIAN,
+};
+
+/** O que vai para a URL: pt-BR, porque a barra de endereço é texto que se lê. */
+const RIDE_TYPE_SLUG: Readonly<Record<RideTypeEnum, string>> = {
+  [RideTypeEnum.SOLIDARITY]: 'solidaria',
+  [RideTypeEnum.EGALITARIAN]: 'igualitaria',
 };
 
 const RIDE_TYPE_LABEL: Readonly<Record<RideTypeEnum, string>> = {
@@ -35,11 +43,15 @@ export function isRideType(value: string): value is RideTypeEnum {
   return RIDE_TYPE_VALUES.has(value);
 }
 
-/** Interpreta o valor da API (PascalCase) ou de query em minúsculas. */
+/** Interpreta o valor da API (PascalCase) e o da URL, em pt-BR minúsculo. */
 export function parseRideType(raw: string | null | undefined): RideTypeEnum | null {
   if (!raw) return null;
 
   return LOWERCASE_TO_RIDE_TYPE[raw.trim().toLowerCase()] ?? null;
+}
+
+export function rideTypeSlug(value: RideTypeEnum): string {
+  return RIDE_TYPE_SLUG[value];
 }
 
 /** Tom da etiqueta do tipo de carona; a cor sai da paleta, nos dois temas. */

--- a/FateConnect/Web/src/pages/Rides/helpers/searchQuery.test.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/searchQuery.test.ts
@@ -1,0 +1,75 @@
+import { RideTypeEnum } from '@app/services/rides/types';
+
+import { FIRST_PAGE, PAGE_SIZE, rideSearchCodec } from './searchQuery';
+
+const read = (search: string) => rideSearchCodec.fromParams(new URLSearchParams(search));
+
+describe('rideSearchCodec', () => {
+  describe('fromParams', () => {
+    it('should fall back to the first page and the fixed size when the url is empty', () => {
+      expect(read('')).toEqual({ page: FIRST_PAGE, pageSize: PAGE_SIZE });
+    });
+
+    it('should read every filter the url carries', () => {
+      expect(read('pagina=3&destino=Sorocaba&data=2026-09-01&hora=07:30&tipo=solidaria')).toEqual({
+        page: 3,
+        pageSize: PAGE_SIZE,
+        destination: 'Sorocaba',
+        departureDate: '2026-09-01',
+        departureTime: '07:30',
+        rideType: RideTypeEnum.SOLIDARITY,
+      });
+    });
+
+    it.each(['pagina=0', 'pagina=-4', 'pagina=abc', 'pagina='])(
+      'should fall back to the first page when the url says %s',
+      (search) => {
+        expect(read(search).page).toBe(FIRST_PAGE);
+      },
+    );
+
+    it('should ignore a ride type it does not recognise instead of breaking', () => {
+      expect(read('tipo=voadora').rideType).toBeUndefined();
+    });
+
+    it('should not care about the case of the ride type', () => {
+      expect(read('tipo=SOLIDARIA').rideType).toBe(RideTypeEnum.SOLIDARITY);
+    });
+
+    it('should drop filters that carry only blank space', () => {
+      expect(read('destino=%20%20&hora=%20')).toEqual({ page: FIRST_PAGE, pageSize: PAGE_SIZE });
+    });
+  });
+
+  describe('toParams', () => {
+    it('should keep the default page and size out of the url', () => {
+      expect(rideSearchCodec.toParams({ page: FIRST_PAGE, pageSize: PAGE_SIZE })).toEqual({});
+    });
+
+    it('should write the ride type in the words the screen shows', () => {
+      const params = rideSearchCodec.toParams({
+        page: 2,
+        pageSize: PAGE_SIZE,
+        rideType: RideTypeEnum.EGALITARIAN,
+        destination: 'Sorocaba',
+      });
+
+      expect(params).toEqual({ pagina: '2', tipo: 'igualitaria', destino: 'Sorocaba' });
+    });
+
+    it('should survive a round trip through the url', () => {
+      const original = {
+        page: 4,
+        pageSize: PAGE_SIZE,
+        destination: 'Votorantim',
+        departureDate: '2026-09-10',
+        departureTime: '18:00',
+        rideType: RideTypeEnum.SOLIDARITY,
+      };
+
+      const params = new URLSearchParams(rideSearchCodec.toParams(original));
+
+      expect(rideSearchCodec.fromParams(params)).toEqual(original);
+    });
+  });
+});

--- a/FateConnect/Web/src/pages/Rides/helpers/searchQuery.ts
+++ b/FateConnect/Web/src/pages/Rides/helpers/searchQuery.ts
@@ -1,0 +1,59 @@
+import type { SearchQueryCodec } from '@app/hooks/useSearchQuery';
+import type { RideFilter } from '@app/services/rides/types';
+
+import { parseRideType, rideTypeSlug } from './rideType';
+
+export const FIRST_PAGE = 1;
+export const PAGE_SIZE = 10;
+
+enum SearchParamEnum {
+  PAGE = 'pagina',
+  DESTINATION = 'destino',
+  DEPARTURE_DATE = 'data',
+  DEPARTURE_TIME = 'hora',
+  RIDE_TYPE = 'tipo',
+}
+
+function readPage(raw: string | null): number {
+  const parsed = Number.parseInt(raw ?? '', 10);
+
+  if (!Number.isFinite(parsed) || parsed < FIRST_PAGE) return FIRST_PAGE;
+
+  return parsed;
+}
+
+function fromParams(params: URLSearchParams): RideFilter {
+  const filter: RideFilter = {
+    page: readPage(params.get(SearchParamEnum.PAGE)),
+    pageSize: PAGE_SIZE,
+  };
+
+  const destination = params.get(SearchParamEnum.DESTINATION)?.trim();
+  if (destination) filter.destination = destination;
+
+  const departureDate = params.get(SearchParamEnum.DEPARTURE_DATE)?.trim();
+  if (departureDate) filter.departureDate = departureDate;
+
+  const departureTime = params.get(SearchParamEnum.DEPARTURE_TIME)?.trim();
+  if (departureTime) filter.departureTime = departureTime;
+
+  const rideType = parseRideType(params.get(SearchParamEnum.RIDE_TYPE));
+  if (rideType) filter.rideType = rideType;
+
+  return filter;
+}
+
+function toParams(filter: RideFilter): Record<string, string> {
+  const params: Record<string, string> = {};
+
+  // A página 1 e o tamanho fixo são o padrão, e padrão não ocupa a URL.
+  if (filter.page && filter.page > FIRST_PAGE) params[SearchParamEnum.PAGE] = String(filter.page);
+  if (filter.destination) params[SearchParamEnum.DESTINATION] = filter.destination;
+  if (filter.departureDate) params[SearchParamEnum.DEPARTURE_DATE] = filter.departureDate;
+  if (filter.departureTime) params[SearchParamEnum.DEPARTURE_TIME] = filter.departureTime;
+  if (filter.rideType) params[SearchParamEnum.RIDE_TYPE] = rideTypeSlug(filter.rideType);
+
+  return params;
+}
+
+export const rideSearchCodec: SearchQueryCodec<RideFilter> = { fromParams, toParams };

--- a/FateConnect/Web/src/pages/Rides/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/index.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { NavLink } from 'react-router';
-import { CircularProgress, PageShell, Typography } from '@design-system';
+import { ListCardSkeleton, PageShell, Pagination, Typography } from '@design-system';
 import { AddIcon, ArrowBackIcon, SearchIcon } from '@design-system/icons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useNotification } from '@app/hooks/useNotification';
+import { useSearchQuery } from '@app/hooks/useSearchQuery';
 import { RoutePathEnum } from '@app/routes/paths';
 import { deleteRide, listRides } from '@app/services/rides/ridesService';
 import type { Ride, RideFilter as RideFilterValues } from '@app/services/rides/types';
@@ -12,24 +13,37 @@ import type { Ride, RideFilter as RideFilterValues } from '@app/services/rides/t
 import { RideCard } from './components/RideCard';
 import { RideFilter } from './components/RideFilter';
 import { RideFormDialog } from './components/RideFormDialog';
+import { FIRST_PAGE, PAGE_SIZE, rideSearchCodec } from './helpers/searchQuery';
 import * as C from './constants';
 import * as S from './styles';
 
-const SPINNER_SIZE_PX = 60;
 const NO_ITEMS = 0;
+const NO_PAGES = 0;
 
 export function Rides() {
   const queryClient = useQueryClient();
   const { notifySuccess } = useNotification();
-  const [filters, setFilters] = useState<RideFilterValues>({});
+  const { value: filters, replace: replaceSearch } = useSearchQuery(rideSearchCodec);
   const [editingRide, setEditingRide] = useState<Ride | undefined>(undefined);
   const [isFormOpen, setIsFormOpen] = useState(false);
 
-  const { data: rides = [], isPending } = useQuery({
+  const { data: ridePage, isPending } = useQuery({
     queryKey: [C.RIDES_QUERY_KEY, filters],
     queryFn: () => listRides(filters),
     meta: { errorMessage: C.RIDE_LIST_MESSAGES.loadFailed },
   });
+
+  const rides = ridePage?.items ?? [];
+  const totalPages = ridePage?.totalPages ?? NO_PAGES;
+  const currentPage = filters.page ?? FIRST_PAGE;
+
+  // Quem salvou `?pagina=7` e voltou depois de a lista encolher veria uma página
+  // vazia, que parece defeito. Cai na última existente e a URL acompanha.
+  useEffect(() => {
+    if (totalPages === NO_PAGES || currentPage <= totalPages) return;
+
+    replaceSearch({ ...filters, page: totalPages });
+  }, [currentPage, filters, replaceSearch, totalPages]);
 
   const { mutate: removeRide, isPending: isRemoving } = useMutation({
     mutationFn: (ride: Ride) => deleteRide(ride.id),
@@ -40,7 +54,17 @@ export function Rides() {
     meta: { errorMessage: C.RIDE_LIST_MESSAGES.cancelFailed },
   });
 
-  const handleApplyFilters = useCallback((applied: RideFilterValues) => setFilters(applied), []);
+  // Filtrar refaz a busca, então a página volta a ser a primeira.
+  const handleApplyFilters = useCallback(
+    (applied: RideFilterValues) =>
+      replaceSearch({ ...applied, page: FIRST_PAGE, pageSize: PAGE_SIZE }),
+    [replaceSearch],
+  );
+
+  const handlePageChange = useCallback(
+    (nextPage: number) => replaceSearch({ ...filters, page: nextPage }),
+    [filters, replaceSearch],
+  );
   const handleCancel = useCallback((ride: Ride) => removeRide(ride), [removeRide]);
 
   const handleOffer = useCallback(() => {
@@ -88,14 +112,10 @@ export function Rides() {
         </>
       }
     >
-      <RideFilter onApply={handleApplyFilters} />
+      <RideFilter initialFilters={filters} onApply={handleApplyFilters} />
 
       <S.RideList>
-        {isLoading && (
-          <S.LoadingContainer>
-            <CircularProgress size={SPINNER_SIZE_PX} />
-          </S.LoadingContainer>
-        )}
+        {isLoading && <ListCardSkeleton />}
 
         {!isLoading && rides.length === NO_ITEMS && (
           <Typography variant="subtitle">{C.EMPTY_LIST_MESSAGE}</Typography>
@@ -106,6 +126,12 @@ export function Rides() {
             <RideCard key={ride.id} ride={ride} onEdit={handleEdit} onCancel={handleCancel} />
           ))}
       </S.RideList>
+
+      {!isLoading && (
+        <S.PaginationRow>
+          <Pagination count={totalPages} page={currentPage} onChange={handlePageChange} />
+        </S.PaginationRow>
+      )}
 
       <RideFormDialog open={isFormOpen} onClose={handleCloseForm} ride={editingRide} />
     </PageShell>

--- a/FateConnect/Web/src/pages/Rides/styles.ts
+++ b/FateConnect/Web/src/pages/Rides/styles.ts
@@ -1,17 +1,15 @@
-import { Stack, styled } from '@design-system';
+import { spacingScale, Stack, styled } from '@design-system';
 
-/** Altura reservada enquanto a lista carrega, para o rodapé não pular. */
-const LOADING_MIN_HEIGHT_PX = 300;
+const { sm } = spacingScale;
 
 export const RideList = styled(Stack)({
   flexDirection: 'column',
   width: '100%',
 });
 
-export const LoadingContainer = styled(Stack)({
+export const PaginationRow = styled(Stack)(({ theme }) => ({
   flexDirection: 'row',
   justifyContent: 'center',
-  alignItems: 'center',
-  minHeight: `${LOADING_MIN_HEIGHT_PX}px`,
   width: '100%',
-});
+  paddingTop: theme.space(sm),
+}));

--- a/FateConnect/Web/src/services/rides/ridesService.test.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.test.ts
@@ -6,6 +6,9 @@ import { createRide, deleteRide, listRides, updateRide } from './ridesService';
 import { RideTypeEnum, type RideInput } from './types';
 
 const RIDES_URL = 'https://api.fateconnect.test/rides';
+const FIRST_PAGE = 1;
+const SINGLE_PAGE = 1;
+const PAGE_SIZE = 10;
 
 const RIDE_INPUT: RideInput = {
   availableSeats: 3,
@@ -16,13 +19,23 @@ const RIDE_INPUT: RideInput = {
   description: 'Saída do centro.',
 };
 
+function pageOf(items: unknown[]) {
+  return {
+    items,
+    page: FIRST_PAGE,
+    pageSize: PAGE_SIZE,
+    total: items.length,
+    totalPages: SINGLE_PAGE,
+  };
+}
+
 describe('ridesService', () => {
   it('should translate the front filters into the api query parameters', async () => {
     let received: URLSearchParams | null = null;
     server.use(
       http.get(RIDES_URL, ({ request }) => {
         received = new URL(request.url).searchParams;
-        return HttpResponse.json([]);
+        return HttpResponse.json(pageOf([]));
       }),
     );
 
@@ -39,12 +52,27 @@ describe('ridesService', () => {
     expect(received!.get('rideType')).toBe(RideTypeEnum.EGALITARIAN);
   });
 
+  it('should send the page and the page size the caller asked for', async () => {
+    let received: URLSearchParams | null = null;
+    server.use(
+      http.get(RIDES_URL, ({ request }) => {
+        received = new URL(request.url).searchParams;
+        return HttpResponse.json(pageOf([]));
+      }),
+    );
+
+    await listRides({ page: 3, pageSize: 10 });
+
+    expect(received!.get('page')).toBe('3');
+    expect(received!.get('pageSize')).toBe('10');
+  });
+
   it('should omit parameters that were not filled in', async () => {
     let received: URLSearchParams | null = null;
     server.use(
       http.get(RIDES_URL, ({ request }) => {
         received = new URL(request.url).searchParams;
-        return HttpResponse.json([]);
+        return HttpResponse.json(pageOf([]));
       }),
     );
 
@@ -54,17 +82,20 @@ describe('ridesService', () => {
   });
 
   it('should list rides without filters', async () => {
-    server.use(http.get(RIDES_URL, () => HttpResponse.json([{ id: 1, destination: 'Sorocaba' }])));
+    server.use(
+      http.get(RIDES_URL, () => HttpResponse.json(pageOf([{ id: 1, destination: 'Sorocaba' }]))),
+    );
 
-    const rides = await listRides();
+    const page = await listRides();
 
-    expect(rides).toHaveLength(1);
+    expect(page.items).toHaveLength(1);
+    expect(page.totalPages).toBe(SINGLE_PAGE);
   });
 
-  it('should fail when the response is not a list', async () => {
+  it('should fail when the response is not a page', async () => {
     server.use(http.get(RIDES_URL, () => HttpResponse.text('<!doctype html><html></html>')));
 
-    await expect(listRides()).rejects.toThrow(/não é uma lista/);
+    await expect(listRides()).rejects.toThrow(/não é uma página/);
   });
 
   it('should send the whole ride when creating', async () => {

--- a/FateConnect/Web/src/services/rides/ridesService.ts
+++ b/FateConnect/Web/src/services/rides/ridesService.ts
@@ -1,18 +1,18 @@
 import { apiClient } from '../httpClient';
+import type { PagedResult } from '../types';
 import type { Ride, RideFilter, RideInput } from './types';
 
 const RIDES_PATH = '/rides';
+const INVALID_LIST_PAYLOAD_MESSAGE = 'A API de caronas respondeu algo que não é uma página.';
 
-const INVALID_LIST_PAYLOAD_MESSAGE = 'A API de caronas respondeu algo que não é uma lista.';
-
-export async function listRides(filters?: RideFilter): Promise<Ride[]> {
-  const { data } = await apiClient.get<Ride[]>(RIDES_PATH, { params: filters });
+export async function listRides(filters?: RideFilter): Promise<PagedResult<Ride>> {
+  const { data } = await apiClient.get<PagedResult<Ride>>(RIDES_PATH, { params: filters });
 
   // O tipo do axios é uma promessa de contrato, não uma garantia: sem o endereço
   // da API a requisição cai no próprio servidor de desenvolvimento, que responde
   // o HTML da aplicação com status 200. Falhar aqui transforma isso na
   // notificação de erro da tela, em vez de estourar depois ao percorrer a lista.
-  if (!Array.isArray(data)) throw new Error(INVALID_LIST_PAYLOAD_MESSAGE);
+  if (!Array.isArray(data?.items)) throw new Error(INVALID_LIST_PAYLOAD_MESSAGE);
 
   return data;
 }

--- a/FateConnect/Web/src/services/rides/types.ts
+++ b/FateConnect/Web/src/services/rides/types.ts
@@ -1,3 +1,5 @@
+import type { PageQuery } from '../types';
+
 /** Valores canônicos alinhados à serialização do backend. */
 export enum RideTypeEnum {
   SOLIDARITY = 'Solidarity',
@@ -32,9 +34,9 @@ export type Ride = {
 export type RideInput = Omit<Ride, 'id' | 'createdAt' | 'driver' | 'isOwner'>;
 
 /** Filtros da listagem, com os mesmos nomes que a API recebe na query. */
-export type RideFilter = {
+export interface RideFilter extends PageQuery {
   destination?: string;
   departureDate?: string;
   departureTime?: string;
   rideType?: RideTypeEnum;
-};
+}

--- a/FateConnect/Web/src/services/types.ts
+++ b/FateConnect/Web/src/services/types.ts
@@ -1,0 +1,12 @@
+export type PagedResult<T> = {
+  items: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+};
+
+export type PageQuery = {
+  page?: number;
+  pageSize?: number;
+};


### PR DESCRIPTION
## Objetivo

A tela buscava a lista inteira e desenhava um cartão por item. Passa a pedir uma página por vez, e a busca — página e filtros — passa a viver no endereço, para o link guardar o que a pessoa escolheu.

A metade de baixo já está na `develop`: a API responde paginado desde o #236.

## Alterações

### O que fica para a próxima tela reusar

| | |
| --- | --- |
| `PagedResult<T>` e `PageQuery` | `src/services/types.ts`, ao lado do `httpClient` |
| `useSearchQuery` | `src/hooks/`, genérico — a tela entrega o `codec` |

A tela de achados e perdidos (#174) consome os dois sem tocar em nada aqui.

### A tela de caronas

`listRides` passa a devolver a página e a guarda de formato acompanha. O filtro **nasce preenchido a partir da URL** — antes ele guardava tudo em `useState`, então um link salvo trazia a lista filtrada com os campos em branco. O `Pagination` entra centralizado no rodapé, e o `CircularProgress` dá lugar ao `ListCardSkeleton` em **todas** as cargas: abrir, filtrar e trocar de página.

Dois comportamentos que a issue pede e que valem destacar:

- **Aplicar filtro volta para a primeira página**, que some da URL por ser o padrão.
- **Página fora do intervalo cai na última existente**, reescrevendo o endereço. Quem salvou `?pagina=7` e voltou depois de a lista encolher vê itens, não uma lista vazia que parece defeito.

### A URL

```
/caronas?pagina=2&destino=Sorocaba&data=2026-09-01&hora=07:30&tipo=solidaria
```

Em pt-BR, com o mesmo nome que a tela mostra — `Solidária` vira `solidaria`. Só entra o que a pessoa escolheu: a página 1 e o tamanho 10 ficam implícitos, e não há seletor de tamanho na interface. A leitura é tolerante: maiúscula não diferencia e valor irreconhecível é ignorado em vez de quebrar a tela.

⚠️ **São dois vocabulários, e o codec traduz entre eles**: a URL em pt-BR porque é texto que a pessoa lê, e a query da API em inglês.

## Issue

- #173

Closes #173

Sub-issue da #170.

### Duas premissas da issue tinham envelhecido

Corrigi as duas **na issue** antes de implementar, com data e motivo:

| O que a issue dizia | O que o código mostra |
| --- | --- |
| contrato em português — `/caronas?Pagina=`, `{ itens, pagina, totalPaginas }` | inglês desde as #194, #222 e #224; a #172 entregou nos nomes atuais |
| aceitar `filantropica` "para link já gerado não morrer" | o termo saiu no #194, e a URL com filtros é o que **esta** issue cria |

A segunda só se fechou medindo o histórico: nunca existiu link com `?tipo=filantropica`, porque a tela guardava filtro em `useState`. O item saiu do escopo — seria código nascendo morto.

## Evidências

| Verificação | Resultado |
| --- | --- |
| ESLint / `tsc` | 0 / 0 |
| Suíte | **468 testes**, 69 arquivos |
| Cobertura global | 98,5 / 92,87 / 98,07 / 99,34 |
| `src/hooks` · `src/pages/Rides` · `src/services` | 100/93 · 100/95 · 96/90 |
| Cada commit isolado | compila e passa sozinho, verificado em worktree (o primeiro fecha com 449 testes) |

O corte dos commits é assim de propósito: se o serviço mudasse de tipo antes da tela, `rides.map` quebraria no meio do histórico.

**O `RideFilter` melhorou em todas as métricas** contra a `develop` — ele é o único arquivo tocado que fica abaixo de 90 em alguma coluna, e já ficava:

| | develop | aqui |
| --- | --- | --- |
| statements | 80,76 | **82,75** |
| branches | 50 | **80** |
| funções | 60 | **75** |
| linhas | 90,9 | **91,66** |

O design system não precisou de nada: a #171 já havia entregue `Pagination` e `ListCardSkeleton`, ambos no barrel, e o rótulo dos botões de página já era pt-BR (`Ir para a página 2`).

<img width="1280" height="943" alt="image" src="https://github.com/user-attachments/assets/8da92ce2-8fea-42ce-885f-d68ed9121732" />

