### PR TITLE
fix(251): fit the long institutional email in the landing login card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige a data que a busca recebia enquanto ainda se digitava: com o ano pela metade, `25/12/20` valia como o ano 20 e era enviada assim (#274) [Frontend]
 - Corrige o indicador de carregamento dos botões, que girava num cinza escuro em vez da cor do texto do próprio botão — sobre o botão preenchido ele mal se distinguia do fundo (#275) [Frontend]
 - Aumenta os ícones de ação dos cartões das duas listas, pequenos demais ao lado da etiqueta de situação (#276) [Frontend]
+- Corrige o cartão de entrar da página inicial, que era estreito demais para o e-mail institucional completo e o cortava dentro do campo — e é o único formato de e-mail que a tela aceita (#278) [Frontend]
 
 ## [0.7.0] - 2026-08-31
 

--- a/FateConnect/Web/src/pages/Home/components/LandingLoginCard/styles.ts
+++ b/FateConnect/Web/src/pages/Home/components/LandingLoginCard/styles.ts
@@ -17,17 +17,13 @@ export const CardRoot = styled(PolymorphicStack)(({ theme }) => ({
   flexDirection: 'column',
   gap: theme.space(md),
   padding: theme.space(lg),
-  // Largura desejada, não imposta: a base é a largura do cartão e ele encolhe
-  // quando a linha aperta, para a landing caber já a partir do desktop estreito.
-  flex: `0 1 ${CARD_WIDTH_PX}px`,
+  // Largura de verdade, e não `flex-basis`: a âncora entre o cartão e a faixa se
+  // mede pelo conteúdo, e a base de 360px chegava ao cartão como 300px.
+  width: `${CARD_WIDTH_PX}px`,
+  maxWidth: '100%',
   background: theme.palette.background.paper,
   borderRadius: theme.radius(radiusScale.component),
   boxShadow: shadowTokens.component,
-
-  [theme.breakpoints.down('md')]: {
-    justifySelf: 'center',
-    maxWidth: '24rem',
-  },
 }));
 
 export const CardTitle = styled(Box)(({ theme }) => ({

--- a/FateConnect/Web/src/pages/Home/styles.ts
+++ b/FateConnect/Web/src/pages/Home/styles.ts
@@ -23,7 +23,12 @@ export const DescriptionContainer = styled(PolymorphicStack)(({ theme }) => ({
 export const LoginAnchor = styled(Stack)(({ theme }) => ({
   flexDirection: 'row',
 
-  [theme.breakpoints.down('md')]: { justifyContent: 'center' },
+  [theme.breakpoints.down('md')]: {
+    // A âncora toma a faixa inteira para o `max-width` do cartão ter contra o
+    // que medir; sem isso ele mantém os 360px e come as goteiras no celular.
+    alignSelf: 'stretch',
+    justifyContent: 'center',
+  },
 }));
 
 export const ServicesContainer = styled(PolymorphicStack)(({ theme }) => ({


### PR DESCRIPTION
## Objetivo

O cartão de entrar da página inicial não comportava um e-mail institucional completo — o texto era cortado dentro do campo. Não é caso extremo: esse é o **único** formato que o login aceita.

## A premissa da issue estava errada, e a medição derrubou

A issue apontava duas alavancas: o recuo do contêiner e o vão entre o texto e o cartão. **As duas são inertes.** Medido no app, a 1440px, o cartão media 300,5px com qualquer valor:

| Alavanca | Largura do cartão |
| --- | --- |
| como estava | 300,5 |
| recuo reduzido pela metade | 300,5 |
| recuo quase zerado | 300,5 |
| recuo quase zerado **e** vão reduzido | 300,5 |

E media 300,5px em **todos** os viewports — 1440, 1200, 933, 409, 375.

A causa: o cartão declarava a largura desejada como base de flex, mas entre ele e a faixa existe um contêiner que se mede pelo **conteúdo**. A base de 360px nunca chegava; o cartão encolhia até a largura intrínseca do campo, e o recuo só alimentava a coluna de texto.

## Alterações

A largura do cartão passa a ser largura de verdade, com teto de 100% para ele não estourar a tela no estreito, e o contêiner da âncora passa a ocupar a faixa inteira no mobile — é o que dá ao teto algo contra o que medir.

Saiu também um bloco de mobile cujo teto de 384px sobrescreveria o novo, mantendo 360px num celular de 360px e comendo as duas goteiras.

**Nenhuma linha de recuo, margem ou vão no diff** — a escala de espaçamento fica intacta.

## Issue

- #251

Closes #251

## Evidências

Medido com `victor.brayner@aluno.cps.sp.gov.br` preenchido, no app de pé:

| Viewport | Cartão | Campo | E-mail inteiro |
| --- | --- | --- | --- |
| 1440 | 300,5 → **360** | 252,5 → **312** | não → **sim** |
| 409 | 300,5 → **360** | 252,5 → **312** | não → **sim** |
| 375 | 300,5 → **327** | 252,5 → **279** | não → **sim** |

"Inteiro" significa `scrollWidth === clientWidth` no campo. O controle positivo é a mesma sonda acusando o corte antes da correção.

**Um efeito colateral medido, para você decidir se incomoda:** os 59,5px que o cartão ganha saem da coluna de texto, mas só entre 933 e 1216px — acima disso ela já bate no próprio teto. A 933px o título passa a quebrar em quatro linhas em vez de três. Se quiser compensar, o recuo do desktop é a alavanca, e aí ela funciona.

Gates: ESLint 0 erros, `tsc` limpo, 14 testes da página.

<img width="1285" height="952" alt="image" src="https://github.com/user-attachments/assets/0ca3bb34-1104-4b66-a379-892966f18905" />
<img width="1285" height="952" alt="image" src="https://github.com/user-attachments/assets/ce702e18-9c26-4e60-bd2e-0cdff80ad2e7" />
