### PR TITLE
feat(253): reject a signup whose contact is already registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Passa a pedir a data por digitação, com o calendário atrás de um botão, na busca de caronas, no mural de achados e perdidos e nos dois formulários; o campo ganha a mesma borda e o mesmo espaçamento dos campos ao lado, dos quais destoava (#274) [Frontend]
 - Reduz a altura do rodapé no desktop, que ocupava espaço demais e empurrava o conteúdo para cima (#282) [Frontend]
+- Passa a recusar cadastro cujo telefone ou e-mail de contato já pertença a outra pessoa, com o mesmo 409 que o e-mail de login já respondia; a unicidade passa a valer também no banco, e para isso os cadastros que repetiam um contato são apagados junto com as caronas que ofertaram, ficando o mais antigo (#284) [Backend]
+- Passa a dizer qual campo está em uso na resposta de conflito do cadastro, que antes trazia só a mensagem (#284) [Backend]
 
 ### Fixed
 

--- a/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
+++ b/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
@@ -57,10 +57,13 @@ public class ApiFactory : WebApplicationFactory<Program>
 
     public static string UniqueContactEmail() => $"contato{Guid.NewGuid():N}@gmail.com";
 
-    public int SeedUser(string fullName, string phone, string contactEmail)
+    public SeededUser SeedUser(string fullName)
     {
         using IServiceScope scope = Services.CreateScope();
         FateConnectDbContext context = scope.ServiceProvider.GetRequiredService<FateConnectDbContext>();
+
+        string phone = UniquePhone();
+        string contactEmail = UniqueContactEmail();
 
         User user = new()
         {
@@ -76,7 +79,7 @@ public class ApiFactory : WebApplicationFactory<Program>
         context.Users.Add(user);
         context.SaveChanges();
 
-        return user.Id;
+        return new SeededUser(user.Id, phone, contactEmail);
     }
 
     public (int Id, string FatecEmail) SeedUserWithPassword(string fullName, string password)

--- a/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
+++ b/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
@@ -53,6 +53,10 @@ public class ApiFactory : WebApplicationFactory<Program>
             .GenerateJwtToken(new User { Id = userId, FatecEmail = "mariana.rocha@aluno.cps.sp.gov.br" });
     }
 
+    public static string UniquePhone() => $"15{Random.Shared.Next(100_000_000, 999_999_999)}";
+
+    public static string UniqueContactEmail() => $"contato{Guid.NewGuid():N}@gmail.com";
+
     public int SeedUser(string fullName, string phone, string contactEmail)
     {
         using IServiceScope scope = Services.CreateScope();

--- a/FateConnect/FateConnect.Api.Tests/DuplicatedContactCleanupTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/DuplicatedContactCleanupTests.cs
@@ -1,0 +1,65 @@
+using FateConnect.Api.Infrastructure.Database;
+using FateConnect.Api.Infrastructure.Database.Migrations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FateConnect.Api.Tests;
+
+public class DuplicatedContactCleanupTests : IClassFixture<ApiFactory>
+{
+    private readonly ApiFactory _factory;
+
+    public DuplicatedContactCleanupTests(ApiFactory factory) => _factory = factory;
+
+    [Fact]
+    public void TheCleanup_RemovesTheNewerUserWhoRepeatsAPhone_WithTheirRides()
+    {
+        SeededUser older = _factory.SeedUser("Ana Beatriz Nogueira");
+        SeededUser newer = _factory.SeedUser("Bruno Carvalho Souza");
+
+        Guid rideOfNewer = _factory.SeedRide(
+            newer.Id,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)),
+            new TimeOnly(8, 30));
+
+        Execute("DROP INDEX \"IX_Contacts_Phone\"");
+        ExecuteWithPhone("UPDATE \"Contacts\" SET \"Phone\" = {0} WHERE \"UserId\" = {1}", older.Phone, newer.Id);
+
+        Execute(DuplicatedContactCleanup.Sql);
+
+        Execute("CREATE UNIQUE INDEX \"IX_Contacts_Phone\" ON \"Contacts\" (\"Phone\")");
+
+        Assert.True(UserExists(older.Id));
+        Assert.False(UserExists(newer.Id));
+        Assert.False(RideExists(rideOfNewer));
+    }
+
+    private void Execute(string sql)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<FateConnectDbContext>().Database.ExecuteSqlRaw(sql);
+    }
+
+    private void ExecuteWithPhone(string sql, string phone, int userId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<FateConnectDbContext>()
+            .Database.ExecuteSqlRaw(sql, phone, userId);
+    }
+
+    private bool UserExists(int userId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+
+        return scope.ServiceProvider.GetRequiredService<FateConnectDbContext>()
+            .Users.AsNoTracking().Any(user => user.Id == userId);
+    }
+
+    private bool RideExists(Guid rideId)
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+
+        return scope.ServiceProvider.GetRequiredService<FateConnectDbContext>()
+            .Rides.AsNoTracking().Any(ride => ride.Id == rideId);
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/GlobalExceptionMiddlewareTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/GlobalExceptionMiddlewareTests.cs
@@ -65,6 +65,28 @@ public class GlobalExceptionMiddlewareTests
     }
 
     [Fact]
+    public async Task ADuplicatePhone_AnswersConflictNamingThePhoneField()
+    {
+        (HttpStatusCode statusCode, string error, string? field) =
+            await AnswerFor(new ContactPhoneAlreadyRegisteredException("15999990000"));
+
+        Assert.Equal(HttpStatusCode.Conflict, statusCode);
+        Assert.Equal("O telefone '15999990000' já está em uso no sistema.", error);
+        Assert.Equal("phone", field);
+    }
+
+    [Fact]
+    public async Task ADuplicateContactEmail_AnswersConflictNamingTheContactEmailField()
+    {
+        (HttpStatusCode statusCode, string error, string? field) =
+            await AnswerFor(new ContactEmailAlreadyRegisteredException("mariana.rocha@gmail.com"));
+
+        Assert.Equal(HttpStatusCode.Conflict, statusCode);
+        Assert.Equal("O e-mail de contato 'mariana.rocha@gmail.com' já está em uso no sistema.", error);
+        Assert.Equal("contactEmail", field);
+    }
+
+    [Fact]
     public async Task AnErrorWithoutAField_OmitsTheFieldFromTheBody()
     {
         (_, _, string? field) = await AnswerFor(new InvalidRideTypeException());

--- a/FateConnect/FateConnect.Api.Tests/GlobalExceptionMiddlewareTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/GlobalExceptionMiddlewareTests.cs
@@ -12,7 +12,7 @@ namespace FateConnect.Api.Tests;
 
 public class GlobalExceptionMiddlewareTests
 {
-    private static async Task<(HttpStatusCode StatusCode, string Error)> AnswerFor(Exception thrown)
+    private static async Task<(HttpStatusCode StatusCode, string Error, string? Field)> AnswerFor(Exception thrown)
     {
         await using ServiceProvider services = new ServiceCollection().BuildServiceProvider();
 
@@ -30,13 +30,15 @@ public class GlobalExceptionMiddlewareTests
         body.Position = 0;
         using JsonDocument document = await JsonDocument.ParseAsync(body);
 
-        return ((HttpStatusCode)context.Response.StatusCode, document.RootElement.GetProperty("error").GetString()!);
+        string? field = document.RootElement.TryGetProperty("field", out JsonElement raw) ? raw.GetString() : null;
+
+        return ((HttpStatusCode)context.Response.StatusCode, document.RootElement.GetProperty("error").GetString()!, field);
     }
 
     [Fact]
     public async Task AnUnmappedException_AnswersTheFallbackMessageInPortuguese()
     {
-        (HttpStatusCode statusCode, string error) = await AnswerFor(new TimeoutException("connection dropped"));
+        (HttpStatusCode statusCode, string error, _) = await AnswerFor(new TimeoutException("connection dropped"));
 
         Assert.Equal(HttpStatusCode.InternalServerError, statusCode);
         Assert.Equal("Algo deu errado. Tente novamente.", error);
@@ -45,7 +47,7 @@ public class GlobalExceptionMiddlewareTests
     [Fact]
     public async Task ARideDomainException_AnswersBadRequestWithItsOwnMessage()
     {
-        (HttpStatusCode statusCode, string error) = await AnswerFor(new InvalidRideTypeException());
+        (HttpStatusCode statusCode, string error, _) = await AnswerFor(new InvalidRideTypeException());
 
         Assert.Equal(HttpStatusCode.BadRequest, statusCode);
         Assert.Equal("Tipo de carona inválido.", error);
@@ -54,17 +56,26 @@ public class GlobalExceptionMiddlewareTests
     [Fact]
     public async Task ADuplicateEmail_AnswersConflictWithItsOwnMessage()
     {
-        (HttpStatusCode statusCode, string error) =
+        (HttpStatusCode statusCode, string error, string? field) =
             await AnswerFor(new EmailAlreadyRegisteredException("mariana.rocha@aluno.cps.sp.gov.br"));
 
         Assert.Equal(HttpStatusCode.Conflict, statusCode);
         Assert.Equal("O e-mail 'mariana.rocha@aluno.cps.sp.gov.br' já está em uso no sistema.", error);
+        Assert.Equal("fatecEmail", field);
+    }
+
+    [Fact]
+    public async Task AnErrorWithoutAField_OmitsTheFieldFromTheBody()
+    {
+        (_, _, string? field) = await AnswerFor(new InvalidRideTypeException());
+
+        Assert.Null(field);
     }
 
     [Fact]
     public async Task InvalidCredentials_AnswerUnauthorizedWithTheirOwnMessage()
     {
-        (HttpStatusCode statusCode, string error) = await AnswerFor(new InvalidCredentialsException());
+        (HttpStatusCode statusCode, string error, _) = await AnswerFor(new InvalidCredentialsException());
 
         Assert.Equal(HttpStatusCode.Unauthorized, statusCode);
         Assert.Equal("E-mail ou senha inválidos.", error);
@@ -73,7 +84,7 @@ public class GlobalExceptionMiddlewareTests
     [Fact]
     public async Task AMissingJwtSecret_AnswersInternalServerErrorWithItsOwnMessage()
     {
-        (HttpStatusCode statusCode, string error) = await AnswerFor(new JwtNotConfiguredException());
+        (HttpStatusCode statusCode, string error, _) = await AnswerFor(new JwtNotConfiguredException());
 
         Assert.Equal(HttpStatusCode.InternalServerError, statusCode);
         Assert.Equal("JWT_SECRET não configurado.", error);
@@ -82,7 +93,7 @@ public class GlobalExceptionMiddlewareTests
     [Fact]
     public async Task AnUnidentifiedUser_AnswersUnauthorizedInPortuguese()
     {
-        (HttpStatusCode statusCode, string error) = await AnswerFor(new UnidentifiedUserException());
+        (HttpStatusCode statusCode, string error, _) = await AnswerFor(new UnidentifiedUserException());
 
         Assert.Equal(HttpStatusCode.Unauthorized, statusCode);
         Assert.Equal("Sessão expirada. Entre novamente para continuar.", error);

--- a/FateConnect/FateConnect.Api.Tests/RideListingTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/RideListingTests.cs
@@ -18,7 +18,7 @@ public class RideListingTests
 
     private static int SeedRides(ApiFactory factory, int count)
     {
-        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira").Id;
         DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
 
         for (int index = 0; index < count; index++)
@@ -124,7 +124,7 @@ public class RideListingTests
     public async Task GetRides_WithoutAnyResult_ReportsZeroTotalPages()
     {
         using ApiFactory factory = new();
-        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira").Id;
 
         PagedRides page = await GetPageAsync(factory, driverId);
 
@@ -137,7 +137,7 @@ public class RideListingTests
     public async Task GetRides_WithARideAlreadyDeparted_LeavesItOutAndOutOfTheTotal()
     {
         using ApiFactory factory = new();
-        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira").Id;
 
         DateOnly yesterday = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1));
         DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
@@ -154,7 +154,7 @@ public class RideListingTests
     public async Task GetRides_FilteredByDepartureTime_KeepsOnlyTheRidesThatLeaveAtThatHour()
     {
         using ApiFactory factory = new();
-        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira").Id;
         DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
         factory.SeedRide(driverId, tomorrow, new TimeOnly(7, 0));
         factory.SeedRide(driverId, tomorrow, new TimeOnly(22, 0));
@@ -195,7 +195,7 @@ public class RideListingTests
     public async Task GetRides_FilteredByDestination_KeepsOnlyTheRidesThatMatch()
     {
         using ApiFactory factory = new();
-        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira").Id;
         DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
         Guid matching = factory.SeedRide(driverId, tomorrow, new TimeOnly(8, 30), "São Paulo centro");
         factory.SeedRide(driverId, tomorrow, new TimeOnly(9, 0), "Campinas");
@@ -213,7 +213,7 @@ public class RideListingTests
     public async Task GetRides_FilteredByDestination_IgnoresAccentsAndCase(string destination, string search)
     {
         using ApiFactory factory = new();
-        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira").Id;
         DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
         Guid expected = factory.SeedRide(driverId, tomorrow, new TimeOnly(8, 30), destination);
 
@@ -226,7 +226,7 @@ public class RideListingTests
     public async Task GetRides_WithEveryFilterAtOnce_IsTranslatedToSql()
     {
         using ApiFactory factory = new();
-        int driverId = factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
+        int driverId = factory.SeedUser("Ana Beatriz Nogueira").Id;
         DateOnly tomorrow = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1));
         Guid expected = factory.SeedRide(driverId, tomorrow, new TimeOnly(8, 30), "Sorocaba centro");
 

--- a/FateConnect/FateConnect.Api.Tests/RideOwnershipTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/RideOwnershipTests.cs
@@ -30,39 +30,39 @@ public class RideOwnershipTests : IClassFixture<ApiFactory>
         description = "Vaga para quem sai do campus.",
     };
 
-    private async Task<(ReadRide Ride, int DriverId, int OtherUserId)> OfferRideAsync(string destination)
+    private async Task<(ReadRide Ride, SeededUser Driver, int OtherUserId)> OfferRideAsync(string destination)
     {
-        int driverId = _factory.SeedUser("Ana Beatriz Nogueira", "15999990000", "ana.nogueira@gmail.com");
-        int otherUserId = _factory.SeedUser("Bruno Carvalho Souza", "15988880000", "bruno.souza@gmail.com");
+        SeededUser driver = _factory.SeedUser("Ana Beatriz Nogueira");
+        SeededUser otherUser = _factory.SeedUser("Bruno Carvalho Souza");
 
         HttpResponseMessage response = await _factory
-            .CreateClientFor(driverId)
+            .CreateClientFor(driver.Id)
             .PostAsJsonAsync("/Rides", NewRidePayload(destination));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         ReadRide ride = (await response.Content.ReadFromJsonAsync<ReadRide>(JsonOptions))!;
 
-        return (ride, driverId, otherUserId);
+        return (ride, driver, otherUser.Id);
     }
 
     [Fact]
     public async Task CreateRide_RecordsTheAuthenticatedUserAsTheDriver()
     {
-        (ReadRide ride, _, _) = await OfferRideAsync("Sorocaba centro");
+        (ReadRide ride, SeededUser driver, _) = await OfferRideAsync("Sorocaba centro");
 
         Assert.Equal("Ana Beatriz Nogueira", ride.Driver.Name);
-        Assert.Equal("ana.nogueira@gmail.com", ride.Driver.Email);
-        Assert.Equal("15999990000", ride.Driver.Phone);
+        Assert.Equal(driver.ContactEmail, ride.Driver.Email);
+        Assert.Equal(driver.Phone, ride.Driver.Phone);
         Assert.True(ride.IsOwner);
     }
 
     [Fact]
     public async Task ReadRide_FlagsOwnershipForEachReader()
     {
-        (ReadRide ride, int driverId, int otherUserId) = await OfferRideAsync("Votorantim");
+        (ReadRide ride, SeededUser driver, int otherUserId) = await OfferRideAsync("Votorantim");
 
-        ReadRide asDriver = (await _factory.CreateClientFor(driverId)
+        ReadRide asDriver = (await _factory.CreateClientFor(driver.Id)
             .GetFromJsonAsync<ReadRide>($"/Rides/{ride.Id}", JsonOptions))!;
 
         ReadRide asOther = (await _factory.CreateClientFor(otherUserId)
@@ -98,8 +98,8 @@ public class RideOwnershipTests : IClassFixture<ApiFactory>
     [Fact]
     public async Task UpdateAndDeleteRide_ByTheDriver_Succeed()
     {
-        (ReadRide ride, int driverId, _) = await OfferRideAsync("Piedade");
-        HttpClient driver = _factory.CreateClientFor(driverId);
+        (ReadRide ride, SeededUser owner, _) = await OfferRideAsync("Piedade");
+        HttpClient driver = _factory.CreateClientFor(owner.Id);
 
         HttpResponseMessage update = await driver
             .PutAsJsonAsync($"/Rides/{ride.Id}", new { availableSeats = 1 });

--- a/FateConnect/FateConnect.Api.Tests/SeededUser.cs
+++ b/FateConnect/FateConnect.Api.Tests/SeededUser.cs
@@ -1,0 +1,3 @@
+namespace FateConnect.Api.Tests;
+
+public sealed record SeededUser(int Id, string Phone, string ContactEmail);

--- a/FateConnect/FateConnect.Api.Tests/SignupTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/SignupTests.cs
@@ -166,4 +166,32 @@ public class SignupTests : IClassFixture<ApiFactory>
         Assert.Equal(HttpStatusCode.Conflict, statusCode);
         Assert.Equal("phone", field);
     }
+
+    [Fact]
+    public async Task Signup_WithTheLoginEmailAlreadyRegistered_IsRejectedNamingTheLoginEmail()
+    {
+        string takenEmail = $"sonda{Guid.NewGuid():N}@aluno.cps.sp.gov.br";
+
+        object PayloadFor(string phone, string contactEmail) => new
+        {
+            fatecEmail = takenEmail,
+            password = "SenhaForte123!",
+            fullName = "Mariana Alves Rocha",
+            birthDate = "2000-01-01T00:00:00Z",
+            gender = "Male",
+            addresses = new[] { new { zipCode = "18040-430", street = "Rua Cesário Mota", streetNumber = "1", complement = "Casa", city = "Sorocaba", state = "SP" } },
+            contacts = new[] { new { phone, contactEmail } },
+        };
+
+        (HttpStatusCode first, _) = await SignupAnswerFor(
+            PayloadFor(ApiFactory.UniquePhone(), ApiFactory.UniqueContactEmail()));
+
+        Assert.Equal(HttpStatusCode.Created, first);
+
+        (HttpStatusCode second, string? field) = await SignupAnswerFor(
+            PayloadFor(ApiFactory.UniquePhone(), ApiFactory.UniqueContactEmail()));
+
+        Assert.Equal(HttpStatusCode.Conflict, second);
+        Assert.Equal("fatecEmail", field);
+    }
 }

--- a/FateConnect/FateConnect.Api.Tests/SignupTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/SignupTests.cs
@@ -23,12 +23,25 @@ public class SignupTests : IClassFixture<ApiFactory>
         contacts = contacts,
     };
 
+    private async Task<(HttpStatusCode StatusCode, string? Field)> SignupAnswerFor(object payload)
+    {
+        HttpResponseMessage response = await _factory.CreateClient().PostAsJsonAsync("/Users/signup", payload);
+
+        if (response.StatusCode == HttpStatusCode.Created)
+            return (response.StatusCode, null);
+
+        JsonElement raw = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        string? field = raw.TryGetProperty("field", out JsonElement value) ? value.GetString() : null;
+
+        return (response.StatusCode, field);
+    }
+
     [Fact]
     public async Task Signup_WithOneContact_IsAccepted()
     {
         HttpResponseMessage r = await _factory.CreateClient().PostAsJsonAsync(
             "/Users/signup",
-            SignupPayload(new[] { new { phone = "15999990000", contactEmail = "mariana.rocha@gmail.com" } }));
+            SignupPayload(new[] { new { phone = ApiFactory.UniquePhone(), contactEmail = ApiFactory.UniqueContactEmail() } }));
 
         string corpo = await r.Content.ReadAsStringAsync();
 
@@ -40,7 +53,7 @@ public class SignupTests : IClassFixture<ApiFactory>
     {
         HttpResponseMessage signup = await _factory.CreateClient().PostAsJsonAsync(
             "/Users/signup",
-            SignupPayload(new[] { new { phone = "15999990000", contactEmail = "mariana.rocha@gmail.com" } }));
+            SignupPayload(new[] { new { phone = ApiFactory.UniquePhone(), contactEmail = ApiFactory.UniqueContactEmail() } }));
 
         Assert.Equal(HttpStatusCode.Created, signup.StatusCode);
 
@@ -97,11 +110,60 @@ public class SignupTests : IClassFixture<ApiFactory>
             birthDate = "2000-01-01T00:00:00Z",
             gender = "Male",
             addresses = new[] { new { zipCode = "18040-430", street = "Rua Cesário Mota", streetNumber = "1", complement = "Casa", city = "Sorocaba", state = "SP" } },
-            contacts = new[] { new { phone = "15999990000", contactEmail = "mariana.rocha@gmail.com" } },
+            contacts = new[] { new { phone = ApiFactory.UniquePhone(), contactEmail = ApiFactory.UniqueContactEmail() } },
         });
 
         string corpo = await r.Content.ReadAsStringAsync();
 
         Assert.True(r.StatusCode == HttpStatusCode.Created, $"status={r.StatusCode} corpo={corpo}");
+    }
+
+    [Fact]
+    public async Task Signup_WithAPhoneAlreadyRegistered_IsRejectedNamingThePhone()
+    {
+        string takenPhone = ApiFactory.UniquePhone();
+
+        (HttpStatusCode first, _) = await SignupAnswerFor(
+            SignupPayload(new[] { new { phone = takenPhone, contactEmail = ApiFactory.UniqueContactEmail() } }));
+
+        Assert.Equal(HttpStatusCode.Created, first);
+
+        (HttpStatusCode second, string? field) = await SignupAnswerFor(
+            SignupPayload(new[] { new { phone = takenPhone, contactEmail = ApiFactory.UniqueContactEmail() } }));
+
+        Assert.Equal(HttpStatusCode.Conflict, second);
+        Assert.Equal("phone", field);
+    }
+
+    [Fact]
+    public async Task Signup_WithAContactEmailAlreadyRegistered_IsRejectedNamingTheContactEmail()
+    {
+        string takenEmail = ApiFactory.UniqueContactEmail();
+
+        (HttpStatusCode first, _) = await SignupAnswerFor(
+            SignupPayload(new[] { new { phone = ApiFactory.UniquePhone(), contactEmail = takenEmail } }));
+
+        Assert.Equal(HttpStatusCode.Created, first);
+
+        (HttpStatusCode second, string? field) = await SignupAnswerFor(
+            SignupPayload(new[] { new { phone = ApiFactory.UniquePhone(), contactEmail = takenEmail } }));
+
+        Assert.Equal(HttpStatusCode.Conflict, second);
+        Assert.Equal("contactEmail", field);
+    }
+
+    [Fact]
+    public async Task Signup_RepeatingThePhoneWithinTheSameRequest_IsRejectedNamingThePhone()
+    {
+        string repeated = ApiFactory.UniquePhone();
+
+        (HttpStatusCode statusCode, string? field) = await SignupAnswerFor(SignupPayload(new[]
+        {
+            new { phone = repeated, contactEmail = ApiFactory.UniqueContactEmail() },
+            new { phone = repeated, contactEmail = ApiFactory.UniqueContactEmail() },
+        }));
+
+        Assert.Equal(HttpStatusCode.Conflict, statusCode);
+        Assert.Equal("phone", field);
     }
 }

--- a/FateConnect/FateConnect.Api.Tests/UnderPostingTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/UnderPostingTests.cs
@@ -23,7 +23,7 @@ public class UnderPostingTests : IClassFixture<ApiFactory>
         {
             new { zipCode = "18040-430", street = "Rua Cesário Mota", streetNumber = "1", complement = "Casa", city = "Sorocaba", state = "SP" },
         },
-        ["contacts"] = new[] { new { phone = "15999990000", contactEmail = "mariana.rocha@gmail.com" } },
+        ["contacts"] = new[] { new { phone = ApiFactory.UniquePhone(), contactEmail = ApiFactory.UniqueContactEmail() } },
     };
 
     [Fact]

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/FateConnectDbContext.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/FateConnectDbContext.cs
@@ -51,6 +51,9 @@ public class FateConnectDbContext(DbContextOptions<FateConnectDbContext> options
             entity.Property(c => c.Phone).IsRequired().HasMaxLength(11);
             entity.Property(c => c.ContactEmail).IsRequired().HasMaxLength(150);
 
+            entity.HasIndex(c => c.Phone).IsUnique();
+            entity.HasIndex(c => c.ContactEmail).IsUnique();
+
             entity.HasOne(c => c.User)
                   .WithMany(u => u.Contacts)
                   .HasForeignKey(c => c.UserId)

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260902105230_AddUniqueContactIndexes.Designer.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260902105230_AddUniqueContactIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FateConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FateConnect.Api.Infrastructure.Database.Migrations
 {
     [DbContext(typeof(FateConnectDbContext))]
-    partial class FateConnectDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260902105230_AddUniqueContactIndexes")]
+    partial class AddUniqueContactIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260902105230_AddUniqueContactIndexes.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260902105230_AddUniqueContactIndexes.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FateConnect.Api.Infrastructure.Database.Migrations
+{
+    public partial class AddUniqueContactIndexes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(DuplicatedContactCleanup.Sql);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Contacts_ContactEmail",
+                table: "Contacts",
+                column: "ContactEmail",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Contacts_Phone",
+                table: "Contacts",
+                column: "Phone",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Contacts_ContactEmail",
+                table: "Contacts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Contacts_Phone",
+                table: "Contacts");
+        }
+    }
+}

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/DuplicatedContactCleanup.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/DuplicatedContactCleanup.cs
@@ -1,0 +1,20 @@
+namespace FateConnect.Api.Infrastructure.Database.Migrations;
+
+public static class DuplicatedContactCleanup
+{
+    public const string Sql = """
+        CREATE TEMP TABLE duplicated_contact_users AS
+        SELECT DISTINCT "UserId"
+        FROM "Contacts"
+        WHERE "Id" NOT IN (SELECT MIN("Id") FROM "Contacts" GROUP BY "Phone")
+           OR "Id" NOT IN (SELECT MIN("Id") FROM "Contacts" GROUP BY "ContactEmail");
+
+        DELETE FROM "Rides"
+        WHERE "DriverId" IN (SELECT "UserId" FROM duplicated_contact_users);
+
+        DELETE FROM "Users"
+        WHERE "Id" IN (SELECT "UserId" FROM duplicated_contact_users);
+
+        DROP TABLE duplicated_contact_users;
+        """;
+}

--- a/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
@@ -27,6 +27,7 @@ public partial class GlobalExceptionMiddleware(
     {
         var statusCode = HttpStatusCode.InternalServerError;
         var errorMessage = "Algo deu errado. Tente novamente.";
+        string? conflictingField = null;
 
         switch (exception)
         {
@@ -40,9 +41,10 @@ public partial class GlobalExceptionMiddleware(
                 errorMessage = ex.Message;
                 break;
 
-            case EmailAlreadyRegisteredException ex:
+            case AlreadyRegisteredException ex:
                 statusCode = HttpStatusCode.Conflict;
                 errorMessage = ex.Message;
+                conflictingField = ex.Field;
                 break;
 
             case UnidentifiedUserException or InvalidCredentialsException:
@@ -64,7 +66,9 @@ public partial class GlobalExceptionMiddleware(
         context.Response.ContentType = "application/json";
         context.Response.StatusCode = (int)statusCode;
 
-        await context.Response.WriteAsJsonAsync(new ErrorResponseDto { Error = errorMessage }, context.RequestAborted);
+        await context.Response.WriteAsJsonAsync(
+            new ErrorResponseDto { Error = errorMessage, Field = conflictingField },
+            context.RequestAborted);
     }
 
     [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "Unhandled internal server error occurred.")]

--- a/FateConnect/FateConnect.Api/Modules/Common/DTOs/ErrorResponseDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Common/DTOs/ErrorResponseDto.cs
@@ -8,4 +8,7 @@ public class ErrorResponseDto
     [Required]
     [DefaultValue("O e-mail informado já está em uso no sistema.")]
     public string Error { get; set; } = string.Empty;
+
+    [DefaultValue("fatecEmail")]
+    public string? Field { get; set; }
 }

--- a/FateConnect/FateConnect.Api/Modules/Users/Exceptions/AlreadyRegisteredException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Exceptions/AlreadyRegisteredException.cs
@@ -1,0 +1,12 @@
+namespace FateConnect.Api.Modules.Users.Exceptions;
+
+public abstract class AlreadyRegisteredException : InvalidOperationException
+{
+    protected AlreadyRegisteredException(string field, string message)
+        : base(message)
+    {
+        Field = field;
+    }
+
+    public string Field { get; }
+}

--- a/FateConnect/FateConnect.Api/Modules/Users/Exceptions/ContactEmailAlreadyRegisteredException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Exceptions/ContactEmailAlreadyRegisteredException.cs
@@ -1,0 +1,9 @@
+namespace FateConnect.Api.Modules.Users.Exceptions;
+
+public class ContactEmailAlreadyRegisteredException : AlreadyRegisteredException
+{
+    public ContactEmailAlreadyRegisteredException(string contactEmail)
+        : base("contactEmail", $"O e-mail de contato '{contactEmail}' já está em uso no sistema.")
+    {
+    }
+}

--- a/FateConnect/FateConnect.Api/Modules/Users/Exceptions/ContactPhoneAlreadyRegisteredException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Exceptions/ContactPhoneAlreadyRegisteredException.cs
@@ -1,0 +1,9 @@
+namespace FateConnect.Api.Modules.Users.Exceptions;
+
+public class ContactPhoneAlreadyRegisteredException : AlreadyRegisteredException
+{
+    public ContactPhoneAlreadyRegisteredException(string phone)
+        : base("phone", $"O telefone '{phone}' já está em uso no sistema.")
+    {
+    }
+}

--- a/FateConnect/FateConnect.Api/Modules/Users/Exceptions/EmailAlreadyRegisteredException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Exceptions/EmailAlreadyRegisteredException.cs
@@ -1,9 +1,9 @@
 namespace FateConnect.Api.Modules.Users.Exceptions;
 
-public class EmailAlreadyRegisteredException : InvalidOperationException
+public class EmailAlreadyRegisteredException : AlreadyRegisteredException
 {
     public EmailAlreadyRegisteredException(string email)
-        : base($"O e-mail '{email}' já está em uso no sistema.")
+        : base("fatecEmail", $"O e-mail '{email}' já está em uso no sistema.")
     {
     }
 }

--- a/FateConnect/FateConnect.Api/Modules/Users/Interfaces/IUserRepository.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Interfaces/IUserRepository.cs
@@ -5,6 +5,8 @@ namespace FateConnect.Api.Modules.Users.Interfaces;
 public interface IUserRepository
 {
     Task<bool> EmailExistsAsync(string email);
+    Task<bool> ContactPhoneExistsAsync(string phone);
+    Task<bool> ContactEmailExistsAsync(string contactEmail);
     Task<User?> GetByEmailAsync(string email);
     Task AddAsync(User user);
 }

--- a/FateConnect/FateConnect.Api/Modules/Users/Repositories/UserRepository.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Repositories/UserRepository.cs
@@ -19,6 +19,16 @@ public class UserRepository : IUserRepository
         return await _context.Users.AnyAsync(u => u.FatecEmail == email);
     }
 
+    public async Task<bool> ContactPhoneExistsAsync(string phone)
+    {
+        return await _context.Contacts.AnyAsync(c => c.Phone == phone);
+    }
+
+    public async Task<bool> ContactEmailExistsAsync(string contactEmail)
+    {
+        return await _context.Contacts.AnyAsync(c => c.ContactEmail == contactEmail);
+    }
+
     public async Task<User?> GetByEmailAsync(string email)
     {
         return await _context.Users.FirstOrDefaultAsync(u => u.FatecEmail == email);

--- a/FateConnect/FateConnect.Api/Modules/Users/Services/UserService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Services/UserService.cs
@@ -24,6 +24,7 @@ public class UserService : IUserService
     public async Task<TokenResponseDto> SignUpAsync(CreateUserDto dto)
     {
         await EnsureEmailIsUniqueAsync(dto.FatecEmail);
+        await EnsureContactsAreUniqueAsync(dto.Contacts);
 
         User newUser = BuildUser(dto);
 
@@ -40,6 +41,25 @@ public class UserService : IUserService
 
         if (emailInUse)
             throw new EmailAlreadyRegisteredException(email);
+    }
+
+    private async Task EnsureContactsAreUniqueAsync(List<CreateContactDto> dtos)
+    {
+        HashSet<string> phonesInRequest = [];
+        HashSet<string> emailsInRequest = [];
+
+        foreach (CreateContactDto dto in dtos)
+        {
+            bool phoneRepeatedInRequest = !phonesInRequest.Add(dto.Phone);
+
+            if (phoneRepeatedInRequest || await _userRepository.ContactPhoneExistsAsync(dto.Phone))
+                throw new ContactPhoneAlreadyRegisteredException(dto.Phone);
+
+            bool emailRepeatedInRequest = !emailsInRequest.Add(dto.ContactEmail);
+
+            if (emailRepeatedInRequest || await _userRepository.ContactEmailExistsAsync(dto.ContactEmail))
+                throw new ContactEmailAlreadyRegisteredException(dto.ContactEmail);
+        }
     }
 
     private static User BuildUser(CreateUserDto dto)


### PR DESCRIPTION
> Sai da branch da #255 e aponta para ela, porque as duas mexem no mesmo módulo e na mesma sequência de migrações. O diff próprio deste PR são os três commits de cima.

## Objetivo

O cadastro conferia se o e-mail de login já existia, mas não olhava o contato: duas pessoas podiam se cadastrar com o mesmo telefone e o mesmo e-mail de contato, e a partir daí não havia como saber quem responde por aquele número.

## Alterações

**A recusa.** O cadastro passa a responder **409** quando o telefone ou o e-mail de contato já pertence a outra pessoa — o mesmo status que o e-mail de login já respondia. A checagem cobre também o **mesmo contato repetido dentro da própria requisição**: isso não estava no escopo, mas passou a ser possível quebrar, porque dois contatos iguais no mesmo corpo bateriam no índice novo e virariam **500** em vez de 409.

**O corpo do erro passa a dizer qual campo.** Ele era `{ error }` e passa a ser `{ error, field }`, com `field` valendo `fatecEmail`, `phone` ou `contactEmail` — os mesmos nomes que a requisição usa. Erro sem campo associado continua respondendo só `error`. Sem isso a tela não teria como apontar o erro no campo certo, e casar substring da mensagem deixaria o tratamento preso à redação da copy.

**A unicidade no banco**, com índice único nos dois campos, e a limpeza que os cadastros existentes exigem.

## A limpeza da migração

O índice único **falha ao aplicar** se a base já tiver duplicata, e aí a API sobe com erro de migração e sai do ar. A limpeza roda antes de criar os índices: mantém o cadastro mais antigo e apaga o mais novo por inteiro.

⚠️ **É perda de dado**, decidida com a consequência à vista. E ela alcança mais do que os contatos: `Rides.DriverId` tem `OnDelete(Restrict)`, então apagar um usuário que ofertou carona **falha** — a limpeza apaga as caronas dele primeiro, e endereços e contatos vão por cascade.

Produção não tem usuário, então na prática a limpeza só alcança homologação.

## Como isso foi provado

⛔ Uma limpeza destrutiva que nenhum teste exercita é a pior coisa para entrar num deploy: o banco de teste nasce vazio, então o caminho da limpeza nunca rodaria sozinho.

O teste força a situação: derruba o índice, semeia dois usuários com o mesmo telefone, dá uma carona ao mais novo, roda o SQL e confere que o antigo fica, o mais novo sai e a carona sai. O SQL mora numa constante que a migração e o teste compartilham, então o teste não exercita uma cópia.

**Controle positivo:** removendo só o `DELETE FROM "Rides"` do SQL, o teste falha com exatamente o erro que derrubaria o deploy —

```
23503: update or delete on table "Users" violates foreign key constraint "FK_Rides_Users_DriverId"
```

A migração inteira também roda a cada execução da suíte, porque a aplicação aplica migrações na subida e a fábrica de teste sobe a aplicação contra um PostgreSQL em contêiner.

## Efeito na tela, até a #256 entrar

O `Signup` de hoje mapeia **qualquer 409** para a mensagem fixa "e-mail já cadastrado", ignorando a resposta do servidor. Então, enquanto a #256 não entrar, um telefone repetido aparece na tela com a copy errada. É o que ela conserta, usando o `field`.

## Gates

Build 0 erros e 0 warnings; **94 testes** contra contêiner real (eram 87). Cada um dos três commits foi montado por replay e passa sozinho.

## Issue

- #253

Closes #253

## Evidências
