### PR TITLE
fix(260): paint the button loading indicator in the label color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Corrige a data que a busca recebia enquanto ainda se digitava: com o ano pela metade, `25/12/20` valia como o ano 20 e era enviada assim (#274) [Frontend]
+- Corrige o indicador de carregamento dos botões, que girava num cinza escuro em vez da cor do texto do próprio botão — sobre o botão preenchido ele mal se distinguia do fundo (#275) [Frontend]
 
 ## [0.7.0] - 2026-08-31
 

--- a/FateConnect/Web/design-system/theme/components.ts
+++ b/FateConnect/Web/design-system/theme/components.ts
@@ -51,6 +51,18 @@ export const components: Components<Theme> = {
 
         return { ...veil, '&:hover': { backgroundColor: theme.palette[ownerState.color].main } };
       },
+      // Herdar do botão não pinta o indicador: no carregamento centrado o MUI
+      // deixa o rótulo `transparent`, então a cor do texto é nomeada de novo aqui.
+      loadingIndicator: ({ theme, ownerState }) => {
+        const { color, variant } = ownerState;
+
+        if (variant === 'soft') return { color: theme.palette.text.primary };
+        // `color="inherit"` recebe a cor de quem envolve o botão, que este slot não lê.
+        if (!color || color === 'inherit') return {};
+        if (variant === 'contained') return { color: theme.palette[color].contrastText };
+
+        return { color: theme.palette[color].main };
+      },
     },
     variants: [
       {


### PR DESCRIPTION
## Objetivo

O botão em carregamento desenhava o indicador num cinza escuro, que não é a cor do texto dele. Em botão preenchido isso derruba o contraste justamente no momento em que a pessoa está esperando uma resposta.

## O mecanismo

A cor não vinha de um token nosso: é o padrão da biblioteca, que pinta o indicador com a cor de **elemento desabilitado**. Medido antes da correção, o indicador computava `rgba(0, 0, 0, 0.26)` sobre o vermelho do botão.

⚠️ E `inherit` **não** resolveria: no estado de carregamento a própria biblioteca deixa o rótulo `transparent` — é assim que o texto some para dar lugar ao indicador. Herdar daria indicador invisível. Por isso a cor do texto é nomeada de novo, a partir da paleta.

## Alterações

Um slot novo nos overrides do tema, sem tocar em nenhum ponto de uso. Ele reproduz o mesmo mapeamento que o rótulo do botão já usa: cor de contraste no preenchido, cor principal no contornado e no de texto, e a cor de texto do produto na variante nossa.

**Uma lacuna consciente:** botão com `color="inherit"` segue com o cinza. A cor dele vem de quem o envolve, e o slot não tem como lê-la — qualquer valor ali seria chute, e erraria justamente nos dois usos vivos, que ficam sobre o cromo. Nenhum botão `inherit` carrega hoje.

## Issue

- #260

Closes #260

## Evidências

Medido com a aplicação de pé, no botão de entrar da landing, com o login atrasado de propósito para abrir a janela de carregamento:

| Tema | Indicador | Texto do botão | Fundo |
| --- | --- | --- | --- |
| Claro | `rgb(255, 255, 255)` | `rgba(0, 0, 0, 0)` | `rgb(207, 46, 46)` |
| Escuro | `rgb(255, 255, 255)` | `rgba(0, 0, 0, 0)` | `rgb(207, 46, 46)` |

O texto em `rgba(0, 0, 0, 0)` é a confirmação do mecanismo descrito acima. Antes da correção, o mesmo indicador computava `rgba(0, 0, 0, 0.26)`.

Gates: ESLint 0 erros, `tsc` limpo, 502 testes, cobertura 98,52 / 93,35 / 98,15 / 99,37.


<img width="1285" height="952" alt="image" src="https://github.com/user-attachments/assets/77499d2f-5b0d-40ef-b88e-5a0494995400" />
<img width="1285" height="952" alt="image" src="https://github.com/user-attachments/assets/d5dabe65-18f7-49f6-8b5a-46366d920297" />
