### PR TITLE
docs: record the typing rules and close issues on merge

### DIFF
--- a/.claude/rules/web-design-system.md
+++ b/.claude/rules/web-design-system.md
@@ -22,7 +22,7 @@ paths:
 - **Esconder visualmente sem tirar da acessibilidade é o `HiddenField`.** Serve ao texto que só o leitor de tela ouve e ao campo que só um botão aciona, pela prop `component`. ⛔ Não reescreva o bloco `position: absolute` + `clip` — ele existia duplicado em dois arquivos, byte a byte, até virar componente.
 - Esses componentes são **prop-driven**: recebem conteúdo por propriedade ou slot e **não importam nada de `@app/*`**. O domínio (rotas, hooks, textos) é fornecido por quem os compõe.
 - Composição de domínio (um botão que conhece uma seção da landing, por exemplo) fica em `src/components/`, não no design system.
-- **A prop fala em termos visuais, não em termos do domínio.** A etiqueta de estado recebe `tone="success"`, não `tipo="filantropica"`: quem traduz o domínio para o tom é a tela. Foi o que permitiu o mesmo `StatusTag` servir caronas sem o design system saber o que é uma carona.
+- **A prop fala em termos visuais, não em termos do domínio.** A etiqueta de estado recebe `tone="success"`, não `tipo="solidaria"`: quem traduz o domínio para o tom é a tela. Foi o que permitiu o mesmo `StatusTag` servir caronas sem o design system saber o que é uma carona.
 - **Ação secundária usa `variant="soft"`**, a variante de contorno neutro declarada no tema. ⛔ Não componha uma aparência nova no ponto de uso — `variant="outlined" color="inherit"` apareceu em dois PRs no mesmo dia, escolhido duas vezes sem ninguém combinar. Falta variante para o que você precisa: **declare no tema**, como se faz com token.
 - **Subcomponente interno vai numa pasta dentro do pai**, com o seu `index` (`ConfirmDialog/DialogMessage/`). Se ele faz sentido para quem consome, expor por composição — `ConfirmDialog.Message` — em vez de repassar props do filho pelo pai.
 

--- a/.claude/rules/web-react-patterns.md
+++ b/.claude/rules/web-react-patterns.md
@@ -38,6 +38,8 @@ Vale para pasta de componente e de tela. Pastas que **já são** dedicadas por n
 
 ## Tipagem e imports
 
+- **`type` por padrão; `interface` só quando herda.** Tipo que estende outro usa `interface X extends Y`, não `type X = Y & {...}`. Na #173 o `RideFilter` nasceu como interseção e virou `interface RideFilter extends PageQuery` — os tipos que ele estende (`PagedResult`, `PageQuery`) seguem `type`, porque não herdam nada.
+- ⛔ **`as const` não entra.** Para um conjunto finito de chaves, o que vale é `enum` — é o que `RideTypeFilterEnum` e `LostItemKindFilterEnum` já fazem. Escrevi um objeto `as const` no codec da busca da #173 e ele era o **único** do front inteiro; o ESLint passou nas duas formas, então quem decide é o precedente do repo, não o lint.
 - **Props de componente sempre em `Readonly`**: `type RideCardProps = Readonly<{ ride: Ride; onEdit: (ride: Ride) => void }>`. Props não são para mutar.
 - **`enum` leva o sufixo `Enum`**: `RideTypeEnum`, `RoutePathEnum`, `GenderValueEnum`. O sufixo separa, na leitura, o que é enum do que é tipo ou componente.
 - **O tipo entra no import que já existe.** Se o módulo já é importado por valor, o tipo vai junto com o modificador inline, no fim das chaves — `import { createMemoryRouter, RouterProvider, type LinkProps } from 'react-router'`. Segunda declaração `import type` só quando o módulo entra **apenas** por tipo, como o `ReactNode` num arquivo que não usa nada de valor do React. O lint funde e ordena sozinho.
@@ -99,6 +101,8 @@ if (useSessionStatus() === SessionStatusEnum.VALID)
 ## Constante de módulo mora no topo
 
 Depois dos imports, num bloco só, junto das que já existem — não encostada na função que a usa. Constante espalhada pelo arquivo esconde que o mesmo número já tinha nome três linhas acima.
+
+⛔ **E nada atravessa o bloco.** Na #173 furei essa regra de dois jeitos no mesmo PR: num arquivo deixei `FIRST_PAGE` e `PAGE_SIZE` lá embaixo, colados na função que os usava; no outro enfiei uma função **no meio** do bloco, partindo-o em dois. O segundo é mais fácil de cometer, porque a função parece pertencer às constantes que acabou de usar — ela vai depois do bloco inteiro.
 
 ## Número solto vira nome que explica o significado
 

--- a/.claude/skills/fateconnect-create-component/SKILL.md
+++ b/.claude/skills/fateconnect-create-component/SKILL.md
@@ -21,7 +21,7 @@ A pergunta é uma só: **ele conhece o domínio?**
 | Sim — e serve só uma tela | `src/pages/<Tela>/components/<Nome>/` |
 
 - Componente do design system é **prop-driven**: recebe conteúdo por propriedade ou slot e **não importa nada de `@app/*`**. Quem compõe fornece rota, texto e domínio.
