### PR TITLE
refactor(255): remove the user nickname from the contract and database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige o logo dentro do menu lateral, que navegava e deixava o menu aberto por cima da tela nova (#281) [Frontend]
 - Corrige o realce de passar o ponteiro no topo e no menu lateral: no topo ele não chegava a aparecer, e no menu clareava tanto que apagava o próprio rótulo (#281) [Frontend]
 
+### Removed
+
+- Remove o apelido do cadastro: o campo sai do contrato e do banco, e a requisição que ainda o mande é aceita com o valor descartado. A coluna é apagada, então o apelido de quem já se cadastrou se perde (#283) [Backend]
+
 ## [0.7.0] - 2026-08-31
 
 ### Changed

--- a/FateConnect/FateConnect.Api.Tests/SignupTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/SignupTests.cs
@@ -84,4 +84,24 @@ public class SignupTests : IClassFixture<ApiFactory>
 
         Assert.Equal(HttpStatusCode.BadRequest, r.StatusCode);
     }
+
+    [Fact]
+    public async Task Signup_WithTheRemovedNicknameField_IsAccepted()
+    {
+        HttpResponseMessage r = await _factory.CreateClient().PostAsJsonAsync("/Users/signup", new
+        {
+            fatecEmail = $"sonda{Guid.NewGuid():N}@aluno.cps.sp.gov.br",
+            password = "SenhaForte123!",
+            fullName = "Mariana Alves Rocha",
+            nickname = "Mari",
+            birthDate = "2000-01-01T00:00:00Z",
+            gender = "Male",
+            addresses = new[] { new { zipCode = "18040-430", street = "Rua Cesário Mota", streetNumber = "1", complement = "Casa", city = "Sorocaba", state = "SP" } },
+            contacts = new[] { new { phone = "15999990000", contactEmail = "mariana.rocha@gmail.com" } },
+        });
+
+        string corpo = await r.Content.ReadAsStringAsync();
+
+        Assert.True(r.StatusCode == HttpStatusCode.Created, $"status={r.StatusCode} corpo={corpo}");
+    }
 }

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/FateConnectDbContext.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/FateConnectDbContext.cs
@@ -24,7 +24,6 @@ public class FateConnectDbContext(DbContextOptions<FateConnectDbContext> options
             entity.HasKey(e => e.Id);
             entity.Property(e => e.FatecEmail).IsRequired().HasMaxLength(150);
             entity.Property(e => e.FullName).IsRequired().HasMaxLength(200);
-            entity.Property(e => e.Nickname).HasMaxLength(50);
             entity.Property(e => e.Password).IsRequired().HasMaxLength(255);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
             entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260901232951_RemoveUserNickname.Designer.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260901232951_RemoveUserNickname.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FateConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FateConnect.Api.Infrastructure.Database.Migrations
 {
     [DbContext(typeof(FateConnectDbContext))]
-    partial class FateConnectDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901232951_RemoveUserNickname")]
+    partial class RemoveUserNickname
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260901232951_RemoveUserNickname.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260901232951_RemoveUserNickname.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FateConnect.Api.Infrastructure.Database.Migrations
+{
+    public partial class RemoveUserNickname : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Nickname",
+                table: "Users");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Nickname",
+                table: "Users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+    }
+}

--- a/FateConnect/FateConnect.Api/Modules/Users/DTOs/CreateUserDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/DTOs/CreateUserDto.cs
@@ -25,10 +25,6 @@ public class CreateUserDto
     [DefaultValue("João da Silva")]
     public string FullName { get; set; } = string.Empty;
 
-    [MaxLength(50)]
-    [DefaultValue("Joãozinho")]
-    public string? Nickname { get; set; }
-
     [Required]
     [DefaultValue("2000-01-01T00:00:00Z")]
     required public DateTime BirthDate { get; set; }

--- a/FateConnect/FateConnect.Api/Modules/Users/Entities/User.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Entities/User.cs
@@ -8,7 +8,6 @@ public class User
     public string FatecEmail { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
     public string FullName { get; set; } = string.Empty;
-    public string? Nickname { get; set; }
     public DateTime BirthDate { get; set; }
     public EnumGender Gender { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/FateConnect/FateConnect.Api/Modules/Users/Services/UserService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Services/UserService.cs
@@ -53,7 +53,6 @@ public class UserService : IUserService
         {
             FatecEmail = dto.FatecEmail,
             FullName = dto.FullName,
-            Nickname = dto.Nickname,
             BirthDate = dto.BirthDate,
             Gender = dto.Gender,
             Password = hashedPassword,


### PR DESCRIPTION
## Objetivo

O apelido era pedido no cadastro, gravado no banco e nunca exibido: nenhuma tela o lia. Ele sai do contrato, da entidade e do banco.

## Alterações

O campo tinha **quatro referências vivas**, e as quatro saíram:

| Camada | O que saiu |
| --- | --- |
| Contrato | a propriedade do DTO de cadastro |
| Entidade | a propriedade de `User` |
| Montagem | a linha que copiava o valor do DTO para a entidade |
| Configuração | o limite de tamanho declarado no `DbContext` |

Mais a migração `RemoveUserNickname`, que apaga a coluna.

⚠️ **A migração é destrutiva:** o apelido de quem já se cadastrou se perde, inclusive em produção. Decidido com essa consequência à vista, e registrado na #247 — não é efeito colateral não visto.

O item de escopo *"limpar o que restar nos testes e na fábrica de dados"* saiu **vazio**: o projeto de teste não tinha uma única referência ao campo.

## Como o critério de aceite foi verificado

O critério é *"`POST /Users/signup` com `nickname` no corpo é aceito e ignora o campo; a coluna não existe mais"*, e as duas metades foram exercitadas, não deduzidas:

**A requisição continua aceita.** Um teste novo manda o corpo com `nickname` e espera `201`. Ele discrimina de verdade: se a API recusasse campo desconhecido, o teste falharia com `400`. Isso importa porque o formulário de hoje **ainda envia o campo** — parar de enviar é a #256 —, então esta mudança não pode quebrar a tela.

**A coluna deixou de existir, e a migração destrutiva roda de verdade.** A aplicação aplica as migrações na subida, e a fábrica de teste sobe a aplicação contra um PostgreSQL em contêiner: cada execução da suíte constrói o banco pela sequência inteira de migrações, o `DropColumn` incluído.

## Gates

Build com 0 erros e 0 warnings; **87 testes passando** contra contêiner real.

## Issue

- #255

Closes #255

## Evidências
