### PR TITLE
refactor(237): run the api suite against a real postgres

### DIFF
--- a/.claude/rules/dotnet-code-style.md
+++ b/.claude/rules/dotnet-code-style.md
@@ -117,7 +117,7 @@ E o `Where` passa a se ler sozinho: `.Where(HasNotDeparted(today, currentTime))`
 
 ⚠️ **Nomeie o conceito inteiro, não as metades.** `HasNotDeparted` diz o que a regra significa; quebrar em `isAfterToday || isTodayAndAfterNow` obriga quem lê a recompor o sentido a partir dos pedaços.
 
-⚠️ **O gate não protege isto.** A suíte roda no provider em memória, que executa LINQ em memória e aceita as duas formas — a que traduz e a que não. Para provar tradução, gere o SQL com `ToQueryString()` contra o `UseNpgsql`, que não precisa de banco no ar.
+✅ **O gate protege isto desde a #237.** A suíte roda contra PostgreSQL de verdade, então predicado que não traduz derruba teste: a mutação para método `bool` fez **20 testes** caírem. Antes, no provedor em memória, as duas formas passavam iguais.
 
 ## DTO de query: opcional é nullable, derivado é `[BindNever]`
 

--- a/.claude/rules/dotnet-migrations.md
+++ b/.claude/rules/dotnet-migrations.md
@@ -28,7 +28,7 @@ Renomear a tabela **não** renomeia o que aponta para ela. Cada um destes precis
 
 ## Provar que os dados sobrevivem
 
