### PR TITLE
feat(174): paginate the lost and found screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Passa a responder a listagem de caronas em páginas de 10, com o total e a quantidade de páginas, e aceita escolher a página e o tamanho dela até um teto de 50; antes devolvia todas as caronas ativas de uma vez (#236) [Backend]
 - Passa a mostrar a lista de caronas em páginas de 10, com a busca guardada no endereço: copiar a URL e abrir noutra aba devolve a mesma página, com os mesmos filtros preenchidos; enquanto a lista carrega, o lugar dos cartões fica marcado em vez de um indicador girando (#239) [Frontend]
+- Passa a mostrar o mural de achados e perdidos em páginas de 10, com a mesma busca guardada no endereço da tela de caronas — inclusive o filtro de quem cadastrou e o de situação (#241) [Frontend]
 
 ### Fixed
 

--- a/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/LostAndFound.test.tsx
@@ -51,12 +51,34 @@ function activeFilterDot(title: string) {
   return screen.getByText(title).closest('.MuiBadge-root')?.querySelector('.MuiBadge-badge');
 }
 
+const FIRST_PAGE = 1;
+const PAGE_SIZE = 10;
+
+/**
+ * Fatia como a API fatia: o `total` conta o conjunto inteiro e a página além da
+ * última sai vazia. Stub mais tolerante que a API é teste que mente.
+ */
+function pagedResponse(all: LostItem[], url: URL) {
+  const page = Number(url.searchParams.get('Page') ?? FIRST_PAGE);
+  const pageSize = Number(url.searchParams.get('PageSize') ?? PAGE_SIZE);
+  const start = (page - FIRST_PAGE) * pageSize;
+
+  return {
+    items: all.slice(start, start + pageSize),
+    page,
+    pageSize,
+    total: all.length,
+    totalPages: Math.ceil(all.length / pageSize),
+  };
+}
+
 function listReturning(items: LostItem[], onRequest?: (url: URL) => void) {
   server.use(
     http.get(LOST_ITEMS_URL, ({ request }) => {
-      onRequest?.(new URL(request.url));
+      const url = new URL(request.url);
+      onRequest?.(url);
 
-      return HttpResponse.json(items);
+      return HttpResponse.json(pagedResponse(items, url));
     }),
   );
 }
@@ -83,10 +105,11 @@ function boardTracking(initial: LostItem) {
 
   server.use(
     http.get(LOST_ITEMS_URL, ({ request }) => {
-      const wanted = new URL(request.url).searchParams.get('Situacao');
-      if (wanted && wanted !== current.situacao) return HttpResponse.json([]);
+      const url = new URL(request.url);
+      const wanted = url.searchParams.get('Situacao');
+      if (wanted && wanted !== current.situacao) return HttpResponse.json(pagedResponse([], url));
 
-      return HttpResponse.json([current]);
+      return HttpResponse.json(pagedResponse([current], url));
     }),
     http.patch<{ itemId: string }, { situacao: LostItemStatusEnum }>(
       `${LOST_ITEMS_URL}/:itemId/situacao`,
@@ -128,13 +151,13 @@ async function filterByStatus(optionLabel: string) {
   await userEvent.click(screen.getByRole('button', { name: FILTER_SUBMIT_LABEL }));
 }
 
-function renderComponent() {
+function renderComponent(search = '') {
   const router = createMemoryRouter(
     [
       { path: RoutePathEnum.LOST_AND_FOUND, element: <LostAndFound /> },
       { path: RoutePathEnum.MENU, element: <div>menu</div> },
     ],
-    { initialEntries: [RoutePathEnum.LOST_AND_FOUND] },
+    { initialEntries: [`${RoutePathEnum.LOST_AND_FOUND}${search}`] },
   );
   render(<RouterProvider router={router} />);
 
@@ -468,5 +491,70 @@ describe('LostAndFound', () => {
     const dialog = within(await screen.findByRole('dialog'));
     expect(dialog.getByRole('heading', { name: EDIT_MODE.title })).toBeInTheDocument();
     expect(dialog.getByDisplayValue(OWN_OPEN_ITEM.nome)).toBeInTheDocument();
+  });
+
+  describe('paginação e busca na URL', () => {
+    const SECOND_PAGE_LABEL = 'Ir para a página 2';
+
+    function manyItems(total: number) {
+      return Array.from({ length: total }, (_, index) => ({
+        ...LOST_ITEM,
+        id: `item-${index}`,
+        nome: `Item ${index}`,
+      }));
+    }
+
+    it('should open with the fields already filled from the url', async () => {
+      listReturning([LOST_ITEM]);
+
+      renderComponent('?nome=Garrafa&tipo=perdido');
+
+      expect(await screen.findByDisplayValue('Garrafa')).toBeInTheDocument();
+    });
+
+    it('should ask the api for the page the url names', async () => {
+      let asked: URL | null = null;
+      listReturning(manyItems(30), (url) => {
+        asked = url;
+      });
+
+      renderComponent('?pagina=3');
+
+      await waitFor(() => expect(asked!.searchParams.get('Page')).toBe('3'));
+    });
+
+    it('should put the chosen page in the url and leave the first one out', async () => {
+      listReturning(manyItems(30));
+      const router = renderComponent();
+
+      await userEvent.click(await screen.findByRole('button', { name: SECOND_PAGE_LABEL }));
+
+      await waitFor(() => expect(router.state.location.search).toBe('?pagina=2'));
+    });
+
+    it('should go back to the first page when a filter is applied', async () => {
+      listReturning(manyItems(30));
+      const router = renderComponent('?pagina=3');
+
+      await userEvent.type(await screen.findByLabelText(FILTER_LABELS.name), 'Mochila');
+      await userEvent.click(screen.getByRole('button', { name: FILTER_SUBMIT_LABEL }));
+
+      await waitFor(() => expect(router.state.location.search).toBe('?nome=Mochila'));
+    });
+
+    it('should fall back to the last page when the url asks beyond it', async () => {
+      listReturning(manyItems(12));
+      const router = renderComponent('?pagina=9');
+
+      await waitFor(() => expect(router.state.location.search).toBe('?pagina=2'));
+    });
+
+    it('should keep the default status out of the url while showing it on the screen', async () => {
+      listReturning([LOST_ITEM]);
+      const router = renderComponent();
+
+      expect(await screen.findByText(LOST_ITEM.nome)).toBeInTheDocument();
+      expect(router.state.location.search).toBe('');
+    });
   });
 });

--- a/FateConnect/Web/src/pages/LostAndFound/components/LostItemFilter/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/components/LostItemFilter/index.tsx
@@ -7,30 +7,44 @@ import {
   LostItemStatusEnum,
   type LostItemFilter as LostItemFilterValues,
 } from '@app/services/lostAndFound/types';
-import { toApiDate } from '@app/utils/apiDate';
+import { fromFormDate, toApiDate } from '@app/utils/apiDate';
 
 import * as C from './constants';
 
 /** Células por linha no desktop: cinco campos e o botão quebram em duas. */
 const FILTER_COLUMNS = 3;
-const NO_FILTERS = 0;
 
-/** O mural já abre em Aberto, então isso sozinho não conta como filtro. */
-function isBeyondDefault({ status, ...rest }: LostItemFilterValues): boolean {
-  if (Object.keys(rest).length > NO_FILTERS) return true;
+/** O mural já abre em Aberto, e paginação não é escolha de busca: nenhum dos dois acende o ponto. */
+function isBeyondDefault({
+  name,
+  occurredOn,
+  kind,
+  onlyMine,
+  status,
+}: LostItemFilterValues): boolean {
+  if (name || occurredOn || kind || onlyMine) return true;
 
   return status !== LostItemStatusEnum.OPEN;
 }
 
-type LostItemFilterProps = Readonly<{ onApply: (filters: LostItemFilterValues) => void }>;
+type LostItemFilterProps = Readonly<{
+  initialFilters: LostItemFilterValues;
+  onApply: (filters: LostItemFilterValues) => void;
+}>;
 
-export function LostItemFilter({ onApply }: LostItemFilterProps) {
-  const [itemName, setItemName] = useState('');
-  const [occurredOn, setOccurredOn] = useState<Date | null>(null);
-  const [kind, setKind] = useState<string>(C.LostItemKindFilterEnum.ALL);
-  const [owner, setOwner] = useState<string>(C.LostItemOwnerFilterEnum.ALL);
-  const [status, setStatus] = useState<string>(LostItemStatusEnum.OPEN);
-  const [isFiltered, setIsFiltered] = useState(false);
+export function LostItemFilter({ initialFilters, onApply }: LostItemFilterProps) {
+  const [itemName, setItemName] = useState(initialFilters.name ?? '');
+  const [occurredOn, setOccurredOn] = useState<Date | null>(() =>
+    fromFormDate(initialFilters.occurredOn ?? ''),
+  );
+  const [kind, setKind] = useState<string>(initialFilters.kind ?? C.LostItemKindFilterEnum.ALL);
+  const [owner, setOwner] = useState<string>(() => {
+    if (initialFilters.onlyMine) return C.LostItemOwnerFilterEnum.MINE;
+
+    return C.LostItemOwnerFilterEnum.ALL;
+  });
+  const [status, setStatus] = useState<string>(initialFilters.status ?? LostItemStatusEnum.OPEN);
+  const [isFiltered, setIsFiltered] = useState(() => isBeyondDefault(initialFilters));
   // Item achado ou perdido só pode ter ocorrido até hoje.
   const today = useMemo(() => new Date(), []);
 

--- a/FateConnect/Web/src/pages/LostAndFound/helpers/lostItemKind.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/helpers/lostItemKind.ts
@@ -13,3 +13,18 @@ export const LOST_ITEM_KIND_OPTIONS: readonly { value: LostItemKindEnum; label: 
 export function isLostItemKind(value: string): value is LostItemKindEnum {
   return KIND_VALUES.has(value);
 }
+
+/** Interpreta o valor canônico e o da URL, que é o mesmo em minúsculo. */
+export function parseLostItemKind(raw: string | null | undefined): LostItemKindEnum | null {
+  if (!raw) return null;
+
+  const found = Object.values(LostItemKindEnum).find(
+    (kind) => kind.toLowerCase() === raw.trim().toLowerCase(),
+  );
+
+  return found ?? null;
+}
+
+export function lostItemKindSlug(value: LostItemKindEnum): string {
+  return value.toLowerCase();
+}

--- a/FateConnect/Web/src/pages/LostAndFound/helpers/lostItemStatus.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/helpers/lostItemStatus.ts
@@ -28,6 +28,21 @@ export function isLostItemStatus(value: string): value is LostItemStatusEnum {
   return STATUS_VALUES.has(value);
 }
 
+/** Interpreta o valor canônico e o da URL, que é o mesmo em minúsculo. */
+export function parseLostItemStatus(raw: string | null | undefined): LostItemStatusEnum | null {
+  if (!raw) return null;
+
+  const found = Object.values(LostItemStatusEnum).find(
+    (status) => status.toLowerCase() === raw.trim().toLowerCase(),
+  );
+
+  return found ?? null;
+}
+
+export function lostItemStatusSlug(value: LostItemStatusEnum): string {
+  return value.toLowerCase();
+}
+
 export function lostItemStatusLabel(value: string): string {
   if (!isLostItemStatus(value)) return value.trim() || UNKNOWN_LABEL;
 

--- a/FateConnect/Web/src/pages/LostAndFound/helpers/searchQuery.test.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/helpers/searchQuery.test.ts
@@ -1,0 +1,96 @@
+import { LostItemKindEnum, LostItemStatusEnum } from '@app/services/lostAndFound/types';
+
+import { DEFAULT_STATUS, FIRST_PAGE, lostItemSearchCodec, PAGE_SIZE } from './searchQuery';
+
+const read = (search: string) => lostItemSearchCodec.fromParams(new URLSearchParams(search));
+
+describe('lostItemSearchCodec', () => {
+  describe('fromParams', () => {
+    it('should open the board on the default status when the url is empty', () => {
+      expect(read('')).toEqual({ page: FIRST_PAGE, pageSize: PAGE_SIZE, status: DEFAULT_STATUS });
+    });
+
+    it('should read every filter the url carries', () => {
+      expect(
+        read('pagina=2&nome=Garrafa&data=2026-08-01&tipo=perdido&situacao=resolvido&meus=sim'),
+      ).toEqual({
+        page: 2,
+        pageSize: PAGE_SIZE,
+        name: 'Garrafa',
+        occurredOn: '2026-08-01',
+        kind: LostItemKindEnum.LOST,
+        status: LostItemStatusEnum.RESOLVED,
+        onlyMine: true,
+      });
+    });
+
+    it.each(['pagina=0', 'pagina=-2', 'pagina=xis'])(
+      'should fall back to the first page when the url says %s',
+      (search) => {
+        expect(read(search).page).toBe(FIRST_PAGE);
+      },
+    );
+
+    it('should fall back to the default status when the url names one it does not know', () => {
+      expect(read('situacao=extraviado').status).toBe(DEFAULT_STATUS);
+    });
+
+    it('should ignore a kind it does not recognise', () => {
+      expect(read('tipo=emprestado').kind).toBeUndefined();
+    });
+
+    it('should not care about the case of the words', () => {
+      expect(read('tipo=ACHADO&situacao=Cancelado')).toMatchObject({
+        kind: LostItemKindEnum.FOUND,
+        status: LostItemStatusEnum.CANCELLED,
+      });
+    });
+
+    it.each(['meus=nao', 'meus=', 'meus=talvez'])(
+      'should leave "only mine" off when the url says %s',
+      (search) => {
+        expect(read(search).onlyMine).toBeUndefined();
+      },
+    );
+  });
+
+  describe('toParams', () => {
+    it('should keep the defaults out of the url', () => {
+      const params = lostItemSearchCodec.toParams({
+        page: FIRST_PAGE,
+        pageSize: PAGE_SIZE,
+        status: DEFAULT_STATUS,
+      });
+
+      expect(params).toEqual({});
+    });
+
+    it('should write the words the screen shows', () => {
+      const params = lostItemSearchCodec.toParams({
+        page: 3,
+        pageSize: PAGE_SIZE,
+        kind: LostItemKindEnum.FOUND,
+        status: LostItemStatusEnum.CANCELLED,
+        onlyMine: true,
+      });
+
+      expect(params).toEqual({ pagina: '3', tipo: 'achado', situacao: 'cancelado', meus: 'sim' });
+    });
+
+    it('should survive a round trip through the url', () => {
+      const original = {
+        page: 4,
+        pageSize: PAGE_SIZE,
+        name: 'Guarda-chuva azul',
+        occurredOn: '2026-07-15',
+        kind: LostItemKindEnum.LOST,
+        status: LostItemStatusEnum.RESOLVED,
+        onlyMine: true,
+      };
+
+      const params = new URLSearchParams(lostItemSearchCodec.toParams(original));
+
+      expect(lostItemSearchCodec.fromParams(params)).toEqual(original);
+    });
+  });
+});

--- a/FateConnect/Web/src/pages/LostAndFound/helpers/searchQuery.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/helpers/searchQuery.ts
@@ -1,0 +1,67 @@
+import type { SearchQueryCodec } from '@app/hooks/useSearchQuery';
+import { LostItemStatusEnum, type LostItemFilter } from '@app/services/lostAndFound/types';
+
+import { lostItemKindSlug, parseLostItemKind } from './lostItemKind';
+import { lostItemStatusSlug, parseLostItemStatus } from './lostItemStatus';
+
+export const FIRST_PAGE = 1;
+export const PAGE_SIZE = 10;
+export const DEFAULT_STATUS = LostItemStatusEnum.OPEN;
+
+const MINE = 'sim';
+
+enum SearchParamEnum {
+  PAGE = 'pagina',
+  NAME = 'nome',
+  OCCURRED_ON = 'data',
+  KIND = 'tipo',
+  STATUS = 'situacao',
+  ONLY_MINE = 'meus',
+}
+
+function readPage(raw: string | null): number {
+  const parsed = Number.parseInt(raw ?? '', 10);
+
+  if (!Number.isFinite(parsed) || parsed < FIRST_PAGE) return FIRST_PAGE;
+
+  return parsed;
+}
+
+function fromParams(params: URLSearchParams): LostItemFilter {
+  const filter: LostItemFilter = {
+    page: readPage(params.get(SearchParamEnum.PAGE)),
+    pageSize: PAGE_SIZE,
+    // O mural abre em Aberto, então a ausência do parâmetro é essa escolha.
+    status: parseLostItemStatus(params.get(SearchParamEnum.STATUS)) ?? DEFAULT_STATUS,
+  };
+
+  const name = params.get(SearchParamEnum.NAME)?.trim();
+  if (name) filter.name = name;
+
+  const occurredOn = params.get(SearchParamEnum.OCCURRED_ON)?.trim();
+  if (occurredOn) filter.occurredOn = occurredOn;
+
+  const kind = parseLostItemKind(params.get(SearchParamEnum.KIND));
+  if (kind) filter.kind = kind;
+
+  if (params.get(SearchParamEnum.ONLY_MINE)?.trim().toLowerCase() === MINE) filter.onlyMine = true;
+
+  return filter;
+}
+
+function toParams(filter: LostItemFilter): Record<string, string> {
+  const params: Record<string, string> = {};
+
+  if (filter.page && filter.page > FIRST_PAGE) params[SearchParamEnum.PAGE] = String(filter.page);
+  if (filter.name) params[SearchParamEnum.NAME] = filter.name;
+  if (filter.occurredOn) params[SearchParamEnum.OCCURRED_ON] = filter.occurredOn;
+  if (filter.kind) params[SearchParamEnum.KIND] = lostItemKindSlug(filter.kind);
+  if (filter.status && filter.status !== DEFAULT_STATUS) {
+    params[SearchParamEnum.STATUS] = lostItemStatusSlug(filter.status);
+  }
+  if (filter.onlyMine) params[SearchParamEnum.ONLY_MINE] = MINE;
+
+  return params;
+}
+
+export const lostItemSearchCodec: SearchQueryCodec<LostItemFilter> = { fromParams, toParams };

--- a/FateConnect/Web/src/pages/LostAndFound/index.tsx
+++ b/FateConnect/Web/src/pages/LostAndFound/index.tsx
@@ -1,44 +1,62 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { NavLink } from 'react-router';
-import { CircularProgress, PageShell, Typography } from '@design-system';
+import { ListCardSkeleton, PageShell, Pagination, Typography } from '@design-system';
 import { AddIcon, ArrowBackIcon, SearchIcon } from '@design-system/icons';
 import { useQuery } from '@tanstack/react-query';
 
+import { useSearchQuery } from '@app/hooks/useSearchQuery';
 import { RoutePathEnum } from '@app/routes/paths';
 import { listLostItems } from '@app/services/lostAndFound/lostAndFoundService';
-import {
-  LostItemStatusEnum,
-  type LostItem,
-  type LostItemFilter as LostItemFilterValues,
+import type {
+  LostItem,
+  LostItemFilter as LostItemFilterValues,
 } from '@app/services/lostAndFound/types';
 
 import { LostItemCard } from './components/LostItemCard';
 import { LostItemFilter } from './components/LostItemFilter';
 import { LostItemFormDialog } from './components/LostItemFormDialog';
+import { FIRST_PAGE, lostItemSearchCodec, PAGE_SIZE } from './helpers/searchQuery';
 import { useLostItemTransitions } from './hooks/useLostItemTransitions';
 import * as C from './constants';
 import * as S from './styles';
 
-const SPINNER_SIZE_PX = 60;
 const NO_ITEMS = 0;
-
-const INITIAL_FILTERS: LostItemFilterValues = { status: LostItemStatusEnum.OPEN };
+const NO_PAGES = 0;
 
 export function LostAndFound() {
-  const [filters, setFilters] = useState<LostItemFilterValues>(INITIAL_FILTERS);
+  const { value: filters, replace: replaceSearch } = useSearchQuery(lostItemSearchCodec);
   const [editingItem, setEditingItem] = useState<LostItem | undefined>(undefined);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const { resolveItem, cancelItem, reopenItem, isTransitioning } = useLostItemTransitions();
 
-  const { data: items = [], isPending } = useQuery({
+  const { data: itemPage, isPending } = useQuery({
     queryKey: [C.LOST_ITEMS_QUERY_KEY, filters],
     queryFn: () => listLostItems(filters),
     meta: { errorMessage: C.LOST_ITEM_LIST_MESSAGES.loadFailed },
   });
 
+  const items = itemPage?.items ?? [];
+  const totalPages = itemPage?.totalPages ?? NO_PAGES;
+  const currentPage = filters.page ?? FIRST_PAGE;
+
+  // Quem salvou `?pagina=7` e voltou depois de a lista encolher veria uma página
+  // vazia, que parece defeito. Cai na última existente e a URL acompanha.
+  useEffect(() => {
+    if (totalPages === NO_PAGES || currentPage <= totalPages) return;
+
+    replaceSearch({ ...filters, page: totalPages });
+  }, [currentPage, filters, replaceSearch, totalPages]);
+
+  // Filtrar refaz a busca, então a página volta a ser a primeira.
   const handleApplyFilters = useCallback(
-    (applied: LostItemFilterValues) => setFilters(applied),
-    [],
+    (applied: LostItemFilterValues) =>
+      replaceSearch({ ...applied, page: FIRST_PAGE, pageSize: PAGE_SIZE }),
+    [replaceSearch],
+  );
+
+  const handlePageChange = useCallback(
+    (nextPage: number) => replaceSearch({ ...filters, page: nextPage }),
+    [filters, replaceSearch],
   );
 
   const handleRegister = useCallback(() => {
@@ -84,14 +102,10 @@ export function LostAndFound() {
         </>
       }
     >
-      <LostItemFilter onApply={handleApplyFilters} />
+      <LostItemFilter initialFilters={filters} onApply={handleApplyFilters} />
 
       <S.LostItemList>
-        {isLoading && (
-          <S.LoadingContainer>
-            <CircularProgress size={SPINNER_SIZE_PX} />
-          </S.LoadingContainer>
-        )}
+        {isLoading && <ListCardSkeleton />}
 
         {!isLoading && items.length === NO_ITEMS && (
           <Typography variant="subtitle">{C.EMPTY_LIST_MESSAGE}</Typography>
@@ -109,6 +123,12 @@ export function LostAndFound() {
             />
           ))}
       </S.LostItemList>
+
+      {!isLoading && (
+        <S.PaginationRow>
+          <Pagination count={totalPages} page={currentPage} onChange={handlePageChange} />
+        </S.PaginationRow>
+      )}
 
       <LostItemFormDialog open={isFormOpen} onClose={handleCloseForm} item={editingItem} />
     </PageShell>

--- a/FateConnect/Web/src/pages/LostAndFound/styles.ts
+++ b/FateConnect/Web/src/pages/LostAndFound/styles.ts
@@ -1,17 +1,15 @@
-import { Stack, styled } from '@design-system';
+import { spacingScale, Stack, styled } from '@design-system';
 
-/** Altura reservada enquanto a lista carrega, para o rodapé não pular. */
-const LOADING_MIN_HEIGHT_PX = 300;
+const { sm } = spacingScale;
 
 export const LostItemList = styled(Stack)({
   flexDirection: 'column',
   width: '100%',
 });
 
-export const LoadingContainer = styled(Stack)({
+export const PaginationRow = styled(Stack)(({ theme }) => ({
   flexDirection: 'row',
   justifyContent: 'center',
-  alignItems: 'center',
-  minHeight: `${LOADING_MIN_HEIGHT_PX}px`,
   width: '100%',
-});
+  paddingTop: theme.space(sm),
+}));

--- a/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.test.ts
+++ b/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.test.ts
@@ -21,6 +21,9 @@ const LOST_ITEM_INPUT: LostItemInput = {
 };
 
 const LOST_AND_FOUND_URL = 'https://api.fateconnect.test/achado';
+const FIRST_PAGE = 1;
+const PAGE_SIZE = 10;
+const SINGLE_PAGE = 1;
 const ITEM_ID = 'c4a1f0d2-5b3e-4a6c-9f81-7d2e5b0a3c14';
 
 const NO_CONTENT = 204;
@@ -42,13 +45,23 @@ function statusEndpointRecording(received: StatusRequest[]) {
   );
 }
 
+function pageOf(items: unknown[]) {
+  return {
+    items,
+    page: FIRST_PAGE,
+    pageSize: PAGE_SIZE,
+    total: items.length,
+    totalPages: SINGLE_PAGE,
+  };
+}
+
 describe('lostAndFoundService', () => {
   it('should translate the front filters into the api query parameters', async () => {
     let received: URLSearchParams | null = null;
     server.use(
       http.get(LOST_AND_FOUND_URL, ({ request }) => {
         received = new URL(request.url).searchParams;
-        return HttpResponse.json([]);
+        return HttpResponse.json(pageOf([]));
       }),
     );
 
@@ -72,7 +85,7 @@ describe('lostAndFoundService', () => {
     server.use(
       http.get(LOST_AND_FOUND_URL, ({ request }) => {
         received = new URL(request.url).searchParams;
-        return HttpResponse.json([]);
+        return HttpResponse.json(pageOf([]));
       }),
     );
 
@@ -83,12 +96,14 @@ describe('lostAndFoundService', () => {
 
   it('should list items without filters', async () => {
     server.use(
-      http.get(LOST_AND_FOUND_URL, () => HttpResponse.json([{ id: 'c7d2', nome: 'Guarda-chuva' }])),
+      http.get(LOST_AND_FOUND_URL, () =>
+        HttpResponse.json(pageOf([{ id: 'c7d2', nome: 'Guarda-chuva' }])),
+      ),
     );
 
-    const items = await listLostItems();
+    const page = await listLostItems();
 
-    expect(items).toHaveLength(1);
+    expect(page.items).toHaveLength(1);
   });
 
   it('should conclude the item through the status resource', async () => {
@@ -129,7 +144,7 @@ describe('lostAndFoundService', () => {
       http.get(LOST_AND_FOUND_URL, () => HttpResponse.text('<!doctype html><html></html>')),
     );
 
-    await expect(listLostItems()).rejects.toThrow(/não é uma lista/);
+    await expect(listLostItems()).rejects.toThrow(/não é uma página/);
   });
 
   it('should post the item on creation and return what the api answered', async () => {

--- a/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.ts
+++ b/FateConnect/Web/src/services/lostAndFound/lostAndFoundService.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '../httpClient';
+import type { PagedResult } from '../types';
 import {
   LostItemStatusEnum,
   type LostItem,
@@ -9,7 +10,7 @@ import {
 const LOST_AND_FOUND_PATH = '/achado';
 
 const INVALID_LIST_PAYLOAD_MESSAGE =
-  'A API de achados e perdidos respondeu algo que não é uma lista.';
+  'A API de achados e perdidos respondeu algo que não é uma página.';
 
 function toQueryParams(filters: LostItemFilter = {}): Record<string, string> {
   const params: Record<string, string> = {};
@@ -19,17 +20,19 @@ function toQueryParams(filters: LostItemFilter = {}): Record<string, string> {
   if (filters.kind) params.Tipo = filters.kind;
   if (filters.onlyMine) params.MeusItens = 'true';
   if (filters.status) params.Situacao = filters.status;
+  if (filters.page) params.Page = String(filters.page);
+  if (filters.pageSize) params.PageSize = String(filters.pageSize);
 
   return params;
 }
 
-export async function listLostItems(filters?: LostItemFilter): Promise<LostItem[]> {
-  const { data } = await apiClient.get<LostItem[]>(LOST_AND_FOUND_PATH, {
+export async function listLostItems(filters?: LostItemFilter): Promise<PagedResult<LostItem>> {
+  const { data } = await apiClient.get<PagedResult<LostItem>>(LOST_AND_FOUND_PATH, {
     params: toQueryParams(filters),
   });
 
   // Sem endereço de API a requisição cai no dev server, que responde HTML com 200.
-  if (!Array.isArray(data)) throw new Error(INVALID_LIST_PAYLOAD_MESSAGE);
+  if (!Array.isArray(data?.items)) throw new Error(INVALID_LIST_PAYLOAD_MESSAGE);
 
   return data;
 }

--- a/FateConnect/Web/src/services/lostAndFound/types.ts
+++ b/FateConnect/Web/src/services/lostAndFound/types.ts
@@ -1,3 +1,5 @@
+import type { PageQuery } from '../types';
+
 /** Valores canônicos alinhados à serialização do backend. */
 export enum LostItemKindEnum {
   FOUND = 'Achado',
@@ -35,10 +37,10 @@ export type LostItemInput = Pick<
   'nome' | 'tipo' | 'local' | 'dataOcorrido' | 'descricao'
 >;
 
-export type LostItemFilter = {
+export interface LostItemFilter extends PageQuery {
   name?: string;
   occurredOn?: string;
   kind?: LostItemKindEnum;
   onlyMine?: boolean;
   status?: LostItemStatusEnum;
-};
+}


### PR DESCRIPTION
## Objetivo

O mesmo trabalho da tela de caronas, no mural de achados e perdidos: uma página por vez, e a busca guardada no endereço.

## Alterações

### O hook foi reusado, não reescrito

Era o ponto da issue: *"a mesma decisão tomada duas vezes em dois PRs é como as duas telas divergem"*. Daqui saiu **só o codec desta tela** — `useSearchQuery`, `PagedResult` e `PageQuery` vieram prontos.

### A tela

`listLostItems` passa a devolver a página e a guarda de formato acompanha. O filtro **nasce preenchido a partir da URL**, o `Pagination` entra no rodapé, e o `CircularProgress` dá lugar ao `ListCardSkeleton` em todas as cargas. Página fora do intervalo cai na última existente, reescrevendo o endereço; aplicar filtro volta para a primeira.

### A URL

```
/achados-perdidos?pagina=2&nome=Garrafa&data=2026-08-01&tipo=perdido&situacao=resolvido&meus=sim
```

Em pt-BR, com o valor canônico em minúsculo. **A situação `Aberto` fica implícita** — é como o mural abre, e escolher outra é o que escreve o parâmetro. `meus=sim` liga; ausência, `nao` ou qualquer outra coisa desliga. Leitura tolerante a maiúscula, e valor irreconhecível é ignorado em vez de quebrar a tela.

### O stub passou a fatiar como a API

A issue pedia **mesma rigidez da API**, e o stub agora lê `Page` e `PageSize`, corta a fatia e conta o `total` sobre o conjunto inteiro. Página além da última sai vazia sem eu programar o caso — porque é o que a API faria.

## Issue

- #174

Closes #174

Sub-issue da #170, que fecha quando esta entrar.

### O envelope nasce em inglês, os itens seguem em português

Decisão registrada na issue: o envelope é **código novo**, então nasce nos nomes que a #172 já entregou em `/Rides` e que o `PagedResult<T>` usa — sem tipo novo e sem tradução depois. Os campos do item (`nome`, `situacao`, `meuItem`) seguem em português; traduzi-los é a **#111**, e o contrato do item já está em inglês na #106.

A query fica misturada de propósito e por pouco tempo: `Page` e `PageSize` são novos e nascem em inglês, ao lado de `Nome`, `DataOcorrido`, `Tipo`, `MeusItens` e `Situacao`, que já existiam.

Corrigi também, **na #106**, o bloco de paginação que estava em português destoando do contrato do item que a #207 já levara para inglês. E a própria **#174** teve o contrato corrigido antes de eu implementar, com data e motivo.

## Evidências

| Verificação | Resultado |
| --- | --- |
| ESLint / `tsc` | 0 / 0 |
| Suíte | **488 testes**, 70 arquivos (eram 468) |
| Cobertura global | 98,5 / 93,22 / 98,13 / 99,36 |
| `src/pages/LostAndFound` | 100 / 95,65 / 100 / 100 |
| Cada commit isolado | compila e passa sozinho, em worktree (o primeiro fecha com 468) |

### Um defeito que a paginação teria introduzido

O `isBeyondDefault` decide se o ponto de "há filtro valendo" acende ao lado do título. Ele contava as chaves do filtro com `{ status, ...rest }` — e, com `page` e `pageSize` agora no mesmo objeto, passaria a **retornar sempre true**: o ponto ficaria aceso para sempre.

Nenhum teste existente pegaria isso. Reescrito explícito, no mesmo desenho do `hasAnyFilter` que o #239 criou em caronas; a constante `NO_FILTERS`, que ficou órfã, saiu junto.

ℹ️ **Não vai para o changelog:** nasceu e morreu dentro deste PR, nunca esteve no código publicado.