-- A prop do design system fala em termos **visuais**, não de domínio: `tone="success"`, nunca `tipo="filantropica"`.
+- A prop do design system fala em termos **visuais**, não de domínio: `tone="success"`, nunca `tipo="solidaria"`.
 - Só entra no barrel o que a aplicação pode usar direto. Matéria-prima do tema (paleta, fábrica do tema, largura crua de breakpoint) fica interna.
 - **Antes de criar, procure:** `Grep` pelo nome e por um componente parecido na mesma pasta. Copiar o vizinho é mais seguro que inventar estrutura.
 

--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -39,6 +39,8 @@ Format: `pr-type(branch-name): short description`
 
 > ⚠️ **`Closes #N` does NOT auto-close in this repo.** GitHub only closes a referenced issue when the PR merges into the **default branch**, which here is `main`. This repo follows gitflow and PRs target `develop`, so the keyword never fires. Keep the line (it documents intent and works if the branch ever reaches `main`), but **close the issue manually after the merge** — `gh issue close <n> --comment "..."` — and move its card on the project board. Confirmed on PR #61 / issue #60.
 
+⛔ **Mergeou = fechar. Não pergunte.** Fechar a issue é a última etapa de entregá-la, não uma decisão à parte — perguntar "quer que eu feche?" devolve ao usuário um passo que já está combinado. Cobrado em 30/08/2026, depois de eu perguntar sobre a #172 com o PR #236 já mergeado: *"não precisa nem me perguntar. mergeou == fechar a issue"*. O card vai para `Done` pelo bot em seguida.
+
 ## Build PR description (pt-BR)
 
 The PR description must be in **pt-BR** and must include:


### PR DESCRIPTION
## Objetivo

Registrar as correções da rodada da #173. Sem issue: harness dispensa a issue, não o PR.

⚠️ **Duas das quatro mudanças nascem de regras que já estavam escritas e que eu violei assim mesmo.** O que faltava não era a regra — era a variante concreta do erro, que é o que me faz reconhecer a situação.

## Alterações

### 1. Tipagem: o que o repo tinha só por hábito

Duas regras entram em `web-react-patterns.md`. As duas viviam apenas no `CLAUDE.md` privado, que não vale para quem clona o repositório.

**`type` por padrão; `interface` só quando herda.** `interface X extends Y`, nunca `type X = Y & {...}`. O `RideFilter` da #173 nasceu como interseção; os tipos que ele estende (`PagedResult`, `PageQuery`) seguem `type`, porque não herdam nada.

**`as const` não entra.** Para conjunto finito de chaves vale `enum`, como `RideTypeFilterEnum` e `LostItemKindFilterEnum` já fazem. Escrevi um objeto `as const` no codec da busca e ele era o **único do front inteiro** — o ESLint passou nas duas formas, então quem decide é o precedente do repo, não o lint.

### 2. Constante de módulo: nada atravessa o bloco

A seção **já existia** e dizia que a constante não fica encostada na função que a usa. Furei de dois jeitos no mesmo PR:

| Onde | O que fiz |
| --- | --- |
| `Rides.test.tsx` | deixei `FIRST_PAGE` e `PAGE_SIZE` lá embaixo, colados na função |
| `ridesService.test.ts` | enfiei uma função **no meio** do bloco, partindo-o em dois |

O segundo é o mais fácil de cometer, porque a função parece pertencer às constantes que acabou de usar. A regra ganhou essa variante.

### 3. Mergeou = fechar. Não pergunte.

A `pr-creator` já mandava fechar a issue à mão depois do merge — o `Closes #N` não dispara mirando a `develop`. Mesmo assim perguntei antes de fechar a #172, com o #236 já mergeado. Fechar é a última etapa de entregar, não uma decisão à parte.

### 4. Exemplos apontando para um termo morto

`web-design-system.md` e a skill `fateconnect-create-component` citavam `tipo="filantropica"` como exemplo de prop de domínio. O termo saiu do código no PR #194, então quem procurasse no repo não acharia. Passam a citar `tipo="solidaria"`.

ℹ️ **O `product-copy.md` continua com `filantropica`, de propósito.** Lá não é exemplo: é o registro de um erro que cometi ao especificar a paginação, com a palavra que foi de fato escrita. Trocar falsificaria o caso.

## Evidências

- `./scripts/check-harness-paths.sh` — nenhum caminho órfão
- Os símbolos citados pelas regras novas (`RideTypeFilterEnum`, `LostItemKindFilterEnum`, `PagedResult`, `PageQuery`, `RideFilter`) conferidos na branch do **#239**

⚠️ **Como no #238, os exemplos citam código que chega com outro PR.** `PagedResult`, `PageQuery` e o `RideFilter` como interface vêm do #239, ainda aberto. Nada quebra — o check valida caminhos, não símbolos —, mas mergear o #239 antes deixa as regras completas.
