### PR TITLE
fix(262): draw the card action icons at the design system size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Corrige a data que a busca recebia enquanto ainda se digitava: com o ano pela metade, `25/12/20` valia como o ano 20 e era enviada assim (#274) [Frontend]
 - Corrige o indicador de carregamento dos botões, que girava num cinza escuro em vez da cor do texto do próprio botão — sobre o botão preenchido ele mal se distinguia do fundo (#275) [Frontend]
+- Aumenta os ícones de ação dos cartões das duas listas, pequenos demais ao lado da etiqueta de situação (#276) [Frontend]
 
 ## [0.7.0] - 2026-08-31
 

--- a/FateConnect/Web/design-system/components/ListCard/ListCard.test.tsx
+++ b/FateConnect/Web/design-system/components/ListCard/ListCard.test.tsx
@@ -1,4 +1,8 @@
 import { render, screen } from '@app/test/testing-library';
+import { IconButton } from '@ds-root/components/IconButton';
+import { StatusTag } from '@ds-root/components/StatusTag';
+import { EditIcon } from '@ds-root/icons';
+import { iconSizeTokens } from '@ds-root/tokens';
 
 import { ListCard, type ListCardProps } from '.';
 
@@ -7,6 +11,22 @@ const OWN_LABEL = 'Meu item';
 const MEDIA_TEXT = 'foto';
 const FIRST_INFO = 'Biblioteca';
 const SECOND_INFO = '11/08/2026';
+const STATUS_LABEL = 'Aberto';
+const ACTION_LABEL = 'Editar';
+const TOUCH_TARGET = '32px';
+
+/** Os recuos são declarados em `rem`; o alvo de toque e o glifo, em `px`. */
+const REM_IN_PX = 16;
+
+function toNumber(value: string): number {
+  return Number.parseFloat(value);
+}
+
+function styleOf(candidate: Element | null, what: string): CSSStyleDeclaration {
+  if (!candidate) throw new Error(`Não renderizou ${what}.`);
+
+  return getComputedStyle(candidate);
+}
 
 const DEFAULT_PROPS: ListCardProps = { children: TITLE };
 
@@ -48,6 +68,36 @@ describe('ListCard', () => {
     });
 
     expect(screen.getByRole('article')).toHaveTextContent(`${FIRST_INFO}${SECOND_INFO}`);
+  });
+
+  it('should draw the action icon at the design system size, inside the touch target', () => {
+    renderComponent({
+      children: (
+        <ListCard.Header>
+          <ListCard.Actions>
+            <StatusTag>{STATUS_LABEL}</StatusTag>
+
+            <ListCard.ActionButtons>
+              <IconButton type="button" label={ACTION_LABEL}>
+                <EditIcon />
+              </IconButton>
+            </ListCard.ActionButtons>
+          </ListCard.Actions>
+        </ListCard.Header>
+      ),
+    });
+
+    const button = screen.getByRole('button', { name: ACTION_LABEL });
+    const buttonStyle = getComputedStyle(button);
+    const icon = styleOf(button.querySelector('svg'), 'o ícone da ação');
+
+    const verticalPadding =
+      (toNumber(buttonStyle.paddingTop) + toNumber(buttonStyle.paddingBottom)) * REM_IN_PX;
+
+    expect(icon.fontSize).toBe(`${iconSizeTokens.md}px`);
+    expect(buttonStyle.height).toBe(TOUCH_TARGET);
+    // O glifo mais os dois recuos ocupam o botão inteiro: cresce mais e ele encosta.
+    expect(iconSizeTokens.md + verticalPadding).toBe(toNumber(TOUCH_TARGET));
   });
 
   it('should keep the own flag out of the markup', () => {

--- a/FateConnect/Web/design-system/components/ListCard/styles.ts
+++ b/FateConnect/Web/design-system/components/ListCard/styles.ts
@@ -11,9 +11,8 @@ const { xxs, sm, md } = spacingScale;
 
 const OWN_STRIPE_PX = 4;
 const HAIRLINE = '1px';
+/** Alvo de toque no mínimo aceitável: o glifo cresce dentro dele, ele não encolhe. */
 const ACTION_BUTTON_SIZE_PX = 32;
-/** O glifo da biblioteca de origem ocupa 70% do botão. */
-const ACTION_ICON_SCALE = 0.7;
 
 const STYLE_ONLY_PROPS: ReadonlySet<string> = new Set(['own', 'hasMedia']);
 
@@ -85,9 +84,10 @@ export const ActionButtons = styled(Stack)(({ theme }) => ({
     padding: theme.space(xxs),
     color: theme.palette.text.primary,
   },
+  // O glifo do MUI mede `1em`, então o token vai no `font-size`. Com 24px ele
+  // ocupa o botão inteiro menos o recuo, sem encostar na borda.
   '& .MuiIconButton-root svg': {
-    transform: `scale(${ACTION_ICON_SCALE})`,
-    transformOrigin: 'center',
+    fontSize: `${iconSizeTokens.md}px`,
   },
 }));
 


### PR DESCRIPTION
## Objetivo

Os ícones de ação do cartão eram pequenos demais ao lado da etiqueta de situação, e a fileira do topo do cartão lia como desalinhada. Vale para as duas listas, que usam o mesmo cartão.

## O tamanho, medido na tela

| | Antes | Agora |
| --- | --- | --- |
| Glifo desenhado | **16,8px** | **24px** |
| Como | 24px reduzidos por transformação a 70% | `font-size` no token `md` do design system, sem transformação |
| Recuo do botão | 4px | 4px |
| Botão (alvo de toque) | 32px | 32px |

Os 24px do glifo mais os dois recuos de 4px fecham exatamente os 32px do botão. **O alvo de toque não mudou.**

## Um caminho que foi descartado no review

A primeira versão mirava a **altura da etiqueta**, 27,6px, que é o que a issue pedia ao pé da letra. Na tela ficou grande demais: o glifo ocupava 27,6 dos 32px do botão, sobrando 2,2px de cada lado, e lia como se o ícone encostasse na borda.

O que a issue chamava de "altura da etiqueta" inclui os 4px de recuo de cima e de baixo dela — recuo que ninguém enxerga, porque o fundo da etiqueta é claro. O que o olho compara é o texto dentro dela, que mede 19,6px. Os 24px do token da casa ficam entre os dois e vieram da sua escolha, vendo os três números.

Por isso a etiqueta **não** publica mais a própria altura: sem ninguém consumindo, aquele acoplamento seria código morto.

## Issue

- #262

Closes #262

## Evidências

Medido com a aplicação de pé, a 412px, na lista de caronas, nos dois estados — o "antes" na `develop` e o "agora" nesta branch.

| | Glifo | Botão | Etiqueta |
| --- | --- | --- | --- |
| `develop` | 16,8px | 32px | 27,6px |
| esta branch | **24px** | 32px | 27,6px |

Gates: ESLint 0 erros, `tsc` limpo, **505 testes**.

O teste afirma o contrato novo: o glifo é o token `md`, o botão mede 32px, e o glifo mais os dois recuos fecham o botão inteiro — o que reprova se alguém crescer o ícone e ele passar a encostar na borda.

<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/1208e5e4-e06e-46b3-b8cc-9858530314b5" />
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/938b2c15-bb15-4aca-aefe-ce6e7a57a808" />
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/5efa1db4-0e02-46d8-be79-198908a29bf8" />
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/38c17431-f19d-497c-8819-e08693a44988" />

