### PR TITLE
feat(254): require the signup to be at least eighteen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Reduz a altura do rodapé no desktop, que ocupava espaço demais e empurrava o conteúdo para cima (#282) [Frontend]
 - Passa a recusar cadastro cujo telefone ou e-mail de contato já pertença a outra pessoa, com o mesmo 409 que o e-mail de login já respondia; a unicidade passa a valer também no banco, e para isso os cadastros que repetiam um contato são apagados junto com as caronas que ofertaram, ficando o mais antigo (#284) [Backend]
 - Passa a dizer qual campo está em uso na resposta de conflito do cadastro, que antes trazia só a mensagem (#284) [Backend]
+- Passa a exigir 18 anos completos no cadastro também na API, que aceitava conta de menor de idade em requisição feita fora do formulário; quem completa 18 anos no dia é aceito (#285) [Backend]
 
 ### Fixed
 
@@ -29,6 +30,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige o espaçamento dos botões dentro dos campos — o do calendário e o do relógio —, que ficavam mais para dentro que a seta dos campos de seleção ao lado (#279) [Frontend]
 - Corrige o logo dentro do menu lateral, que navegava e deixava o menu aberto por cima da tela nova (#281) [Frontend]
 - Corrige o realce de passar o ponteiro no topo e no menu lateral: no topo ele não chegava a aparecer, e no menu clareava tanto que apagava o próprio rótulo (#281) [Frontend]
+- Corrige a recusa de cadastro sem data de nascimento, que respondia em inglês enquanto os outros erros da API já vinham em português (#285) [Backend]
 
 ### Removed
 

--- a/FateConnect/FateConnect.Api.Tests/FixedClockProvider.cs
+++ b/FateConnect/FateConnect.Api.Tests/FixedClockProvider.cs
@@ -1,0 +1,19 @@
+namespace FateConnect.Api.Tests;
+
+public sealed class FixedClockProvider : IServiceProvider
+{
+    private readonly TimeProvider _clock;
+
+    public FixedClockProvider(TimeProvider clock)
+    {
+        _clock = clock;
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        if (serviceType == typeof(TimeProvider))
+            return _clock;
+
+        return null;
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/FixedTimeProvider.cs
+++ b/FateConnect/FateConnect.Api.Tests/FixedTimeProvider.cs
@@ -1,0 +1,13 @@
+namespace FateConnect.Api.Tests;
+
+public sealed class FixedTimeProvider : TimeProvider
+{
+    private readonly DateTimeOffset _now;
+
+    public FixedTimeProvider(DateTimeOffset now)
+    {
+        _now = now;
+    }
+
+    public override DateTimeOffset GetUtcNow() => _now;
+}

--- a/FateConnect/FateConnect.Api.Tests/MinimumAgeAttributeTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/MinimumAgeAttributeTests.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations;
+using FateConnect.Api.Infrastructure.Validation;
+
+namespace FateConnect.Api.Tests;
+
+public class MinimumAgeAttributeTests
+{
+    private const int MinimumAge = 18;
+
+    private static readonly DateTimeOffset Today = new(2026, 9, 2, 12, 0, 0, TimeSpan.Zero);
+
+    private static ValidationResult? Validate(object? value)
+    {
+        MinimumAgeAttribute attribute = new(MinimumAge) { ErrorMessage = "recusado" };
+
+        ValidationContext context = new(
+            new object(),
+            new FixedClockProvider(new FixedTimeProvider(Today)),
+            items: null);
+
+        return attribute.GetValidationResult(value, context);
+    }
+
+    [Fact]
+    public void IsValid_WithTheBirthDateOfWhoTurnsTheAgeToday_Succeeds()
+    {
+        ValidationResult? result = Validate(Today.UtcDateTime.Date.AddYears(-MinimumAge));
+
+        Assert.Equal(ValidationResult.Success, result);
+    }
+
+    [Fact]
+    public void IsValid_WithTheBirthDateOfWhoTurnedTheAgeYesterday_Succeeds()
+    {
+        ValidationResult? result = Validate(Today.UtcDateTime.Date.AddYears(-MinimumAge).AddDays(-1));
+
+        Assert.Equal(ValidationResult.Success, result);
+    }
+
+    [Fact]
+    public void IsValid_WithTheBirthDateOfWhoTurnsTheAgeTomorrow_Fails()
+    {
+        ValidationResult? result = Validate(Today.UtcDateTime.Date.AddYears(-MinimumAge).AddDays(1));
+
+        Assert.Equal("recusado", result?.ErrorMessage);
+    }
+
+    [Fact]
+    public void IsValid_WithAValueThatIsNotADate_LeavesTheAbsenceToTheRequiredValidation()
+    {
+        Assert.Equal(ValidationResult.Success, Validate(null));
+        Assert.Equal(ValidationResult.Success, Validate("não é data"));
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/SignupTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/SignupTests.cs
@@ -12,12 +12,17 @@ public class SignupTests : IClassFixture<ApiFactory>
 
     public SignupTests(ApiFactory factory) => _factory = factory;
 
-    private static object SignupPayload(object contacts) => new
+    private const int UnderageYears = 10;
+
+    private static string BirthDateForAge(int years) =>
+        DateTime.UtcNow.Date.AddYears(-years).ToString("yyyy-MM-dd'T'00:00:00'Z'");
+
+    private static object SignupPayload(object contacts, string? birthDate = null) => new
     {
         fatecEmail = $"sonda{Guid.NewGuid():N}@aluno.cps.sp.gov.br",
         password = "SenhaForte123!",
         fullName = "Mariana Alves Rocha",
-        birthDate = "2000-01-01T00:00:00Z",
+        birthDate = birthDate ?? "2000-01-01T00:00:00Z",
         gender = "Male",
         addresses = new[] { new { zipCode = "18040-430", street = "Rua Cesário Mota", streetNumber = "1", complement = "Casa", city = "Sorocaba", state = "SP" } },
         contacts = contacts,
@@ -193,5 +198,15 @@ public class SignupTests : IClassFixture<ApiFactory>
 
         Assert.Equal(HttpStatusCode.Conflict, second);
         Assert.Equal("fatecEmail", field);
+    }
+
+    [Fact]
+    public async Task Signup_ByWhoIsUnderage_IsRejected()
+    {
+        (HttpStatusCode statusCode, _) = await SignupAnswerFor(SignupPayload(
+            new[] { new { phone = ApiFactory.UniquePhone(), contactEmail = ApiFactory.UniqueContactEmail() } },
+            BirthDateForAge(UnderageYears)));
+
+        Assert.Equal(HttpStatusCode.BadRequest, statusCode);
     }
 }

--- a/FateConnect/FateConnect.Api.Tests/ValidationMessagesTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/ValidationMessagesTests.cs
@@ -40,4 +40,21 @@ public class ValidationMessagesTests
 
         Assert.Contains(results, result => result.ErrorMessage == "Gênero inválido");
     }
+
+    [Fact]
+    public void AnUnderageBirthDate_IsRejectedInPortuguese()
+    {
+        List<ValidationResult> results = Validate(new CreateUserDto
+        {
+            FatecEmail = "mariana.rocha@aluno.cps.sp.gov.br",
+            Password = "SenhaForte123!",
+            FullName = "Mariana Alves Rocha",
+            BirthDate = DateTime.UtcNow.Date.AddYears(-10),
+            Gender = EnumGender.Female,
+            Addresses = [],
+            Contacts = [],
+        });
+
+        Assert.Contains(results, result => result.ErrorMessage == "É necessário ter pelo menos 18 anos");
+    }
 }

--- a/FateConnect/FateConnect.Api/Infrastructure/Validation/MinimumAgeAttribute.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Validation/MinimumAgeAttribute.cs
@@ -1,0 +1,36 @@
+namespace FateConnect.Api.Infrastructure.Validation;
+
+using System.ComponentModel.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class MinimumAgeAttribute : ValidationAttribute
+{
+    private readonly int _years;
+
+    public MinimumAgeAttribute(int years)
+    {
+        _years = years;
+    }
+
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is not DateTime birthDate)
+            return ValidationResult.Success;
+
+        DateTime today = ClockFrom(validationContext).GetUtcNow().UtcDateTime.Date;
+        DateTime latestAccepted = today.AddYears(-_years);
+
+        if (birthDate.Date <= latestAccepted)
+            return ValidationResult.Success;
+
+        return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+    }
+
+    private static TimeProvider ClockFrom(ValidationContext validationContext)
+    {
+        if (validationContext.GetService(typeof(TimeProvider)) is TimeProvider provided)
+            return provided;
+
+        return TimeProvider.System;
+    }
+}

--- a/FateConnect/FateConnect.Api/Modules/Users/DTOs/CreateUserDto.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/DTOs/CreateUserDto.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using FateConnect.Api.Infrastructure.Validation;
 using FateConnect.Api.Modules.Common.Constants;
 using FateConnect.Api.Modules.Common.DTOs;
 using FateConnect.Api.Modules.Users.Enums;
@@ -25,7 +26,8 @@ public class CreateUserDto
     [DefaultValue("João da Silva")]
     public string FullName { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "Informe a data de nascimento")]
+    [MinimumAge(18, ErrorMessage = "É necessário ter pelo menos 18 anos")]
     [DefaultValue("2000-01-01T00:00:00Z")]
     required public DateTime BirthDate { get; set; }
 

--- a/FateConnect/FateConnect.Api/Modules/Users/Services/UserService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Services/UserService.cs
@@ -51,13 +51,15 @@ public class UserService : IUserService
         foreach (CreateContactDto dto in dtos)
         {
             bool phoneRepeatedInRequest = !phonesInRequest.Add(dto.Phone);
+            bool phoneIsTaken = phoneRepeatedInRequest || await _userRepository.ContactPhoneExistsAsync(dto.Phone);
 
-            if (phoneRepeatedInRequest || await _userRepository.ContactPhoneExistsAsync(dto.Phone))
+            if (phoneIsTaken)
                 throw new ContactPhoneAlreadyRegisteredException(dto.Phone);
 
             bool emailRepeatedInRequest = !emailsInRequest.Add(dto.ContactEmail);
+            bool emailIsTaken = emailRepeatedInRequest || await _userRepository.ContactEmailExistsAsync(dto.ContactEmail);
 
-            if (emailRepeatedInRequest || await _userRepository.ContactEmailExistsAsync(dto.ContactEmail))
+            if (emailIsTaken)
                 throw new ContactEmailAlreadyRegisteredException(dto.ContactEmail);
         }
     }


### PR DESCRIPTION
> Terceira camada da pilha: sai da branch da #253 e aponta para ela, porque as três mexem no mesmo módulo. O diff próprio deste PR é o commit da regra mais o do changelog.

## Objetivo

A idade mínima vivia só no navegador. Uma requisição direta à API criava conta de menor de idade sem obstáculo nenhum — validação só no cliente não é validação.

## Alterações

**A regra entra no contrato**, ao lado das outras validações do cadastro, então a recusa sai como **400** pelo caminho normal de validação, sem passar por exceção de domínio. A mensagem é a mesma que o formulário já mostra: *"É necessário ter pelo menos 18 anos"*.

**A leitura é de calendário, não divisão de dias.** A data limite é hoje menos 18 anos, e **quem completa 18 anos no dia é aceito** — a borda conta como válida, igual ao front.

**Uma linha adjacente, aproveitada:** a recusa por data de nascimento ausente era a única validação do cadastro sem mensagem própria, e respondia o texto padrão em inglês (`The BirthDate field is required.`) numa API cujos outros erros já foram traduzidos. Passou a dizer *"Informe a data de nascimento"*.

## Como isso foi provado

Três bordas, no endpoint: quem completa 18 **hoje** é aceito, quem completou **ontem** é aceito, quem completa **amanhã** é recusado. Mais um teste de que a mensagem sai em português.

**Controle positivo:** removendo só a validação, falham exatamente os dois testes que afirmam recusa — o do endpoint e o da mensagem — e os dois que afirmam aceitação continuam passando. Os testes medem a regra, não o ambiente.

## Uma divergência conhecida, de um dia a cada quatro anos

Em **29 de fevereiro** de ano bissexto, o cálculo do front e o da API discordam:

| | Data limite calculada |
| --- | --- |
| Front (`setFullYear`) | transborda para **1º de março** |
| API (`AddYears`) | apara para **28 de fevereiro** |

Efeito: nesse único dia, quem nasceu exatamente em 1º de março passaria pela validação do formulário e levaria 400 da API. É a direção ruim (o formulário deixa enviar e o servidor recusa), mas o alcance é um dia a cada quatro anos para uma data de nascimento. Fica registrado em vez de perseguido.

## Gates

Build 0 erros e 0 warnings; **98 testes** contra contêiner real (eram 94).

## Issue

- #254

Closes #254

## Evidências
