### PR TITLE
feat(263): bring back the dialog close button below the mobile breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Adiciona o botão de fechar nos diálogos quando a tela é estreita: a faixa em volta deles é curta demais para fechar por toque, e alargá-la deixaria o diálogo apertado. No desktop nada muda (#277) [Frontend]
+
 ### Changed
 
 - Passa a pedir a data por digitação, com o calendário atrás de um botão, na busca de caronas, no mural de achados e perdidos e nos dois formulários; o campo ganha a mesma borda e o mesmo espaçamento dos campos ao lado, dos quais destoava (#274) [Frontend]

--- a/FateConnect/Web/design-system/components/Dialog/Dialog.test.tsx
+++ b/FateConnect/Web/design-system/components/Dialog/Dialog.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, userEvent } from '@app/test/testing-library';
 
+import { CLOSE_LABEL } from './constants';
 import { Dialog, type DialogProps } from '.';
 
 const DEFAULT_PROPS: DialogProps = {
@@ -11,6 +12,9 @@ const DEFAULT_PROPS: DialogProps = {
 
 const renderComponent = (props = DEFAULT_PROPS) => render(<Dialog {...props} />);
 
+// O botão de fechar só aparece abaixo do breakpoint mobile, por CSS. O jsdom não
+// avalia media query, então ele fica com `display: none` e precisa ser buscado
+// com `hidden`.
 describe('Dialog', () => {
   it('should name itself by the title it was given', () => {
     renderComponent();
@@ -40,8 +44,22 @@ describe('Dialog', () => {
     const onClose = vi.fn();
     renderComponent({ ...DEFAULT_PROPS, onClose });
 
-    // Não há botão de fechar: o diálogo sai por tecla ou por clique fora dele.
     await userEvent.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('should keep the close button out of the desktop', () => {
+    renderComponent();
+
+    expect(screen.queryByRole('button', { name: CLOSE_LABEL })).not.toBeInTheDocument();
+  });
+
+  it('should close when the user activates the close button', async () => {
+    const onClose = vi.fn();
+    renderComponent({ ...DEFAULT_PROPS, onClose });
+
+    await userEvent.click(screen.getByRole('button', { name: CLOSE_LABEL, hidden: true }));
 
     expect(onClose).toHaveBeenCalledOnce();
   });

--- a/FateConnect/Web/design-system/components/Dialog/constants/index.ts
+++ b/FateConnect/Web/design-system/components/Dialog/constants/index.ts
@@ -1,0 +1,1 @@
+export const CLOSE_LABEL = 'Fechar';

--- a/FateConnect/Web/design-system/components/Dialog/index.tsx
+++ b/FateConnect/Web/design-system/components/Dialog/index.tsx
@@ -1,6 +1,10 @@
 import { useId, type ReactNode } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
 import MuiDialog from '@mui/material/Dialog';
 
+import { IconButton } from '@ds-root/components/IconButton';
+
+import { CLOSE_LABEL } from './constants';
 import { DialogBody } from './DialogBody';
 import { DialogFooter } from './DialogFooter';
 import * as S from './styles';
@@ -30,9 +34,17 @@ function Dialog({ open, onClose, title, children }: DialogProps) {
     // não sobrescrevemos; `maxWidth="md"` aqui significaria 933px.
     <MuiDialog open={open} onClose={onClose} aria-labelledby={titleId} fullWidth maxWidth="sm">
       <S.DialogSurface>
-        <S.DialogTitleText variant="h2" id={titleId}>
-          {title}
-        </S.DialogTitleText>
+        <S.TitleRow>
+          <S.DialogTitleText variant="h2" id={titleId}>
+            {title}
+          </S.DialogTitleText>
+
+          <S.CloseButtonSlot>
+            <IconButton label={CLOSE_LABEL} onClick={onClose}>
+              <CloseIcon />
+            </IconButton>
+          </S.CloseButtonSlot>
+        </S.TitleRow>
 
         {children}
       </S.DialogSurface>

--- a/FateConnect/Web/design-system/components/Dialog/styles.ts
+++ b/FateConnect/Web/design-system/components/Dialog/styles.ts
@@ -4,7 +4,13 @@ import Typography from '@mui/material/Typography';
 import { styled } from '@ds-root/styled';
 import { spacingScale } from '@ds-root/tokens';
 
-const { lg, xl } = spacingScale;
+const { sm, lg, xl } = spacingScale;
+
+/**
+ * Recuo do botão mais a margem interna da arte do ícone. Sem descontar os dois,
+ * o desenho do X fica 13px aquém da borda dos campos, e o olho acusa.
+ */
+const CLOSE_GLYPH_OFFSET_PX = 13;
 
 export const DialogSurface = styled(Stack)(({ theme }) => ({
   flexDirection: 'column',
@@ -16,6 +22,30 @@ export const DialogSurface = styled(Stack)(({ theme }) => ({
   overflow: 'hidden',
 }));
 
-export const DialogTitleText = styled(Typography)({
+/** Título e o fechar dividem a linha; o título ocupa o resto dela. */
+export const TitleRow = styled(Stack)(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: theme.space(sm),
+}));
+
+/**
+ * Só existe abaixo do breakpoint mobile, onde a faixa clicável em volta do
+ * diálogo é alvo pequeno demais para o toque. O `display: none` da base é o que
+ * o mantém fora do desktop, que segue sem botão de fechar.
+ */
+export const CloseButtonSlot = styled(Stack)(({ theme }) => ({
+  display: 'none',
+  // Puxa o botão para fora da linha para o **desenho** do X cair na borda dos
+  // campos: é a caixa dele que encosta primeiro.
+  marginRight: `-${CLOSE_GLYPH_OFFSET_PX}px`,
+
+  [theme.breakpoints.down('md')]: { display: 'flex' },
+}));
+
+export const DialogTitleText = styled(Typography)(({ theme }) => ({
+  flex: 1,
   textAlign: 'center',
-});
+
+  [theme.breakpoints.down('md')]: { textAlign: 'left' },
+}));


### PR DESCRIPTION
## Objetivo

No celular, fechar um diálogo tocando fora dele é difícil: sobra pouca faixa entre o diálogo e a borda da tela. Alargar essa faixa deixaria o diálogo estreito demais, então a saída é devolver o botão de fechar — **só no estreito**.

Medido: a 409px o diálogo ocupa 345px, restando **32px de faixa clicável de cada lado**.

## A decisão que isto revisa

O diálogo da aplicação foi desenhado de propósito **sem** botão de fechar, e a regra do design system dizia isso sem ressalva. A revisão vale para o estreito e só para ele — no desktop a faixa em volta é larga e o toque não é o gesto. A regra foi ajustada em PR próprio, antes deste, para não reprovar o que aqui se implementa.

## Alterações

O botão existe apenas abaixo do breakpoint de mobile, por CSS — a aplicação inteira decide responsividade assim, e o cabeçalho já resolve exatamente esta forma. Ele é absoluto no canto superior direito, no mesmo recuo que a superfície do diálogo usa em todos os lados.

**O título continua centralizado de fato:** ele reserva a largura do botão **dos dois lados**. Só à direita, ele sairia do centro.

O diálogo é um só, então a mudança alcança de uma vez o formulário de carona, o de item, o contato e as confirmações.

## Issue

- #263

Closes #263

## Evidências

Medido com a aplicação de pé:

| | 409px | 1440px |
| --- | --- | --- |
| Botão de fechar | presente, `display: flex` | **`display: none`** |
| Distância do topo / da direita | 32px / 32px | — |
| Reserva do título | 48px de cada lado | 0 |

O botão mede 40px e cabe nos 48px reservados, com 8px de folga.

Gates: ESLint 0 erros, `tsc` limpo, 504 testes, cobertura 98,52 / 93,25 / 98,15 / 99,36.

O teste do desktop tem controle positivo: tirando o `display: none` da base, ele reprova acusando o botão encontrado — ou seja, ele mede o que afirma.

<img width="1285" height="952" alt="image" src="https://github.com/user-attachments/assets/c5ba0f75-3637-40ff-b470-19383dd7fc2e" />
<img width="1285" height="952" alt="image" src="https://github.com/user-attachments/assets/c7478800-6660-4097-8450-49b6dbb1c5cf" />