-⛔ **Suíte verde não prova nada aqui.** Os testes rodam em `Microsoft.EntityFrameworkCore.InMemory`, que não executa DDL nem gera SQL de Postgres. A prova é aplicar num Postgres de verdade, na versão que a VPS roda:
+⛔ **Suíte verde não prova isto.** A suíte aplica as migrations num PostgreSQL de verdade, então migration que não roda derruba teste — mas sempre num banco **vazio**: nada ali diz se os dados sobreviveram ao rename. A prova é aplicar num Postgres com linhas dentro, na versão que a VPS roda:
 
 ```bash
 docker run -d --name mig-probe -e POSTGRES_HOST_AUTH_METHOD=trust -p 55432:5432 postgres:<versão da VPS>

--- a/.claude/rules/dotnet-testing.md
+++ b/.claude/rules/dotnet-testing.md
@@ -44,6 +44,8 @@ Medido em 2026-08-28, publicando a `FateConnect.Api` dos dois jeitos:
 
 Vão para dentro do contêiner de produção `xunit.core`, `xunit.assert`, `xunit.execution.dotnet`, `xunit.abstractions`, `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.EntityFrameworkCore.InMemory` e um `MvcTestingAppManifest.json` — inclusive um provedor de banco alternativo disponível no processo que atende a internet.
 
+⚠️ **A lista é a daquela medição.** Trocado o `InMemory` pelo `Testcontainers.PostgreSql` na #237, o que vaza hoje é um cliente de Docker: o risco não encolheu, mudou de forma.
+
 É também o que a Microsoft manda por escrito — *"Separate unit tests from integration tests into different projects"* — e o que os projetos de referência fazem: o `dotnet/eShop` tem `src/Catalog.API` com `tests/Catalog.FunctionalTests` ao lado, o `dotnet/aspnetcore` repete `src/` e `test/` em cada módulo, o `MediatR` tem `src/` e `test/`.
 
 **A única peça de apoio a teste que pode morar no app** é tornar o `Program` visível para o `WebApplicationFactory`. O eShop faz isso com um arquivo de três linhas, e explica que `InternalsVisibleTo` não resolve porque a acessibilidade do tipo é verificada. Aqui o `Program` já é público, então nem isso é preciso.
@@ -107,15 +109,29 @@ Nunca exponha membro só para testar. O que interessa é o resultado do método 
 
 Aqui isso já espera por alguém: `Ride.ValidateDepartureDateTime` compara a partida com `DateTime.UtcNow`, então testar a regra de "partida no futuro" exige injetar o tempo antes.
 
-## Subir a aplicação sem banco
+## Subir a aplicação contra PostgreSQL de verdade
 
-O `ApiFactory` troca o provedor por `UseInMemoryDatabase`, e o `Program` só chama `Migrate()` quando `database.IsRelational()` — sem essa guarda a aplicação não sobe no teste, porque provedor em memória não tem migration.
+⛔ **A suíte precisa de Docker.** O `TestDatabase` sobe **um** container `postgres:17` para a suíte inteira, e cada `ApiFactory` registra `UseNpgsql` apontando para um banco próprio dentro dele — o isolamento entre classes de teste é o banco, não o container. Sem Docker a suíte falha inteira, com a mensagem que o `TestDatabase` escreve; não há caminho de fallback, porque verde com testes pulados é o falso verde que esta seção existe para impedir.
 
-⚠️ **O provedor em memória não é o Postgres.** Ele não avalia `unaccent` nem `ILike`, então filtro por destino não se prova ali: ou o teste evita esse caminho, ou a prova é gerar o SQL e lê-lo.
+**A tag casa com a produção.** A VPS roda o `postgres-17` do Ubuntu, então a imagem é `postgres:17` e não a mais recente. Não pinamos versão de Docker: o Testcontainers não declara mínimo, e nada no nosso código fixa versão de API.
 
-⛔ **E o risco maior é o inverso: ele aceita o que o Postgres recusa.** O provedor em memória executa LINQ em memória, então uma consulta que o PostgreSQL não sabe traduzir passa verde aqui e quebra em produção. Trocar a `Expression` de um predicado por um método `bool` — ver `dotnet-code-style.md` — é a forma mais fácil de causar isso: a suíte inteira continua passando.
+**O schema nasce das migrations**, porque é o `Migrate()` do `Program` que roda — o mesmo caminho da produção. Migration quebrada aparece no teste, e o `unaccent` vem junto sem passo manual, porque o `FateConnectDbContext` o declara com `HasPostgresExtension`.
 
-**Enquanto for assim, tradução se prova gerando o SQL**, com `ToQueryString()` contra o `UseNpgsql`, que não precisa de banco no ar. A #237 troca o provedor por PostgreSQL real e **reescreve esta seção**.
+⚠️ **O custo é real e conhecido: ~6s contra ~1s do provedor em memória.** São **24 fábricas** — uma por classe com `IClassFixture`, mais uma por caso de teste do `RideListingTests` —, logo 24 bancos criados e migrados. Isso é aceitável para o que compra, e o que compra foi medido na #237, com três mutações:
+
+| mutação | o que cai |
+| --- | --- |
+| `Expression<Func<Ride, bool>>` vira método `bool` — ver `dotnet-code-style.md` | **20 testes** |
+| `Unaccent` sai da coluna | 2 casos de `GetRides_FilteredByDestination_IgnoresAccentsAndCase` |
+| `Unaccent` sai do padrão de busca | 2 casos, e **não os mesmos** |
+
+As três passavam verdes no provedor em memória, que executa LINQ em memória e não conhece função de PostgreSQL.
+
+⚠️ **Não serialize a criação dos bancos, e não desligue o paralelismo do xUnit.** As 24 fábricas criam banco ao mesmo tempo, e a falha clássica disso — `source database "template1" is being accessed by other users` — exige uma sessão aberta **no template**. Medido durante uma corrida real: os únicos bancos que recebem conexão são o `postgres`, onde o Npgsql abre a conexão administrativa, e os `fateconnect-tests-<guid>`; o `template1` recebe **zero**. Pico de **25 conexões contra o teto de 100**, e 120 `CREATE DATABASE` concorrentes numa sonda não produziram uma falha.
+
+⚠️ **Aquele zero só vale por causa do controle positivo.** Antes de acreditar nele, a mesma sonda forçou o erro de propósito — conexão aberta num banco e `CREATE DATABASE ... TEMPLATE` copiando dele — e ele apareceu. Sonda que não consegue produzir a falha não está medindo a ausência dela.
+
+⚠️ **Cada `[InlineData]` de acento precisa provar um lado.** As duas últimas mutações derrubam casos diferentes justamente porque um deles tem acento na coluna e busca sem, e o outro o inverso. Caso que nenhuma mutação derruba é caso que não está provando nada.
 
 ## Suíte verde não prova que ela pega o defeito
 

--- a/.claude/rules/prove-the-mechanism.md
+++ b/.claude/rules/prove-the-mechanism.md
@@ -1,0 +1,30 @@
+---
+description: Risco residual não é entregável — evidência estatística é gatilho de procurar o mecanismo, e o zero de uma sonda só vale com controle positivo
+---
+
+# Prove o mecanismo, não a frequência
+
+⛔ **Evidência estatística não é resultado para relatar — é ordem de ir atrás do mecanismo.** "Rodei 5 vezes e passou" responde *com que frequência*; a pergunta era *pode acontecer*. Só a segunda fecha o assunto.
+
+**O gatilho é a frase que você está prestes a escrever:** *"é evidência, não prova"*, *"rodei N vezes e passou"*, *"aqui não reproduz"*, *"deve ser raro"*. Nenhuma é conclusão. Todas são o momento de responder duas coisas:
+
+1. **Qual é a pré-condição exata da falha que eu temo?** Ela costuma estar escrita na mensagem de erro dela.
+2. **Essa pré-condição chega a existir aqui — medido, não deduzido?**
+
+Provada a impossibilidade, o risco acabou e o número vira nota de rodapé. Não provada, o resíduo é real e relatá-lo é o certo — dizendo **o que já foi descartado** e o que resolveria.
+
+⛔ Aconteceu na #237. Fechei a entrega listando um risco em aberto — 24 fábricas de teste criando banco ao mesmo tempo, *"5 corridas verdes, é evidência, não prova"* — e pedi confirmação para commitar. A devolução do Victor foi *"ué se é risco oq podemos fazer pra não ter risco?"*. Não havia risco, e o mecanismo levou três minutos: a falha temida exige sessão aberta no `template1`, e o `template1` recebe **zero** conexões na corrida real. Pergunta categórica tratada como estatística.
+
+⚠️ **A ressalva honesta é o disfarce.** *"É evidência, não prova"* soa como rigor — soa melhor que "não consigo explicar" —, e é justamente por isso que a parada passa despercebida. O teste não é se a frase é verdadeira: é se ela **transfere a dúvida** para quem lê.
+
+## O zero só vale com controle positivo
+
+⛔ **Antes de relatar que a falha não aconteceu, force-a a acontecer.** Sonda incapaz de produzir o defeito de propósito não mede a ausência dele — mede nada, e devolve verde.
+
+Duas na mesma #237: `DOCKER_HOST` apontando para porta morta não desligou o Docker, porque o Testcontainers cai para o socket do Desktop e a suíte passa igual; e a guarda que eu escrevi para o caso "sem Docker" **nunca era exibida**, porque a exceção nasce em outro método. As duas só apareceram parando o Docker de verdade.
+
+⚠️ **Desligar por variável de ambiente não é desligar.** Ferramenta com descoberta automática de endpoint — Docker, proxy, DNS, resolvedor de pacote — trata a variável como preferência, não como ordem. Para medir a ausência, tire o recurso do ar.
+
+## O que esta rule não é
+
+Não é ordem de esgotar toda dúvida antes de abrir a boca. Ela vale no **fechamento** — ao dizer "pronto", abrir PR ou pedir confirmação. No meio do trabalho, resíduo em aberto é normal, e dizer que está em aberto é o certo.

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -116,8 +116,8 @@ jobs:
         if: steps.changes.outputs.api == 'true'
         run: dotnet build FateConnect/FateConnect.Api/FateConnect.Api.sln
 
-      # A suíte sobe a própria aplicação com banco em memória, então não há
-      # Postgres a provisionar aqui.
+      # A suíte sobe o próprio PostgreSQL por Testcontainers, no Docker que já vem
+      # no runner — o serviço não se declara aqui.
       #
       # O formato é OpenCover porque o Sonar não lê Cobertura para C#, que é o
       # que o `dotnet test` produz por padrão.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ git config core.hooksPath .githooks
 
 O `pre-commit` conserta o que dá no front — `eslint --fix` e `prettier --write` sobre o que está preparado — e compila a API quando a mudança a alcança, que é a build por onde entra o SonarAnalyzer. O `pre-push` roda o recorte de testes do front relacionado ao que está sendo enviado e a suíte da API. A suíte inteira com cobertura fica no CI.
 
+**A suíte da API precisa de Docker rodando.** Ela sobe um contêiner `postgres:17` e roda as consultas contra o banco de verdade, porque o filtro por destino usa funções do PostgreSQL e porque consulta que o Postgres não traduz precisa quebrar teste, não produção. Vale para `dotnet test` e, por tabela, para o `git push` que dispara o `pre-push`.
+
 ## Branch e commit
 
 Branch sai da **`develop`**, nomeada `<tipo>/<número-da-issue>` — `feat/56`, `fix/171`, `chore/48`. Sem issue, um slug descritivo.

--- a/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
+++ b/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
@@ -35,7 +35,8 @@ public class ApiFactory : WebApplicationFactory<Program>
                 service => service.ServiceType == typeof(DbContextOptions<FateConnectDbContext>));
 
             services.Remove(registration);
-            services.AddDbContext<FateConnectDbContext>(options => options.UseInMemoryDatabase(_databaseName));
+            services.AddDbContext<FateConnectDbContext>(
+                options => options.UseNpgsql(TestDatabase.ConnectionStringFor(_databaseName)));
         });
     }
 

--- a/FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
+++ b/FateConnect/FateConnect.Api.Tests/FateConnect.Api.Tests.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FateConnect/FateConnect.Api.Tests/RideListingTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/RideListingTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 namespace FateConnect.Api.Tests;
 
-public class RidePaginationTests
+public class RideListingTests
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
@@ -189,5 +189,52 @@ public class RidePaginationTests
         Assert.Equal(1, page.Total);
         Assert.Equal(1, page.TotalPages);
         Assert.Single(page.Items);
+    }
+
+    [Fact]
+    public async Task GetRides_FilteredByDestination_KeepsOnlyTheRidesThatMatch()
+    {
+        using ApiFactory factory = new();
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+        Guid matching = factory.SeedRide(driverId, tomorrow, new TimeOnly(8, 30), "São Paulo centro");
+        factory.SeedRide(driverId, tomorrow, new TimeOnly(9, 0), "Campinas");
+
+        PagedRides page = await GetPageAsync(factory, driverId, "?Destination=paulo");
+
+        Assert.Equal(1, page.Total);
+        Assert.Equal(matching, Assert.Single(page.Items).Id);
+    }
+
+    [Theory]
+    [InlineData("São Paulo centro", "sao paulo")]
+    [InlineData("Sao Paulo centro", "são paulo")]
+    [InlineData("São Paulo centro", "SÃO PAULO")]
+    public async Task GetRides_FilteredByDestination_IgnoresAccentsAndCase(string destination, string search)
+    {
+        using ApiFactory factory = new();
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+        Guid expected = factory.SeedRide(driverId, tomorrow, new TimeOnly(8, 30), destination);
+
+        PagedRides page = await GetPageAsync(factory, driverId, $"?Destination={Uri.EscapeDataString(search)}");
+
+        Assert.Equal(expected, Assert.Single(page.Items).Id);
+    }
+
+    [Fact]
+    public async Task GetRides_WithEveryFilterAtOnce_IsTranslatedToSql()
+    {
+        using ApiFactory factory = new();
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
+        Guid expected = factory.SeedRide(driverId, tomorrow, new TimeOnly(8, 30), "Sorocaba centro");
+
+        PagedRides page = await GetPageAsync(
+            factory,
+            driverId,
+            $"?Destination=sorocaba&DepartureDate={tomorrow:yyyy-MM-dd}&DepartureTime=08:30:00&RideType=Solidarity");
+
+        Assert.Equal(expected, Assert.Single(page.Items).Id);
     }
 }

--- a/FateConnect/FateConnect.Api.Tests/TestDatabase.cs
+++ b/FateConnect/FateConnect.Api.Tests/TestDatabase.cs
@@ -1,0 +1,41 @@
+using DotNet.Testcontainers.Builders;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace FateConnect.Api.Tests;
+
+public static class TestDatabase
+{
+    private const string PostgresImage = "postgres:17";
+
+    private const string DockerUnavailable =
+        "The API suite runs against a real PostgreSQL, started as a container, and Docker did not answer. "
+        + "Start Docker and run dotnet test again.";
+
+    private static readonly Lazy<PostgreSqlContainer> RunningContainer = new(Start);
+
+    public static string ConnectionStringFor(string databaseName)
+    {
+        NpgsqlConnectionStringBuilder connection = new(RunningContainer.Value.GetConnectionString())
+        {
+            Database = databaseName,
+        };
+
+        return connection.ConnectionString;
+    }
+
+    private static PostgreSqlContainer Start()
+    {
+        try
+        {
+            PostgreSqlContainer container = new PostgreSqlBuilder(PostgresImage).Build();
+            container.StartAsync().GetAwaiter().GetResult();
+
+            return container;
+        }
+        catch (DockerUnavailableException failure)
+        {
+            throw new InvalidOperationException(DockerUnavailable, failure);
+        }
+    }
+}

--- a/FateConnect/FateConnect.Api/Program.cs
+++ b/FateConnect/FateConnect.Api/Program.cs
@@ -19,7 +19,6 @@ using FateConnect.Api.Modules.Users.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
@@ -168,9 +167,7 @@ public class Program
 
         using (IServiceScope scope = app.Services.CreateScope())
         {
-            DatabaseFacade database = scope.ServiceProvider.GetRequiredService<FateConnectDbContext>().Database;
-
-            if (database.IsRelational()) database.Migrate();
+            scope.ServiceProvider.GetRequiredService<FateConnectDbContext>().Database.Migrate();
         }
 
         app.UseMiddleware<GlobalExceptionMiddleware>();

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A pasta **`.claude/`** guarda o contexto que um agente de código carrega ao tra
 | Artefato            | O que é                                                               | Quando carrega                                                         |
 | ------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `CLAUDE.md`         | Instruções do repositório: idioma, fluxo de trabalho, stack, comandos | sempre                                                                 |
-| `rules/*.md`        | Padrão que vale para uma área do código                               | pelo `paths:` do arquivo — ao abrir um arquivo que casa                |
+| `rules/*.md`        | Padrão que vale para uma área do código                               | com `paths:`, ao abrir um arquivo que casa; sem `paths:`, sempre       |
 | `skills/*/SKILL.md` | Procedimento sob demanda, com passos                                  | quando a tarefa casa com a `description`, ou pelo nome (`/pr-creator`) |
 
 As skills de hoje: **`spec-issue`** (especificar uma issue e dividir em sub-issues), **`pr-creator`** (abrir e atualizar PR), **`resolve-pr-comments`** (triar e responder review), **`write-review-comment`** (comentar o PR de outra pessoa), **`write-commit`** (mensagem de commit e agrupamento em commits), **`changelog-writer`** (entrada do `CHANGELOG.md`), **`create-release`** (cortar uma versão e publicar), **`ux-writing`** (texto de interface) e **`fateconnect-create-component`** (criar componente no front).


### PR DESCRIPTION
## Objetivo

Trocar o provedor em memória por um PostgreSQL de verdade na suíte da API, fechando os dois buracos que a #237 mediu: o filtro por destino não era testável, e uma regressão de tradução para SQL passava verde.

## Alterações

**O provedor.** O `TestDatabase` (novo) sobe **um** container `postgres:17` para a suíte inteira, e cada `ApiFactory` registra `UseNpgsql` apontando para um banco próprio dentro dele — o isolamento continua sendo por banco, como já era com o `_databaseName`. O schema nasce das migrations, porque quem as roda é o `Migrate()` do próprio `Program`, o mesmo caminho da produção; o `unaccent` vem junto sem passo manual, porque o `FateConnectDbContext` o declara com `HasPostgresExtension`. Sem Docker a suíte falha inteira, com mensagem própria.

Saiu `Microsoft.EntityFrameworkCore.InMemory`, entrou `Testcontainers.PostgreSql`. No `Program.cs` saiu a guarda `if (database.IsRelational())`, que só existia porque provedor em memória não tem migration — em produção ela já era sempre verdadeira, então nada muda para quem usa.

**Os testes.** Três métodos, cinco casos: filtro por destino que inclui e exclui; uma `[Theory]` de acento com três casos; e a consulta com todos os filtros de uma vez, caminho que nenhum outro teste alcançava.

**O rename.** `RidePaginationTests` já guardava testes de filtro (`FilteredByDepartureTime`, `FilteredByRideType`), e este PR ia acrescentar destino a um arquivo chamado "Pagination". Virou `RideListingTests`. Nada no repositório citava o nome antigo.

**A documentação.** O comentário do `check-api.yml` que dizia não haver Postgres a provisionar saiu. O `CONTRIBUTING.md` ganhou o pré-requisito de Docker, que não estava escrito em lugar nenhum e agora vale para `dotnet test` e, por tabela, para o `git push`.

A issue pedia só a `dotnet-testing.md`, mas este PR também tornou falsas uma linha da `dotnet-migrations.md` — *"os testes rodam em InMemory, que não executa DDL"* — e uma da `dotnet-code-style.md` — *"o gate não protege isto"*. As duas foram corrigidas aqui porque foi este PR que as envelheceu.

Entrou também a rule **`prove-the-mechanism.md`**, sem `paths:` — a única deste PR que não fala de PostgreSQL. Ela nasceu do próprio processo daqui: eu fechei a entrega listando um risco em aberto (*"5 corridas verdes, é evidência, não prova"*) em vez de ir atrás do mecanismo, que levou três minutos e provou impossibilidade. A rule registra que evidência estatística é gatilho de investigar, não conclusão para relatar, e que o zero de uma sonda só vale com controle positivo — as duas coisas que esta rodada custou. Junto, uma correção de uma linha no `README.md`: a tabela dizia que rule carrega "pelo `paths:`", omitindo que rule sem `paths:` carrega sempre — que é o caso desta.

Sem entrada de CHANGELOG: refactor sem efeito externo.

## Issue

- #237

Closes #237

## Evidências

**Três mutações, cada uma com o build conferido em 0 antes de rodar a suíte:**

| Mutação | O que cai | No InMemory |
| --- | --- | --- |
| `Expression<Func<Ride, bool>>` vira método `bool` | **20 testes** | passava verde |
| `Unaccent` sai da coluna | 2 casos da `[Theory]` | passava verde |
| `Unaccent` sai do padrão de busca | 2 casos, e **não os mesmos** | passava verde |

As duas últimas derrubam casos diferentes justamente porque um `[InlineData]` tem acento na coluna e busca sem, e o outro o inverso — é o que mostra que cada caso está provando um lado.

**Falha sem Docker**, verificada parando o Docker Desktop de verdade:

```
System.InvalidOperationException : The API suite runs against a real PostgreSQL, started as a
container, and Docker did not answer. Start Docker and run dotnet test again.
---- DockerUnavailableException : Docker is either not running or misconfigured...
```

Duas coisas que só apareceram por medir: a primeira versão da guarda **não funcionava** — a `DockerUnavailableException` nasce no `Build()`, não no `StartAsync()` que o `try` envolvia. E `DOCKER_HOST` apontando para porta morta **não serve** de teste: o Testcontainers cai para o socket do Docker Desktop e a suíte passa igual.

**Concorrência.** São 24 fábricas criando banco ao mesmo tempo. A falha clássica disso — `source database "template1" is being accessed by other users` — exige sessão aberta no template. Medindo `pg_stat_activity` durante uma corrida real:

| Banco | Conexões |
| --- | --- |
| `postgres` (conexão administrativa do Npgsql) | pico 8 |
| `fateconnect-tests-<guid>` | uma por fábrica |
| `template1` | **zero** |

Pico de **25 conexões contra o teto de 100**. Numa sonda à parte, **120 `CREATE DATABASE` concorrentes** não produziram uma falha — e esse zero só vale porque o **controle positivo dispara**: forçando o mesmo erro de propósito, com uma sessão aberta e `CREATE DATABASE ... TEMPLATE` copiando dela, ele aparece.

**Versão do Docker: nenhuma pinada.** O Testcontainers não declara mínimo (*"requires a Docker-API compatible container runtime"*), nada no código fixa versão de API, o runner do CI roda 28.0.4 e a máquina local 29.5.3. O que está pinado é a imagem — `postgres:17`, casando com o `/etc/postgresql/17/main/` da VPS.

**Gates:** build com 0 erros e 0 warnings; **86 testes** (eram 81) em ~6s contra ~1s do provedor em memória; `coverage-changed.sh` com `Program.cs` em **97,7%**; cada commit compila e passa sozinho, verificado em worktree isolada — o primeiro fecha com 81.
