### PR TITLE
fix(257): mark the current screen and fix the chrome hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Adiciona o botão de fechar nos diálogos quando a tela é estreita: a faixa em volta deles é curta demais para fechar por toque, e alargá-la deixaria o diálogo apertado. No desktop nada muda (#277) [Frontend]
+- Adiciona a marcação da tela atual no topo e no menu lateral, que antes não indicavam onde a pessoa estava; a marca também é anunciada por leitor de tela (#281) [Frontend]
 
 ### Changed
 
@@ -24,6 +25,8 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige o cartão de entrar da página inicial, que era estreito demais para o e-mail institucional completo e o cortava dentro do campo — e é o único formato de e-mail que a tela aceita (#278) [Frontend]
 - Corrige a explicação do tipo de carona, inalcançável no celular: ela abria só ao passar o ponteiro, e agora abre ao toque, num alvo grande o bastante e sem levar o foco para o campo (#279) [Frontend]
 - Corrige o espaçamento dos botões dentro dos campos — o do calendário e o do relógio —, que ficavam mais para dentro que a seta dos campos de seleção ao lado (#279) [Frontend]
+- Corrige o logo dentro do menu lateral, que navegava e deixava o menu aberto por cima da tela nova (#281) [Frontend]
+- Corrige o realce de passar o ponteiro no topo e no menu lateral: no topo ele não chegava a aparecer, e no menu clareava tanto que apagava o próprio rótulo (#281) [Frontend]
 
 ## [0.7.0] - 2026-08-31
 

--- a/FateConnect/Web/design-system/components/Header/styles.ts
+++ b/FateConnect/Web/design-system/components/Header/styles.ts
@@ -5,7 +5,7 @@ import { PolymorphicBox, PolymorphicStack } from '@ds-root/polymorphic';
 import { styled } from '@ds-root/styled';
 import { shadowTokens, spacingScale } from '@ds-root/tokens';
 
-const { none, xs, lg, giant } = spacingScale;
+const { none, xxs, xs, lg, giant } = spacingScale;
 
 /** Altura do topo; a casca reserva esse espaço porque o header é fixo. */
 export const HEADER_HEIGHT_PX = 64;
@@ -15,6 +15,8 @@ const NAV_FONT_WEIGHT = 500;
 const CTA_FONT_WEIGHT = 400;
 
 const MENU_BUTTON_WIDTH = '48px';
+
+const CURRENT_MARK_THICKNESS_PX = 2;
 
 export const HeaderBar = styled(AppBar)({
   boxShadow: shadowTokens.component,
@@ -52,9 +54,23 @@ export const DesktopNav = styled(PolymorphicStack)(({ theme }) => ({
   marginLeft: 'auto',
 
   '& .MuiButton-root': {
+    position: 'relative',
     fontSize: NAV_FONT_SIZE,
     fontWeight: NAV_FONT_WEIGHT,
     color: theme.palette.chrome.contrastText,
+  },
+  // A marca da tela atual pende do atributo que o leitor de tela já lê, e não de
+  // uma classe própria: assim o traço e o anúncio não têm como divergir.
+  // Vai no `::before` porque o `::after` do botão é o véu de hover do MUI, que
+  // nasce com `opacity: 0` — o traço escrito ali fica invisível.
+  '& .MuiButton-root[aria-current="page"]::before': {
+    content: '""',
+    position: 'absolute',
+    left: theme.space(xs),
+    right: theme.space(xs),
+    bottom: theme.space(xxs),
+    height: `${CURRENT_MARK_THICKNESS_PX}px`,
+    backgroundColor: 'currentColor',
   },
   // O destaque não recebe o peso reforçado, como no produto.
   '& .MuiButton-contained': { fontWeight: CTA_FONT_WEIGHT },

--- a/FateConnect/Web/design-system/components/Header/styles.ts
+++ b/FateConnect/Web/design-system/components/Header/styles.ts
@@ -31,6 +31,14 @@ export const HeaderToolbar = styled(Toolbar)(({ theme }) => ({
   padding: theme.space(none, giant),
   color: theme.palette.chrome.contrastText,
 
+  // O realce de hover que o tema dá aos botões é o de superfície clara — preto a
+  // 3,5%, que sobre o cromo escuro não aparece. Aqui vale o realce do próprio
+  // cromo. O botão preenchido fica de fora: ele traz a sua própria cor.
+  '& .MuiButton-root:not(.MuiButton-contained)::after': {
+    backgroundColor: theme.palette.chrome.hover,
+  },
+  '& .MuiIconButton-root:hover': { backgroundColor: theme.palette.chrome.hover },
+
   [theme.breakpoints.down('md')]: { padding: theme.space(none, lg) },
 }));
 

--- a/FateConnect/Web/design-system/components/NavigationDrawer/styles.ts
+++ b/FateConnect/Web/design-system/components/NavigationDrawer/styles.ts
@@ -12,6 +12,8 @@ const DRAWER_WIDTH_PX = 300;
 /** Altura e recuo padrão de item de lista do Material, preservados. */
 const ITEM_MIN_HEIGHT_PX = 48;
 
+const CURRENT_MARK_THICKNESS_PX = 3;
+
 export const DrawerRoot = styled(Drawer)(({ theme }) => ({
   '& .MuiDrawer-paper': {
     width: `${DRAWER_WIDTH_PX}px`,
@@ -41,11 +43,21 @@ export const DrawerList = styled(List)(({ theme }) => ({
   paddingLeft: theme.space(none),
 
   '& .MuiListItemButton-root': {
+    position: 'relative',
     minHeight: `${ITEM_MIN_HEIGHT_PX}px`,
     paddingLeft: theme.space(md),
     paddingRight: theme.space(md),
   },
   '& .MuiListItemButton-root:hover': { backgroundColor: theme.palette.chrome.hover },
+  '& .MuiListItemButton-root[aria-current="page"]::before': {
+    content: '""',
+    position: 'absolute',
+    left: theme.space(none),
+    top: theme.space(none),
+    bottom: theme.space(none),
+    width: `${CURRENT_MARK_THICKNESS_PX}px`,
+    backgroundColor: 'currentColor',
+  },
   '& .MuiListItemText-primary': {
     color: theme.palette.chrome.contrastText,
     ...theme.typography.body,

--- a/FateConnect/Web/design-system/tokens/palette.ts
+++ b/FateConnect/Web/design-system/tokens/palette.ts
@@ -13,8 +13,12 @@ export const colorTokens = {
 
   surfaceGray: '#F0F2F4',
   surfaceWhite: '#FFFFFF',
-  /** Realce sobre o cromo colorido — menu lateral. Some sobre superfície clara. */
-  chromeHover: 'rgba(255, 255, 255, 0.6)',
+  /**
+   * Realce sobre o cromo colorido — menu lateral. Some sobre superfície clara.
+   * O véu clareia o cromo, então ele tem teto: a 0,6 o rótulo branco caía para
+   * 1,84:1 sobre ele, e a 0,16 já roça o mínimo de 4,5:1.
+   */
+  chromeHover: 'rgba(255, 255, 255, 0.12)',
   /**
    * Realce genérico sobre superfície clara: o produto usa a cor de conteúdo a
    * 3,5%, que é o que o Material desenha na opção do `select`.

--- a/FateConnect/Web/src/components/BrandLogo/index.tsx
+++ b/FateConnect/Web/src/components/BrandLogo/index.tsx
@@ -1,0 +1,18 @@
+import { Link as RouterLink } from 'react-router';
+import { Typography } from '@design-system';
+
+import type { RoutePathEnum } from '@app/routes/paths';
+
+const LOGO_LABEL = 'FateConnect';
+
+type BrandLogoProps = Readonly<{ to: RoutePathEnum; onClick?: VoidFunction }>;
+
+export function BrandLogo({ to, onClick }: BrandLogoProps) {
+  return (
+    <RouterLink to={to} aria-label={LOGO_LABEL} onClick={onClick}>
+      <Typography variant="logo" color="inherit">
+        {LOGO_LABEL}
+      </Typography>
+    </RouterLink>
+  );
+}

--- a/FateConnect/Web/src/layouts/GuestLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/GuestLayout/index.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState } from 'react';
-import { Outlet, Link as RouterLink } from 'react-router';
-import { Footer, Header, NavigationDrawer, ThemeToggleButton, Typography } from '@design-system';
+import { Outlet } from 'react-router';
+import { Footer, Header, NavigationDrawer, ThemeToggleButton } from '@design-system';
 
+import { BrandLogo } from '@app/components/BrandLogo';
 import { DrawerSectionItem } from '@app/components/DrawerSectionItem';
 import { LandingNavButton } from '@app/components/LandingNavButton';
 import { LegalFooterLinks } from '@app/components/LegalFooterLinks';
@@ -13,7 +14,6 @@ import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 import * as S from '../shell.styles';
 
 const MENU_BUTTON_LABEL = 'Abrir menu';
-const LOGO_LABEL = 'FateConnect';
 
 export function GuestLayout() {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -29,18 +29,10 @@ export function GuestLayout() {
     [goToSection],
   );
 
-  const logo = (
-    <RouterLink to={RoutePathEnum.LANDING} aria-label={LOGO_LABEL}>
-      <Typography variant="logo" color="inherit">
-        FateConnect
-      </Typography>
-    </RouterLink>
-  );
-
   return (
     <S.ShellRoot>
       <Header
-        logo={logo}
+        logo={<BrandLogo to={RoutePathEnum.LANDING} />}
         actions={<ThemeToggleButton />}
         menuButtonLabel={MENU_BUTTON_LABEL}
         onMenuClick={handleMenuClick}
@@ -55,7 +47,11 @@ export function GuestLayout() {
         ))}
       />
 
-      <NavigationDrawer open={drawerOpen} onClose={handleDrawerClose} header={logo}>
+      <NavigationDrawer
+        open={drawerOpen}
+        onClose={handleDrawerClose}
+        header={<BrandLogo to={RoutePathEnum.LANDING} onClick={handleDrawerClose} />}
+      >
         {LANDING_LINKS.map(({ section, label }) => (
           <DrawerSectionItem
             key={section}

--- a/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
@@ -78,4 +78,24 @@ describe('MainLayout', () => {
     expect(router.state.location.pathname).toBe(RoutePathEnum.MENU);
     await waitFor(() => expect(screen.queryByRole('presentation')).not.toBeInTheDocument());
   });
+
+  it('should mark the current screen in the header and in the drawer', async () => {
+    renderLayout(RoutePathEnum.RIDES);
+
+    expect(screen.getByRole('link', { name: 'Caronas' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Achados & Perdidos' })).not.toHaveAttribute(
+      'aria-current',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir menu', hidden: true }));
+    const drawer = screen.getByRole('presentation');
+
+    expect(within(drawer).getByRole('link', { name: 'Caronas' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(within(drawer).getByRole('link', { name: 'Achados & Perdidos' })).not.toHaveAttribute(
+      'aria-current',
+    );
+  });
 });

--- a/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
@@ -2,12 +2,12 @@ import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import { RoutePathEnum } from '@app/routes/paths';
 import { tokenStorage } from '@app/services/auth/tokenStorage';
-import { render, screen, userEvent, within } from '@app/test/testing-library';
+import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 import { tokenWithName } from '@app/test/token';
 
 import { MainLayout } from '.';
 
-function renderLayout() {
+function renderLayout(initialEntry: RoutePathEnum = RoutePathEnum.MENU) {
   const router = createMemoryRouter(
     [
       {
@@ -18,7 +18,7 @@ function renderLayout() {
         ],
       },
     ],
-    { initialEntries: [RoutePathEnum.MENU] },
+    { initialEntries: [initialEntry] },
   );
   render(<RouterProvider router={router} />);
 
@@ -66,5 +66,16 @@ describe('MainLayout', () => {
       'href',
       RoutePathEnum.MENU,
     );
+  });
+
+  it('should navigate and close the drawer when the logo inside it is used', async () => {
+    const router = renderLayout(RoutePathEnum.RIDES);
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir menu', hidden: true }));
+
+    const drawer = screen.getByRole('presentation');
+    await userEvent.click(within(drawer).getByRole('link', { name: 'FateConnect' }));
+
+    expect(router.state.location.pathname).toBe(RoutePathEnum.MENU);
+    await waitFor(() => expect(screen.queryByRole('presentation')).not.toBeInTheDocument());
   });
 });

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -7,9 +7,9 @@ import {
   ListItemButton,
   ListItemText,
   NavigationDrawer,
-  Typography,
 } from '@design-system';
 
+import { BrandLogo } from '@app/components/BrandLogo';
 import { LegalFooterLinks } from '@app/components/LegalFooterLinks';
 import * as C from '@app/constants/appContact';
 import { APP_LINKS } from '@app/constants/navigation';
@@ -19,7 +19,6 @@ import * as S from '../shell.styles';
 import { HeaderActions } from './components/HeaderActions';
 
 const MENU_BUTTON_LABEL = 'Abrir menu';
-const LOGO_LABEL = 'FateConnect';
 
 export function MainLayout() {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -27,18 +26,10 @@ export function MainLayout() {
   const handleMenuClick = useCallback(() => setDrawerOpen(true), []);
   const handleDrawerClose = useCallback(() => setDrawerOpen(false), []);
 
-  const logo = (
-    <RouterLink to={RoutePathEnum.MENU} aria-label={LOGO_LABEL}>
-      <Typography variant="logo" color="inherit">
-        FateConnect
-      </Typography>
-    </RouterLink>
-  );
-
   return (
     <S.ShellRoot>
       <Header
-        logo={logo}
+        logo={<BrandLogo to={RoutePathEnum.MENU} />}
         actions={<HeaderActions />}
         menuButtonLabel={MENU_BUTTON_LABEL}
         onMenuClick={handleMenuClick}
@@ -49,7 +40,11 @@ export function MainLayout() {
         ))}
       />
 
-      <NavigationDrawer open={drawerOpen} onClose={handleDrawerClose} header={logo}>
+      <NavigationDrawer
+        open={drawerOpen}
+        onClose={handleDrawerClose}
+        header={<BrandLogo to={RoutePathEnum.MENU} onClick={handleDrawerClose} />}
+      >
         {APP_LINKS.map(({ path, label }) => (
           <ListItemButton key={path} component={RouterLink} to={path} onClick={handleDrawerClose}>
             <ListItemText primary={label} />

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { Outlet, Link as RouterLink } from 'react-router';
+import { Outlet, Link as RouterLink, useLocation } from 'react-router';
 import {
   Button,
   Footer,
@@ -22,6 +22,7 @@ const MENU_BUTTON_LABEL = 'Abrir menu';
 
 export function MainLayout() {
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const { pathname } = useLocation();
 
   const handleMenuClick = useCallback(() => setDrawerOpen(true), []);
   const handleDrawerClose = useCallback(() => setDrawerOpen(false), []);
@@ -34,7 +35,13 @@ export function MainLayout() {
         menuButtonLabel={MENU_BUTTON_LABEL}
         onMenuClick={handleMenuClick}
         navigation={APP_LINKS.map(({ path, label }) => (
-          <Button key={path} color="inherit" component={RouterLink} to={path}>
+          <Button
+            key={path}
+            color="inherit"
+            component={RouterLink}
+            to={path}
+            aria-current={path === pathname ? 'page' : undefined}
+          >
             {label}
           </Button>
         ))}
@@ -46,7 +53,13 @@ export function MainLayout() {
         header={<BrandLogo to={RoutePathEnum.MENU} onClick={handleDrawerClose} />}
       >
         {APP_LINKS.map(({ path, label }) => (
-          <ListItemButton key={path} component={RouterLink} to={path} onClick={handleDrawerClose}>
+          <ListItemButton
+            key={path}
+            component={RouterLink}
+            to={path}
+            onClick={handleDrawerClose}
+            aria-current={path === pathname ? 'page' : undefined}
+          >
             <ListItemText primary={label} />
           </ListItemButton>
         ))}


### PR DESCRIPTION
## Objetivo

Fechar os dois defeitos de navegação da issue: o logo dentro do menu lateral navegava sem fechar o menu, e nada indicava em qual tela a pessoa estava. Junto entrou o realce de passar o ponteiro do topo, que não aparecia sobre a cor do cromo.

## Alterações

**O logo dentro do menu fecha o menu.** O logo era o **mesmo nó** entregue ao topo e ao cabeçalho do menu lateral, então pendurar o fechar nele faria o clique no topo chamar a função também. Virou o componente `BrandLogo`, que recebe o destino e um `onClick` opcional. O `GuestLayout` trazia o mesmo nó byte a byte, mudando só o destino, e passou a usar o componente — o defeito existia igual na landing e foi junto.

**A tela atual aparece marcada.** A marca pende do próprio `aria-current="page"`, o atributo que o leitor de tela lê: o traço e o anúncio não têm como divergir. No topo é um traço de 2px sob o rótulo; no menu lateral, uma barra de 3px na borda esquerda.

**O realce de passar o ponteiro passa a aparecer, sem apagar o texto.** Ele vinha do realce de superfície clara — preto a 3,5% —, invisível sobre o cromo. O topo passou a usar o realce do próprio cromo, e o token `chromeHover` caiu de branco 0,6 para 0,12.

O botão preenchido ficou de fora de propósito: ele traz a própria cor, e o véu dele é decisão de paridade já registrada no tema.

## Medições

Todas na aplicação de pé, com `getComputedStyle` — nenhuma em sonda isolada.

Contraste do traço sobre o cromo, contra o mínimo de **3:1** para elemento não-textual (WCAG 1.4.11):

| Tema | Contraste |
| --- | --- |
| Claro | 6,78:1 |
| Escuro | 12,84:1 |

Realce ao passar o ponteiro, razão entre a superfície com hover e a em repouso:

| | Antes | Depois |
| --- | --- | --- |
| Botão de texto do topo | 1,05 | 1,38 |
| Botão de ícone do topo | 1,05 | 1,38 |

Legibilidade do rótulo do menu lateral sobre o próprio realce: de **1,84:1** para **5,02:1**. O 0,12 saiu de uma tabela — a 0,16 o rótulo cai para 4,55:1 e a 0,20 para 4,14:1, furando o mínimo de 4,5:1.

O logo do menu foi exercitado no app: gaveta aberta em `/caronas` e, depois do clique, fechada e em `/menu`.

## Uma armadilha que os gates não pegaram

O traço nasceu no `::after`, que é onde o MUI põe o véu de hover do botão — e esse véu nasce com `opacity: 0`. O traço ficava **invisível** com ESLint, `tsc` e os 14 testes verdes. Só a medição na aplicação acusou. Passou para o `::before`, que está livre.

## Gates

ESLint 0 erros, `tsc` limpo, suíte inteira: **515 testes em 73 arquivos**. Os três commits de código foram montados por replay, e cada um passou sozinho nos gates da área que toca.

## Issue

- #257

Closes #257

## Evidências
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/9ab28f98-62c6-40c4-b794-77be1001cfc3" />
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/0ed83d40-988b-4006-a2a4-9a4b44bc82d4" />
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/050988db-088c-45e6-97ec-450b285e5981" />
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/f92a8285-08f9-412f-988b-6d558d3212f0" />
