### PR TITLE
fix(258): reduce the footer vertical padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Passa a pedir a data por digitação, com o calendário atrás de um botão, na busca de caronas, no mural de achados e perdidos e nos dois formulários; o campo ganha a mesma borda e o mesmo espaçamento dos campos ao lado, dos quais destoava (#274) [Frontend]
+- Reduz a altura do rodapé no desktop, que ocupava espaço demais e empurrava o conteúdo para cima (#282) [Frontend]
 
 ### Fixed
 

--- a/FateConnect/Web/design-system/components/Footer/styles.ts
+++ b/FateConnect/Web/design-system/components/Footer/styles.ts
@@ -5,14 +5,14 @@ import { PolymorphicStack } from '@ds-root/polymorphic';
 import { styled } from '@ds-root/styled';
 import { spacingScale } from '@ds-root/tokens';
 
-const { xs, md, lg, xxl, giant } = spacingScale;
+const { xs, md, lg, giant } = spacingScale;
 
 export const FooterRoot = styled(PolymorphicStack)(({ theme }) => ({
   flexDirection: 'row',
   justifyContent: 'space-between',
   backgroundColor: theme.palette.chrome.main,
   color: theme.palette.chrome.contrastText,
-  padding: theme.space(xxl, giant),
+  padding: theme.space(lg, giant),
   gap: theme.space(md),
   width: '100%',
 


### PR DESCRIPTION
## Objetivo

Reduzir a altura do rodapé, que ocupava espaço demais e empurrava o conteúdo para cima.

## Alterações

O recuo **vertical** do rodapé caiu no desktop, seguindo a escala de espaçamento do tema — nenhum valor solto.

**No celular o recuo ficou como estava.** A redução foi experimentada lá também e desfeita depois de ver na tela: com o conteúdo empilhado, o recuo menor aproximava demais o rodapé do conteúdo acima sem devolver altura que valesse. O critério de aceite da issue falava nas duas larguras; o que ficou é uma largura só, por decisão tomada olhando o resultado.

O recuo **horizontal continua intocado**: ele é a mesma goteira de página que o topo, as telas e as faixas da página inicial usam, e encolhê-lo desalinharia a coluna de contato do rodapé em relação à marca do topo e ao conteúdo da tela.

## Medições

Feitas na aplicação de pé, com `getComputedStyle` e `getBoundingClientRect`.

| Largura | Altura antes | Altura depois | Diferença |
| --- | --- | --- | --- |
| 1440px | 235,20px · `48px 112px` | **187,20px** · `24px 112px` | −48px (−20,4%) |
| 409px | 366,98px · `24px` | 366,98px · `24px` | inalterado |

Folga entre o texto e a borda do rodapé no desktop, para provar que nada colou: **25px** em cima, **25,8px** embaixo, 112px nas laterais.

O rodapé é o mesmo na página inicial e na área logada, e a medição confirma que os dois recebem o valor novo.

## Gates

ESLint 0 erros, `tsc` limpo, testes do rodapé passando.

## Issue

- #258

Closes #258

## Evidências
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/45ea8112-a73c-448c-967a-e53ddfdefe71" />
