### PR TITLE
docs: record the instrument that only reaches half the problem

### DIFF
--- a/.claude/rules/prove-the-mechanism.md
+++ b/.claude/rules/prove-the-mechanism.md
@@ -25,6 +25,22 @@ Duas na mesma #237: `DOCKER_HOST` apontando para porta morta não desligou o Doc
 
 ⚠️ **Desligar por variável de ambiente não é desligar.** Ferramenta com descoberta automática de endpoint — Docker, proxy, DNS, resolvedor de pacote — trata a variável como preferência, não como ordem. Para medir a ausência, tire o recurso do ar.
 
+## O instrumento que alcança metade
+
+⛔ **Sonda, regra e correção nascem cobrindo uma forma, e a resposta está na outra.** Não basta que o instrumento funcione: ele precisa alcançar **onde o problema mora**. Três vezes na #242, cada uma de um jeito:
+
+| O instrumento | O que ele alcançava | Onde a resposta estava |
+| --- | --- | --- |
+| `grep ... \| head` procurando quem mexia no scroll | as 10 primeiras linhas | na 11ª — e eu **descartei a hipótese certa** por causa disso |
+| a regra `no-restricted-syntax` de tag crua | chamadas de `styled('nav')` | no JSX: três `<li>` passaram no código novo |
+| a correção da fileira de paginação | a ponta inicial, onde a página 4 quebrava | na ponta final, onde a 9 quebrava igual |
+
+⚠️ **`| head` num `grep` de investigação é o pior dos três**, porque some com a evidência sem avisar e a saída parece completa. Em busca que vai sustentar conclusão, conte antes (`grep -c`) ou não trunque.
+
+⛔ **Regra nova se prova nas duas formas.** O controle positivo de uma regra de lint não é só "reprova o que deve" — é também "aceita o que deve". Ao estender a de tag crua, rodei um arquivo com `<div>` **e** `<strong>` no mesmo JSX: o primeiro reprova, o segundo passa. Sem a segunda metade eu teria proibido ênfase de texto sem perceber.
+
+⛔ **Correção com duas pontas se confere nas duas, enumerando.** Consertei a página 4 e entreguei; a 9 tinha o defeito espelhado e quem viu foi o Victor. O que resolveu foi listar **todos** os estados de 1 a 12 numa tabela e olhar a coluna inteira — as duas faixas usavam medidas diferentes, e isso só aparece lado a lado.
+
 ## O que esta rule não é
 
 Não é ordem de esgotar toda dúvida antes de abrir a boca. Ela vale no **fechamento** — ao dizer "pronto", abrir PR ou pedir confirmação. No meio do trabalho, resíduo em aberto é normal, e dizer que está em aberto é o certo.

--- a/.claude/rules/reuse-before-creating.md
+++ b/.claude/rules/reuse-before-creating.md
@@ -24,6 +24,21 @@ A API já respondia isso com um `401`.
 
 **O sinal de risco é a cadeia de suporte:** quando a peça B só existe para a peça A funcionar, e a C só para a B, pare e procure a fonte que dispensa as três. Deduzir também erra sozinho; perguntar, não.
 
+## Antes de substituir o que a biblioteca faz, ponha o caminho barato na mesa
+
+⛔ **Reescrever o comportamento de um componente de terceiro é decisão de quem revisa, não sua** — mesmo quando a reescrita é pequena e você já a mediu. Traga as alternativas com o **custo de cada uma**, e espere.
+
+⛔ Aconteceu na #242. O controle de páginas do MUI quebrava em duas fileiras no celular, e eu passei direto a computar a janela de páginas por conta própria. Funcionou e estava medido — mas o Victor perguntou *"pq a abordagem foi reescrever completamente o componente do MUI?"*, e a pergunta era justa: existia um caminho sem código nenhum, encolher o item, que eu não tinha mencionado.
+
+O que fechou a conversa foi a tabela que eu devia ter apresentado antes:
+
+| Caminho | Custo |
+| --- | --- |
+| computar a janela | 15 linhas nossas para manter |
+| encolher o item de 44px para 38px | zero código, mas alvo de toque abaixo do mínimo de acessibilidade |
+
+**O sinal de risco é você já ter medido que a biblioteca não resolve.** É exatamente aí que a reescrita parece inevitável — e é aí que o caminho barato precisa ser dito em voz alta, com o custo, para o outro lado escolher.
+
 ## Encontrou duplicação: propor e perguntar
 
 Vale também para duplicação **fora da tarefa**. Se eu vi, eu proponho na hora, sem esperar ser cobrado — a sugestão é obrigação, não favor. Trazer três coisas: o que está repetido, o que fica no lugar dos dois, e **onde** passa a morar. E **esperar o sim**.

--- a/.claude/rules/web-design-system.md
+++ b/.claude/rules/web-design-system.md
@@ -33,6 +33,7 @@ paths:
 - ⛔ **O diálogo não tem botão de fechar, e isso é decisão de produto.** `Esc` e clique fora já dispensam, inclusive em toque. Não adicionar um X achando que é melhoria de acessibilidade.
 - ⛔ **Título sempre centralizado**, em qualquer largura.
 - **Conteúdo com um consumidor só não é design system.** Antes de criar componente aqui, conte os consumidores: um só ⇒ ele mora na pasta da tela que o usa. Slot ou token sem consumidor real é o mesmo cheiro.
