### PR TITLE
fix(256): drop the nickname and point the signup conflict at its field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Passa a recusar cadastro cujo telefone ou e-mail de contato já pertença a outra pessoa, com o mesmo 409 que o e-mail de login já respondia; a unicidade passa a valer também no banco, e para isso os cadastros que repetiam um contato são apagados junto com as caronas que ofertaram, ficando o mais antigo (#284) [Backend]
 - Passa a dizer qual campo está em uso na resposta de conflito do cadastro, que antes trazia só a mensagem (#284) [Backend]
 - Passa a exigir 18 anos completos no cadastro também na API, que aceitava conta de menor de idade em requisição feita fora do formulário; quem completa 18 anos no dia é aceito (#285) [Backend]
+- Passa a distribuir os campos da conta em dois por linha no cadastro — nascimento com gênero, e-mail com senha —, em vez de três (#287) [Frontend]
 
 ### Fixed
 
@@ -31,10 +32,12 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige o logo dentro do menu lateral, que navegava e deixava o menu aberto por cima da tela nova (#281) [Frontend]
 - Corrige o realce de passar o ponteiro no topo e no menu lateral: no topo ele não chegava a aparecer, e no menu clareava tanto que apagava o próprio rótulo (#281) [Frontend]
 - Corrige a recusa de cadastro sem data de nascimento, que respondia em inglês enquanto os outros erros da API já vinham em português (#285) [Backend]
+- Corrige o erro de cadastro já em uso, que avisava sempre sobre o e-mail mesmo quando o repetido era o telefone; agora ele aparece embaixo do campo certo, que recebe o foco (#287) [Frontend]
 
 ### Removed
 
 - Remove o apelido do cadastro: o campo sai do contrato e do banco, e a requisição que ainda o mande é aceita com o valor descartado. A coluna é apagada, então o apelido de quem já se cadastrou se perde (#283) [Backend]
+- Remove o campo de apelido do formulário de cadastro, que era opcional e não aparecia em nenhuma tela (#287) [Frontend]
 
 ## [0.7.0] - 2026-08-31
 

--- a/FateConnect/Web/src/pages/Signup/@types/index.ts
+++ b/FateConnect/Web/src/pages/Signup/@types/index.ts
@@ -4,3 +4,10 @@ export enum GenderValueEnum {
   FEMALE = 'Female',
   OTHER = 'Other',
 }
+
+/** Campo que a API nomeia no conflito de cadastro — o texto é o do contrato. */
+export enum SignupConflictFieldEnum {
+  FATEC_EMAIL = 'fatecEmail',
+  PHONE = 'phone',
+  CONTACT_EMAIL = 'contactEmail',
+}

--- a/FateConnect/Web/src/pages/Signup/Signup.test.tsx
+++ b/FateConnect/Web/src/pages/Signup/Signup.test.tsx
@@ -9,6 +9,7 @@ import { RoutePathEnum } from '@app/routes/paths';
 import { tokenStorage } from '@app/services/auth/tokenStorage';
 import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 
+import { SignupConflictFieldEnum } from './@types';
 import { PASSWORD_TOGGLE_LABEL } from './components/AccountSection/constants';
 import { SIGNUP_MESSAGES } from './schema';
 import * as C from './constants';
@@ -330,6 +331,26 @@ describe('Signup', () => {
 
     expect(await screen.findByText(message)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: C.SUBMIT_LABEL })).toBeEnabled();
+  });
+
+  it.each([
+    [SignupConflictFieldEnum.FATEC_EMAIL, /E-mail Fatec/],
+    [SignupConflictFieldEnum.PHONE, /Telefone/],
+    [SignupConflictFieldEnum.CONTACT_EMAIL, /E-mail para contato/],
+  ])('should point the conflict of %s at its own field', async (field, label) => {
+    server.use(
+      http.post(SIGNUP_URL, () =>
+        HttpResponse.json({ error: 'já está em uso no sistema', field }, { status: 409 }),
+      ),
+    );
+    renderSignup();
+    await fillRequiredFields();
+
+    await submit();
+
+    expect(await screen.findByText(C.SIGNUP_CONFLICT_MESSAGES[field])).toBeInTheDocument();
+    expect(screen.getByLabelText(label)).toHaveFocus();
+    expect(screen.queryByText(C.SIGNUP_ERROR_MESSAGES.emailTaken)).not.toBeInTheDocument();
   });
 
   it('should disable the form while the account is being created', async () => {

--- a/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
@@ -36,16 +36,6 @@ export function AccountSection() {
 
       <S.ThirdWidthCell>
         <Input
-          {...register('nickname')}
-          label={FIELD_LABELS.nickname}
-          fullWidth
-          type="text"
-          autoComplete="nickname"
-        />
-      </S.ThirdWidthCell>
-
-      <S.ThirdWidthCell>
-        <Input
           {...register('fatecEmail')}
           label={FIELD_LABELS.fatecEmail}
           required

--- a/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/AccountSection/index.tsx
@@ -34,24 +34,11 @@ export function AccountSection() {
         />
       </S.FullWidthCell>
 
-      <S.ThirdWidthCell>
-        <Input
-          {...register('fatecEmail')}
-          label={FIELD_LABELS.fatecEmail}
-          required
-          fullWidth
-          type="email"
-          autoComplete="work email"
-          placeholder={FIELD_PLACEHOLDERS.fatecEmail}
-          error={errors.fatecEmail?.message}
-        />
-      </S.ThirdWidthCell>
-
-      <S.ThirdWidthCell>
+      <S.HalfWidthCell>
         <BirthDateField />
-      </S.ThirdWidthCell>
+      </S.HalfWidthCell>
 
-      <S.ThirdWidthCell>
+      <S.HalfWidthCell>
         <Controller
           name="gender"
           control={control}
@@ -66,9 +53,22 @@ export function AccountSection() {
             />
           )}
         />
-      </S.ThirdWidthCell>
+      </S.HalfWidthCell>
 
-      <S.ThirdWidthCell>
+      <S.HalfWidthCell>
+        <Input
+          {...register('fatecEmail')}
+          label={FIELD_LABELS.fatecEmail}
+          required
+          fullWidth
+          type="email"
+          autoComplete="work email"
+          placeholder={FIELD_PLACEHOLDERS.fatecEmail}
+          error={errors.fatecEmail?.message}
+        />
+      </S.HalfWidthCell>
+
+      <S.HalfWidthCell>
         <Input
           {...register('password')}
           label={FIELD_LABELS.password}
@@ -89,7 +89,7 @@ export function AccountSection() {
             </IconButton>
           }
         />
-      </S.ThirdWidthCell>
+      </S.HalfWidthCell>
     </>
   );
 }

--- a/FateConnect/Web/src/pages/Signup/components/AccountSection/styles.ts
+++ b/FateConnect/Web/src/pages/Signup/components/AccountSection/styles.ts
@@ -6,9 +6,9 @@ export const FullWidthCell = styled(Box)({
   width: '100%',
 });
 
-/** Um terço da linha no desktop: 2 de 6 colunas. */
-export const ThirdWidthCell = styled(Box)(({ theme }) => ({
+/** Metade da linha no desktop: 3 de 6 colunas. */
+export const HalfWidthCell = styled(Box)(({ theme }) => ({
   width: '100%',
 
-  [theme.breakpoints.up('md')]: { gridColumn: 'span 2' },
+  [theme.breakpoints.up('md')]: { gridColumn: 'span 3' },
 }));

--- a/FateConnect/Web/src/pages/Signup/constants/index.ts
+++ b/FateConnect/Web/src/pages/Signup/constants/index.ts
@@ -4,7 +4,6 @@ export const CONTACT_SECTION_TITLE = 'Dados para contato';
 
 export const FIELD_LABELS = {
   fullName: 'Nome completo',
-  nickname: 'Apelido',
   fatecEmail: 'E-mail Fatec',
   birthDate: 'Data de nascimento',
   gender: 'Gênero',

--- a/FateConnect/Web/src/pages/Signup/constants/index.ts
+++ b/FateConnect/Web/src/pages/Signup/constants/index.ts
@@ -1,3 +1,5 @@
+import { SignupConflictFieldEnum } from '../@types';
+
 export const SIGNUP_TITLE = 'Criar conta';
 export const ADDRESS_SECTION_TITLE = 'Endereço';
 export const CONTACT_SECTION_TITLE = 'Dados para contato';
@@ -35,6 +37,12 @@ export const SIGNUP_ERROR_MESSAGES = {
   emailTaken: 'Este e-mail já está em uso. Entre com ele ou use outro endereço.',
   invalidData: 'Dados inválidos. Verifique os campos preenchidos.',
   generic: 'Erro ao realizar cadastro. Tente novamente.',
+};
+
+export const SIGNUP_CONFLICT_MESSAGES: Record<SignupConflictFieldEnum, string> = {
+  [SignupConflictFieldEnum.FATEC_EMAIL]: 'E-mail já cadastrado — entre com ele',
+  [SignupConflictFieldEnum.PHONE]: 'Telefone já cadastrado',
+  [SignupConflictFieldEnum.CONTACT_EMAIL]: 'E-mail já cadastrado',
 };
 
 export const ZIP_LOOKUP_MESSAGES = {

--- a/FateConnect/Web/src/pages/Signup/helpers/conflictField.ts
+++ b/FateConnect/Web/src/pages/Signup/helpers/conflictField.ts
@@ -1,0 +1,23 @@
+import type { ApiError } from '@app/services/httpClient';
+
+import { SignupConflictFieldEnum } from '../@types';
+
+const CONFLICT = 409;
+
+const CONFLICT_FIELDS: ReadonlySet<string> = new Set(Object.values(SignupConflictFieldEnum));
+
+function isConflictField(value: string): value is SignupConflictFieldEnum {
+  return CONFLICT_FIELDS.has(value);
+}
+
+/**
+ * `null` cobre o 409 sem campo reconhecido — é o que a API responde antes de
+ * publicar a versão que nomeia o campo, e aí o aviso solto ainda vale.
+ */
+export function conflictFieldOf(error: ApiError): SignupConflictFieldEnum | null {
+  if (error.status !== CONFLICT) return null;
+  if (!error.field) return null;
+  if (!isConflictField(error.field)) return null;
+
+  return error.field;
+}

--- a/FateConnect/Web/src/pages/Signup/helpers/mapper.test.ts
+++ b/FateConnect/Web/src/pages/Signup/helpers/mapper.test.ts
@@ -5,7 +5,6 @@ import { toSignupRequest } from './mapper';
 const FILLED: SignupFormValues = {
   ...SIGNUP_DEFAULT_VALUES,
   fullName: 'Maria Silva',
-  nickname: 'Mari',
   fatecEmail: 'maria.silva@aluno.cps.sp.gov.br',
   password: 'segredo123',
   birthDate: '22/05/1999',
@@ -26,17 +25,9 @@ describe('toSignupRequest', () => {
     const request = toSignupRequest(FILLED);
 
     expect(request.fullName).toBe('Maria Silva');
-    expect(request.nickname).toBe('Mari');
     expect(request.fatecEmail).toBe('maria.silva@aluno.cps.sp.gov.br');
     expect(request.birthDate).toContain('1999-05-22');
     expect(request.gender).toBe(GenderValueEnum.FEMALE);
-  });
-
-  // O backend prefere a ausência da chave a uma string vazia.
-  it('should omit the optional nickname instead of sending it empty', () => {
-    const request = toSignupRequest({ ...FILLED, nickname: '' });
-
-    expect(request.nickname).toBeUndefined();
   });
 
   // A API documenta o CEP com o hífen e o telefone só com dígitos.

--- a/FateConnect/Web/src/pages/Signup/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/Signup/helpers/mapper.ts
@@ -5,13 +5,6 @@ import type { SignupRequest } from '@app/services/signup/types';
 import type { SignupFormValues } from '../schema';
 import { parseBirthDate, toApiBirthDate } from './birthDate';
 
-/** Campo opcional: o backend prefere a ausência da chave a uma string vazia. */
-function optionalText(value: string): string | undefined {
-  if (value === '') return undefined;
-
-  return value;
-}
-
 /** O schema já garantiu a data; o vazio só existe para o tipo fechar. */
 function toApiBirthDateOrEmpty(value: string): string {
   const parsed = parseBirthDate(value);
@@ -23,7 +16,6 @@ function toApiBirthDateOrEmpty(value: string): string {
 export function toSignupRequest(values: SignupFormValues): SignupRequest {
   return {
     fullName: values.fullName,
-    nickname: optionalText(values.nickname),
     fatecEmail: values.fatecEmail,
     password: values.password,
     birthDate: toApiBirthDateOrEmpty(values.birthDate),

--- a/FateConnect/Web/src/pages/Signup/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/index.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { Link as RouterLink, useNavigate } from 'react-router';
 import { Button, Typography } from '@design-system';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -6,13 +7,14 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { useNotification } from '@app/hooks/useNotification';
 import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
-import type { ApiError } from '@app/services/httpClient';
+import { ApiError } from '@app/services/httpClient';
 import { signup } from '@app/services/signup/signupService';
 
 import { AccountSection } from './components/AccountSection';
 import { AddressSection } from './components/AddressSection';
 import { ConsentSection } from './components/ConsentSection';
 import { ContactSection } from './components/ContactSection';
+import { conflictFieldOf } from './helpers/conflictField';
 import { toSignupRequest } from './helpers/mapper';
 import { SIGNUP_DEFAULT_VALUES, signupSchema, type SignupFormValues } from './schema';
 import * as C from './constants';
@@ -34,7 +36,7 @@ export function Signup() {
   const navigate = useNavigate();
   const { notifySuccess, notifyError } = useNotification();
 
-  const { mutate, isPending } = useMutation({
+  const { mutateAsync, isPending } = useMutation({
     mutationFn: signup,
     // A mensagem depende do status; o aviso sai daqui, não do tratamento global.
     meta: { notifiesErrorItself: true },
@@ -42,7 +44,6 @@ export function Signup() {
       notifySuccess(C.SIGNUP_SUCCESS_MESSAGE);
       navigate(RoutePathEnum.MENU);
     },
-    onError: (error: ApiError) => notifyError(errorMessageFor(error.status)),
   });
 
   const form = useForm<SignupFormValues>({
@@ -51,7 +52,32 @@ export function Signup() {
     disabled: isPending,
   });
 
-  const handleSubmit = form.handleSubmit((values) => mutate(toSignupRequest(values)));
+  const reportFailure = useCallback(
+    (error: unknown) => {
+      if (!(error instanceof ApiError)) {
+        notifyError(C.SIGNUP_ERROR_MESSAGES.generic);
+        return;
+      }
+
+      const field = conflictFieldOf(error);
+
+      if (field) {
+        form.setError(field, { message: C.SIGNUP_CONFLICT_MESSAGES[field] }, { shouldFocus: true });
+        return;
+      }
+
+      notifyError(errorMessageFor(error.status));
+    },
+    [form, notifyError],
+  );
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      await mutateAsync(toSignupRequest(values));
+    } catch (error) {
+      reportFailure(error);
+    }
+  });
 
   return (
     <S.PageRoot>

--- a/FateConnect/Web/src/pages/Signup/schema/index.ts
+++ b/FateConnect/Web/src/pages/Signup/schema/index.ts
@@ -64,7 +64,6 @@ function hasBrazilianPhoneLength(value: string): boolean {
 
 export const signupSchema = z.object({
   fullName: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.fullNameRequired),
-  nickname: z.string(),
   fatecEmail: z
     .string()
     .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.fatecEmailRequired)
@@ -104,7 +103,6 @@ export type SignupFormValues = z.infer<typeof signupSchema>;
 
 export const SIGNUP_DEFAULT_VALUES: SignupFormValues = {
   fullName: '',
-  nickname: '',
   fatecEmail: '',
   birthDate: '',
   gender: '',

--- a/FateConnect/Web/src/pages/Signup/schema/schema.test.ts
+++ b/FateConnect/Web/src/pages/Signup/schema/schema.test.ts
@@ -37,7 +37,7 @@ describe('signupSchema', () => {
   });
 
   it('should accept the form without the optional fields', () => {
-    const result = parse({ nickname: '', complement: '', acceptMarketing: false });
+    const result = parse({ complement: '', acceptMarketing: false });
 
     expect(result.success).toBe(true);
   });

--- a/FateConnect/Web/src/services/httpClient.ts
+++ b/FateConnect/Web/src/services/httpClient.ts
@@ -9,11 +9,14 @@ import { tokenStorage } from './auth/tokenStorage';
  */
 export class ApiError extends Error {
   readonly status?: number;
+  /** Campo que a API aponta como causa — hoje só o conflito de cadastro manda. */
+  readonly field?: string;
 
-  constructor(message: string, status?: number) {
+  constructor(message: string, status?: number, field?: string) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
+    this.field = field;
   }
 }
 
@@ -34,6 +37,18 @@ export const GENERIC_ERROR_MESSAGE = 'Algo deu errado. Tente novamente.';
 export const SESSION_EXPIRED_MESSAGE = 'Sessão expirada. Entre novamente para continuar.';
 
 const UNAUTHORIZED = 401;
+
+function hasField(body: unknown): body is { field: string } {
+  return (
+    typeof body === 'object' && body !== null && 'field' in body && typeof body.field === 'string'
+  );
+}
+
+function fieldOf(body: unknown): string | undefined {
+  if (!hasField(body)) return undefined;
+
+  return body.field;
+}
 
 function withInterceptors(client: AxiosInstance): AxiosInstance {
   client.interceptors.request.use((config) => {
@@ -66,7 +81,9 @@ function withInterceptors(client: AxiosInstance): AxiosInstance {
         return Promise.reject(new SessionExpiredError(error.response.status));
       }
 
-      return Promise.reject(new ApiError(GENERIC_ERROR_MESSAGE, error.response.status));
+      return Promise.reject(
+        new ApiError(GENERIC_ERROR_MESSAGE, error.response.status, fieldOf(error.response.data)),
+      );
     },
   );
 

--- a/FateConnect/Web/src/services/signup/types.ts
+++ b/FateConnect/Web/src/services/signup/types.ts
@@ -16,7 +16,6 @@ export type SignupRequest = {
   fatecEmail: string;
   password: string;
   fullName: string;
-  nickname?: string;
   birthDate: string;
   gender: string;
   addresses: SignupAddress[];


### PR DESCRIPTION
> Quarta camada da pilha: sai da branch da #254 e aponta para ela. O diff próprio deste PR são os quatro commits de cima.

## Objetivo

Fechar o par das mudanças da API no formulário: tirar o campo que deixou de existir e tratar os erros novos.

## Alterações

**O apelido sai do formulário** — campo, schema, valor inicial, rótulo, mapeamento, tipo do contrato e testes. Levou junto o helper `optionalText`, que existia **só** para ele e ficou sem chamador.

**O erro de "já cadastrado" passa a aparecer no campo**, que recebe o foco:

| Campo | Mensagem |
| --- | --- |
| Telefone | Telefone já cadastrado |
| E-mail para contato | E-mail já cadastrado |
| E-mail Fatec | E-mail já cadastrado — entre com ele |

Antes **qualquer** 409 virava o mesmo aviso solto — "Este e-mail já está em uso" —, inclusive quando o repetido era o telefone. E o formulário tem **dois** campos de e-mail, então o aviso não dizia qual dos dois.

Para isso o `ApiError` passou a carregar o `field` que a API nomeia: o cliente HTTP descartava o corpo inteiro dos erros que não são 401, então o front nunca via nada além do status.

**O aviso solto continua existindo como fallback**, para o 409 sem campo reconhecido — que é exatamente o que a API responde enquanto o #284 não está publicado.

**Os campos da conta passam a dividir a linha em dois:** nascimento com gênero, e-mail com senha. Tirar o apelido deixava a senha sozinha numa linha com dois terços vazios — medido a 1440px: 333px de campo num grid de 1030px.

## Medições

Layout, a 1440px: `Nome completo` em 1030px; `Data de nascimento` e `Gênero` em 507px cada; `E-mail Fatec` e `Senha` em 507px cada. Nenhum vão sobrando. A 409px tudo empilha em largura cheia, 275px por campo.

Comprimento da mensagem mais longa, na largura mais apertada (campo de 275px a 409px), com `measureText` na fonte real depois de `document.fonts.ready`:

| Texto | Largura |
| --- | --- |
| E-mail já cadastrado — entre com ele | **202px** |
| Telefone com DDD: 10 ou 11 dígitos *(a mais longa que já existia)* | 193,2px |

Cabe em uma linha, com 73px de folga.

## Como isso foi provado

Três casos de conflito, um por campo, afirmando que a mensagem aparece **e que o aviso não aparece**. **Controle positivo:** fazendo o helper deixar de reconhecer o campo, falham exatamente esses três e nenhum outro.

## Uma decisão revista no meio do caminho

A primeira versão deixava o e-mail Fatec **fora** do tratamento por campo, com o argumento de que a saída dele é entrar, não corrigir o campo. O argumento estava aplicado no lugar errado: ele fala da **saída**, não da natureza do erro — que é de campo nos três casos. E deixava sem marcação justamente o mais ambíguo dos três, num formulário com dois campos de e-mail. A saída diferente passou a viver no **texto** ("entre com ele"), e não na ausência de marca.

## Gates

ESLint e `tsc` limpos; **517 testes** na suíte inteira.

## Issue

- #256

Closes #256

## Evidências
<img width="1290" height="911" alt="image" src="https://github.com/user-attachments/assets/d6709845-2bb9-4f7b-ade6-f27e52957dc6" />