+- **E a conta se refaz quando alguém sai.** Componente do barrel que fica com um consumidor único **dentro do próprio design system** desce para dentro dele, em `components/`, e sai do barrel — foi o caso do `ListCardSkeleton` quando o `CardsList` passou a ser o único a usá-lo. Exportar o que só um vizinho consome convida a aplicação a montar à mão o que o vizinho já monta.
 
 ## Tokens — proibições
 

--- a/.claude/rules/web-react-patterns.md
+++ b/.claude/rules/web-react-patterns.md
@@ -27,6 +27,10 @@ O arquivo principal da pasta é `index`, então `import { X } from '../../consta
 
 Vale para pasta de componente e de tela. Pastas que **já são** dedicadas por natureza (`src/hooks/`, `src/services/`, `src/utils/`, `design-system/tokens/`) não se aplicam: elas são o destino, não a origem.
 
+⛔ **Arquivo de hook guarda o hook, e nada mais.** Função pura que o hook usa — e que outros também usariam — vai para `src/utils/`, não para o topo do arquivo do hook. Aconteceu na #242: `usePagedSearch.ts` nasceu com os leitores de parâmetro de URL dentro, e o resultado foi um util de **teste** importando de `@app/hooks/` para pegar uma constante. Correção do Victor: *"não faz sentido nenhum elas estarem definidas dentro de um hook, separe os escopos"*.
+
+**O sinal é quem importa de lá.** Se algo que não é componente nem hook precisa importar do arquivo de um hook, o que ele quer não pertence àquele arquivo.
+
 ## Um componente por arquivo
 
 ⛔ **Nunca dois componentes no mesmo arquivo.** Cada componente tem a sua pasta e o seu `index` — inclusive o subcomponente pequeno, usado uma vez só.
@@ -62,6 +66,7 @@ Vale para `useQuery` e `useMutation`. Um teste que conte `getAllByRole('alert')`
 
 - Nome com prefixo `handle`: `handleSubmit`, `handleSectionClick`.
 - **Sem função anônima em callback JSX.** `onClick={() => doThing(id)}` cria função nova a cada render e quebra memoização; extrair um `handle…` com `useCallback` quando o valor vier de fora.
+- **Parâmetro que recebe função se chama pelo que é.** `list` num objeto de entrada se lê como a lista; quem recebe a função que busca a lista é `listFunction`. Cobrado na #242: o nome curto economiza uma palavra e custa uma leitura errada em cada call site.
 
 ## Efeitos
 


### PR DESCRIPTION
## Objetivo

Registrar o que a rodada da #242 ensinou. O fio comum das quatro anotações é o mesmo: **o instrumento existia e funcionava, mas não alcançava onde o problema estava** — e nas três vezes quem viu foi quem revisou, não quem escreveu.

## Alterações

**`prove-the-mechanism.md` — seção nova, "O instrumento que alcança metade".** Três formas do mesmo defeito, numa tabela: um `grep` truncado por `| head` que escondeu a linha da resposta e me fez descartar a hipótese certa; uma regra de lint que cobria `styled('nav')` e não alcançava o JSX, deixando passar três `<li>` crus; e uma correção que consertou uma ponta da paginação e deixou a outra com o defeito espelhado. Junto, duas instruções que saíram disso: regra nova se prova nas **duas** direções — o que ela deve reprovar e o que ela deve aceitar —, e correção com duas pontas se confere enumerando os estados lado a lado.

**`reuse-before-creating.md` — "Antes de substituir o que a biblioteca faz, ponha o caminho barato na mesa".** Reescrever comportamento de componente de terceiro é decisão de quem revisa. O sinal de risco é justamente já ter medido que a biblioteca não resolve: é aí que a reescrita parece inevitável e o caminho barato deixa de ser dito.

**`web-react-patterns.md` — duas linhas.** Arquivo de hook guarda o hook: função pura que ele usa vai para `src/utils/`. O sinal de que o escopo vazou é alguém que não é componente nem hook precisar importar do arquivo de um hook. E parâmetro que recebe função se chama pelo que é — `listFunction`, não `list`.

**`web-design-system.md` — uma linha.** A conta de consumidores se refaz quando alguém sai: componente do barrel que fica com um consumidor único **dentro do próprio design system** desce para dentro dele e sai do barrel.

## Varredura de fechamento

A `harness-evolution` manda cruzar todas as correções da rodada antes de abrir PR que toca `.claude/`, não só as que motivaram este. Estado de cada uma:

| Correção | Estado |
| --- | --- |
| `| head` truncando a evidência | **coberta** aqui |
| regra de lint que não alcança JSX | **coberta** aqui |
| "corrigiu um lado e esqueceu do outro" | **coberta** aqui |
| "pq reescrever o componente do MUI?" | **coberta** aqui |
| helpers definidos dentro de um hook | **coberta** aqui |
| `list` → `listFunction` | **coberta** aqui |
| `ListCardSkeleton` para dentro do `CardsList` | **coberta** aqui |
| "desligar por variável de ambiente não é desligar" | **já escrita** — entrou na rodada anterior, no #243 |
| risco residual entregue como resultado | **já escrita** — `prove-the-mechanism.md`, #243 |
| invocar a skill não é seguir a skill | **fora daqui, de propósito** — é disciplina de processo minha, sem área de código; foi para a memória do projeto |

## Issue

Mudança de harness dispensa issue — mas não dispensa PR.

## Evidências

`./scripts/check-harness-paths.sh` sem caminho órfão. As quatro rules seguem curtas: 46, 46, 65 e 159 linhas.
