### PR TITLE
docs: record that path-scoped rules load on Read, not on Bash

### DIFF
--- a/.claude/rules/dotnet-code-style.md
+++ b/.claude/rules/dotnet-code-style.md
@@ -91,7 +91,7 @@ if (phoneIsTaken)
 **O detector precisa ser o certo, senão ninguém o usa duas vezes.** Procurar o termo "colado a letra dos dois lados" devolve dezenas de camelCase legítimo (`isZipCodeFilled`, `mappedAddresses`); procurar o termo **seguido** de minúscula acusa todo plural (`Users`, `Addresses`). O que discrimina é **termo minúsculo precedido de letra minúscula** — fronteira que camelCase nunca produz.
 
 ```bash
-git diff <base>..HEAD | grep -E "^\+" | grep -oE '"[^"]*<termo-novo>[^"]*"'   # dentro de aspas
+rtk proxy git diff <base>..HEAD | grep -E "^\+" | grep -oE '"[^"]*<termo-novo>[^"]*"'   # dentro de aspas
 ```
 
 ## A rota do controller vem do nome da classe

--- a/.claude/rules/dotnet-code-style.md
+++ b/.claude/rules/dotnet-code-style.md
@@ -51,6 +51,31 @@ if (!int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId))
 
 ⚠️ **Condição que já se lê não ganha linha.** `if (ride is null)` e `if (!isValidUserId)` ficam como estão — a regra é sobre expressão que esconde o teste, não sobre proibir condição no `if`.
 
+⛔ **Nomear metade da disjunção não cumpre esta regra — cumpre pela metade.** É o caso mais difícil de enxergar, porque o nome que já está ali faz o `if` parecer revisado.
+
+⛔ Cobrado no review do PR #284, no `EnsureContactsAreUniqueAsync`: o primeiro operando tinha nome e o segundo entrava cru.
+
+```csharp
+bool phoneRepeatedInRequest = !phonesInRequest.Add(dto.Phone);
+
+if (phoneRepeatedInRequest || await _userRepository.ContactPhoneExistsAsync(dto.Phone))
+    throw new ContactPhoneAlreadyRegisteredException(dto.Phone);
+```
+
+O que ficou:
+
+```csharp
+bool phoneRepeatedInRequest = !phonesInRequest.Add(dto.Phone);
+bool phoneIsTaken = phoneRepeatedInRequest || await _userRepository.ContactPhoneExistsAsync(dto.Phone);
+
+if (phoneIsTaken)
+    throw new ContactPhoneAlreadyRegisteredException(dto.Phone);
+```
+
+**O nome cobre os dois operandos, não o mais fácil.** `phoneIsTaken` diz *este telefone não está disponível*; `phoneAlreadyRegistered` seria falso para metade da disjunção, porque contato repetido dentro da própria requisição ainda não está registrado em lugar nenhum. É a mesma exigência do `HasNotDeparted`, mais abaixo. E são **duas** variáveis de propósito: `phonesInRequest.Add` muda o conjunto, e colapsar as duas enterraria essa mutação dentro de uma condição.
+
+⚠️ **Subir o `||` para a atribuição não gasta consulta a mais.** O curto-circuito é do operador, não do `if`: o segundo operando segue avaliado só quando o primeiro é falso. Sem isso dito, a mudança parece trocar legibilidade por uma ida ao banco.
+
 ## Rename atinge mais do que o identificador alvo
 
 ⛔ **Substituição em lote acerta o que você não pediu, e nenhum gate reclama.** Depois de qualquer rename mecânico, procure separadamente as três formas de estrago — todas pagas na #222, todas com a build verde:

--- a/.claude/rules/dotnet-testing.md
+++ b/.claude/rules/dotnet-testing.md
@@ -105,9 +105,13 @@ Nunca exponha membro só para testar. O que interessa é o resultado do método 
 
 ## Estático precisa de costura
 
-`DateTime.UtcNow`, `TimeZoneInfo` e afins tiram o controle do teste. Enquanto a costura não existir, **não escreva o teste que depende do relógio** — ele passa hoje e falha sozinho depois.
+`DateTime.UtcNow`, `TimeZoneInfo` e afins tiram o controle do teste. **Onde a costura não existir, não escreva o teste que depende do relógio** — ele passa hoje e falha sozinho depois.
 
-Aqui isso já espera por alguém: `Ride.ValidateDepartureDateTime` compara a partida com `DateTime.UtcNow`, então testar a regra de "partida no futuro" exige injetar o tempo antes.
+**O padrão é o `MinimumAgeAttribute`:** ele pergunta o relógio ao `ValidationContext` — `GetService(typeof(TimeProvider))` — e cai para `TimeProvider.System` quando ninguém fornece. O teste entrega um `TimeProvider` fixo por um `IServiceProvider` de duas linhas, e cada borda vira caso determinístico. `TimeProvider` é do .NET 8: não escreva interface de relógio própria.
+
+⛔ **`Ride.ValidateDepartureDateTime` continua sem costura**: compara a partida com `DateTime.UtcNow` direto, então testar "partida no futuro" ainda exige injetar o tempo antes.
+
+⚠️ **Depender do relógio não é ser sensível a ele.** O caso **na borda** é o que quebra: na virada de meia-noite UTC o limite anda um dia e a data muda de lado — e quem cai é o teste de **recusa**, não o de aceitação. Teste de endpoint com uma década de folga do limite lê o relógio e nunca vira. Data literal fixa não é a saída: ela envelhece calada, porque um dia deixa de ser menor de idade. A borda fica no teste de unidade com relógio fixo; o endpoint fica com o caso folgado, provando só a fiação.
 
 ## Subir a aplicação contra PostgreSQL de verdade
 
@@ -117,7 +121,7 @@ Aqui isso já espera por alguém: `Ride.ValidateDepartureDateTime` compara a par
 
 **O schema nasce das migrations**, porque é o `Migrate()` do `Program` que roda — o mesmo caminho da produção. Migration quebrada aparece no teste, e o `unaccent` vem junto sem passo manual, porque o `FateConnectDbContext` o declara com `HasPostgresExtension`.
 
-⚠️ **O custo é real e conhecido: ~6s contra ~1s do provedor em memória.** São **24 fábricas** — uma por classe com `IClassFixture`, mais uma por caso de teste do `RideListingTests` —, logo 24 bancos criados e migrados. Isso é aceitável para o que compra, e o que compra foi medido na #237, com três mutações:
+⚠️ **O custo é real e conhecido: ~6s contra ~1s do provedor em memória.** São **25 fábricas** — uma por classe com `IClassFixture`, mais uma por caso de teste do `RideListingTests` —, logo 25 bancos criados e migrados. Isso é aceitável para o que compra, e o que compra foi medido na #237, com três mutações:
 
 | mutação | o que cai |
 | --- | --- |
@@ -127,7 +131,7 @@ Aqui isso já espera por alguém: `Ride.ValidateDepartureDateTime` compara a par
 
 As três passavam verdes no provedor em memória, que executa LINQ em memória e não conhece função de PostgreSQL.
 
-⚠️ **Não serialize a criação dos bancos, e não desligue o paralelismo do xUnit.** As 24 fábricas criam banco ao mesmo tempo, e a falha clássica disso — `source database "template1" is being accessed by other users` — exige uma sessão aberta **no template**. Medido durante uma corrida real: os únicos bancos que recebem conexão são o `postgres`, onde o Npgsql abre a conexão administrativa, e os `fateconnect-tests-<guid>`; o `template1` recebe **zero**. Pico de **25 conexões contra o teto de 100**, e 120 `CREATE DATABASE` concorrentes numa sonda não produziram uma falha.
+⚠️ **Não serialize a criação dos bancos, e não desligue o paralelismo do xUnit.** As 25 fábricas criam banco ao mesmo tempo, e a falha clássica disso — `source database "template1" is being accessed by other users` — exige uma sessão aberta **no template**. Medido durante uma corrida real: os únicos bancos que recebem conexão são o `postgres`, onde o Npgsql abre a conexão administrativa, e os `fateconnect-tests-<guid>`; o `template1` recebe **zero**. Pico de **26 conexões de cliente contra o teto de 100**, e 120 `CREATE DATABASE` concorrentes numa sonda não produziram uma falha.
 
 ⚠️ **Aquele zero só vale por causa do controle positivo.** Antes de acreditar nele, a mesma sonda forçou o erro de propósito — conexão aberta num banco e `CREATE DATABASE ... TEMPLATE` copiando dele — e ele apareceu. Sonda que não consegue produzir a falha não está medindo a ausência dela.
 

--- a/.claude/rules/fateconnect-locale-code.md
+++ b/.claude/rules/fateconnect-locale-code.md
@@ -45,11 +45,12 @@ Separar o que é **experiência do usuário (pt-BR)** do que é **base de códig
 A API fala **inglês inteira** — caminho, query, corpo e resposta. Não há tradução na borda: o tipo do front vai direto na chamada.
 
 - **Caronas.** Caminho `/Rides`, query (`destination`, `departureDate`, `departureTime`, `rideType`) e propriedades do JSON com os mesmos nomes. Valores do enum: `Solidarity` | `Egalitarian`.
-- **Cadastro.** `POST /Users/signup` com `fullName`, `nickname`, `fatecEmail`, `password`, `birthDate`, `gender`, `addresses` (`zipCode`, `street`, `streetNumber`, `complement`, `city`, `state`) e `contacts` (`phone`, `contactEmail`). Resposta: `{ token }` — o cadastro já autentica. Valores de gênero: `Male` | `Female` | `Other`.
+- **Cadastro.** `POST /Users/signup` com `fullName`, `fatecEmail`, `password`, `birthDate`, `gender`, `addresses` (`zipCode`, `street`, `streetNumber`, `complement`, `city`, `state`) e `contacts` (`phone`, `contactEmail`). Resposta: `{ token }` — o cadastro já autentica. Valores de gênero: `Male` | `Female` | `Other`.
 - **Login.** `POST /Auth/login` com `{ fatecEmail, password }`, resposta `{ token }`.
 - **Sessão.** `GET /Auth/session`, autenticada, responde `204` enquanto o token vale e `401` quando não vale mais. É quem diz se a sessão continua de pé — o front não julga validade por conta própria, e não lê o `exp` do token.
 - **O nome de quem está logado sai do token**, na claim `unique_name`, e não de nenhuma resposta. Cadastro e login devolvem o mesmo `TokenResponseDto`.
 - **Erro.** Qualquer status de erro devolve `{ "error": "..." }`, com a mensagem em pt-BR. O corpo sai do `ErrorResponseDto`, o mesmo tipo que o `ProducesResponseType` anuncia — documentação e resposta não conseguem divergir.
+- **Erro que aponta um campo** acrescenta `field`, com o nome que a **requisição** usa: `fatecEmail`, `phone` ou `contactEmail`. Hoje só o conflito de cadastro o manda, e é ele que permite ao formulário marcar o campo certo em vez de casar substring da mensagem. Erro sem campo associado devolve só `error`, e o front trata a ausência como o caso genérico.
 
 ⚠️ **A API publica com a inicial maiúscula e o front chama minúsculo.** `[Route("[controller]")]` gera `/Rides`, `/Users` e `/Auth`, que é o que o Swagger mostra; os serviços do front padronizam `/rides`, `/users/signup` e `/auth`, porque o roteamento do ASP.NET é case-insensitive. Não "corrija" nenhum dos dois lados — a divergência é deliberada.
 

--- a/.claude/rules/harness-evolution.md
+++ b/.claude/rules/harness-evolution.md
@@ -47,6 +47,30 @@ Antes de escrever, escolha o lugar — os quatro não são intercambiáveis:
 - `description` em rule é documentação para humanos — mantenha precisa, mas não espere que condicione nada. **Só skill dispara por `description`.**
 - Esta rule é uma das exceções sem `paths`: os gatilhos disparam em qualquer arquivo.
 
+### O gatilho é o **Read**, e trabalhar por Bash desliga todas elas
+
+⛔ **Rule com `paths` carrega quando um arquivo que casa é lido pela ferramenta `Read`.** `cat`, `sed`, `grep`, `head` e heredoc de python leem o mesmo arquivo e **não** disparam nada: o conteúdo entra na conversa, a rule não.
+
+Aconteceu em 02/09/2026, nas #255, #253 e #254. Escrevi C# para três PRs de API inspecionando tudo por Bash — e as **cinco** rules de `FateConnect/FateConnect.Api/**` ficaram fora de contexto a sessão inteira: `dotnet-migrations`, `dotnet-testing`, `dotnet-code-style`, `dotnet-code-quality` e `dotnet-authorization`.
+
+O custo, medido depois:
+
+| O que eu fiz sem a rule | O que a rule já dizia |
+| --- | --- |
+| Amostrei dois arquivos para inferir se o `/// <inheritdoc />` gerado sai da migration, e generalizei errado | `dotnet-migrations.md` diz exatamente quais saem e quais ficam |
+| Medi cobertura parseando OpenCover à mão, e só depois de ser cobrado | `./scripts/coverage-changed.sh` existe para isso, e a rule manda rodá-lo **antes** de dizer que acabou |
+| Escrevi três testes de borda sobre `DateTime.UtcNow` | "enquanto a costura não existir, **não escreva o teste que depende do relógio**" |
+
+⚠️ **A tentação é escrever uma rule sem `paths` para garantir que ela carregue.** Não é a saída: sem `paths` ela custa contexto em toda sessão, inclusive nas que não tocam a pasta — o problema é o meu gesto, não o escopo dela.
+
+**O que fazer, antes de escrever a primeira linha numa área:** abrir **um** arquivo daquela pasta com o `Read`, ou ler as rules dela diretamente. Um `Read` num arquivo qualquer de `FateConnect/FateConnect.Api/` traz as cinco de uma vez.
+
+```bash
+ls .claude/rules/            # e ler as que casam com a área da tarefa
+```
+
+⛔ **O sinal de risco é o modo Bash-primeiro.** Ele é pedido de propósito para economizar ferramenta, e o efeito colateral é silencioso: nada avisa que uma rule não carregou. Área nova na sessão ⇒ um `Read` de propósito, mesmo que eu já tenha o arquivo na tela.
+
 ## Caminho citado no harness tem check
 
 Rule e skill citam código por caminho, e nada as avisa quando o código sai — o texto continua sintaticamente perfeito descrevendo algo que não existe.

--- a/.claude/rules/parallelism-and-worktrees.md
+++ b/.claude/rules/parallelism-and-worktrees.md
@@ -50,8 +50,8 @@ Issue que declara "Depende de" só começa quando a base estiver **com o escopo 
 ⛔ **Antes de aceitar o que um agente entregou, meça a densidade de comentário.** As rules do repo carregam para dentro da worktree, mas o agente as pondera menos que o resto do prompt — e comentário é o item que ele mais acrescenta por conta própria.
 
 ```bash
-git diff <base>..HEAD -- '*.ts' '*.tsx' | grep -cE "^\+[^+]"                 # linhas adicionadas
-git diff <base>..HEAD -- '*.ts' '*.tsx' | grep -cE "^\+\s*(/\*\*|\*|//)" # dessas, comentário
+git diff <base>..HEAD --numstat -- '*.ts' '*.tsx' | awk '{total += $1} END {print total}'   # linhas adicionadas
+rtk proxy git diff <base>..HEAD -- '*.ts' '*.tsx' | grep -cE "^\+\s*(/\*\*|\*|//)"      # dessas, comentário
 ```
 
 Na #156 deram **37 de 157 linhas — 24%**. Sete reprovaram no teste da `comments.md` e saíram: um JSDoc que repetia o que o `types.ts` já dizia e ainda pousava sobre a constante errada, um que só reafirmava a linha logo abaixo, e uma enumeração de consumidores que **envelheceu no próprio PR** que a escreveu.

--- a/.claude/rules/prove-the-mechanism.md
+++ b/.claude/rules/prove-the-mechanism.md
@@ -43,6 +43,8 @@ until gh pr checks <n> --json name,bucket | jq -e 'length >= 4 and all(.bucket !
 
 ⛔ **`all`, `every` e `none` sobre coleção que ainda está sendo preenchida respondem "sim" sem medir nada.** Predicado de espera precisa dizer **quantos** itens espera, ou nomear o item que espera.
 
+⛔ **E o complemento de "passou" não é "falhou".** No mesmo `gh pr checks`, tratar `bucket != "pass"` como falha reporta vermelho onde há `pending`: em 02/09/2026 anunciei um check falhando no #287 quando o front ainda estava `IN_PROGRESS`, porque a cascata da pilha havia reiniciado o CI. Estado de terceira via — `pending`, `skipping`, `neutral` — se nomeia, não se deduz por exclusão.
+
 ⚠️ **`| head` num `grep` de investigação é o pior dos três**, porque some com a evidência sem avisar e a saída parece completa. Em busca que vai sustentar conclusão, conte antes (`grep -c`) ou não trunque.
 
 ⛔ **Regra nova se prova nas duas formas.** O controle positivo de uma regra de lint não é só "reprova o que deve" — é também "aceita o que deve". Ao estender a de tag crua, rodei um arquivo com `<div>` **e** `<strong>` no mesmo JSX: o primeiro reprova, o segundo passa. Sem a segunda metade eu teria proibido ênfase de texto sem perceber.

--- a/.claude/rules/prove-the-mechanism.md
+++ b/.claude/rules/prove-the-mechanism.md
@@ -35,6 +35,14 @@ Duas na mesma #237: `DOCKER_HOST` apontando para porta morta não desligou o Doc
 | a regra `no-restricted-syntax` de tag crua | chamadas de `styled('nav')` | no JSX: três `<li>` passaram no código novo |
 | a correção da fileira de paginação | a ponta inicial, onde a página 4 quebrava | na ponta final, onde a 9 quebrava igual |
 
+Em 02/09/2026 entrou um quarto, de outra natureza: o predicado que é verdadeiro **por vacuidade**. Esperando o CI de um PR com `until gh pr checks <n> --json name,bucket | jq -e 'all(.bucket != "pending")'`, o laço saiu na primeira olhada e eu anunciei quatro checks verdes — havia **um** registrado, e `all()` sobre lista de um elemento é verdadeiro. Os outros três nem existiam, incluindo o único que importava naquele PR. A âncora que faltava é de cardinalidade:
+
+```bash
+until gh pr checks <n> --json name,bucket | jq -e 'length >= 4 and all(.bucket != "pending")'; do sleep 20; done
+```
+
+⛔ **`all`, `every` e `none` sobre coleção que ainda está sendo preenchida respondem "sim" sem medir nada.** Predicado de espera precisa dizer **quantos** itens espera, ou nomear o item que espera.
+
 ⚠️ **`| head` num `grep` de investigação é o pior dos três**, porque some com a evidência sem avisar e a saída parece completa. Em busca que vai sustentar conclusão, conte antes (`grep -c`) ou não trunque.
 
 ⛔ **Regra nova se prova nas duas formas.** O controle positivo de uma regra de lint não é só "reprova o que deve" — é também "aceita o que deve". Ao estender a de tag crua, rodei um arquivo com `<div>` **e** `<strong>` no mesmo JSX: o primeiro reprova, o segundo passa. Sem a segunda metade eu teria proibido ênfase de texto sem perceber.

--- a/.claude/rules/prove-the-mechanism.md
+++ b/.claude/rules/prove-the-mechanism.md
@@ -43,6 +43,18 @@ until gh pr checks <n> --json name,bucket | jq -e 'length >= 4 and all(.bucket !
 
 ⛔ **`all`, `every` e `none` sobre coleção que ainda está sendo preenchida respondem "sim" sem medir nada.** Predicado de espera precisa dizer **quantos** itens espera, ou nomear o item que espera.
 
+⛔ **`grep` ancorado sobre diff filtrado responde zero.** O `git diff` desta máquina sai em **formato compacto**, e a forma dele não é estável: numa invocação ele renderiza as linhas `+` indentadas, noutra ele resume. Então `grep -E "^\+"` não casa nada — e o zero se lê como "nenhuma linha", que é justamente a resposta tranquilizadora.
+
+Medido em 03/09/2026 sobre um diff de 18 adições:
+
+| Comando | Responde |
+| --- | --- |
+| `git diff \| grep -cE "^\+[^+]"` | **0** |
+| `git diff --numstat` | **18** ✅ |
+| `rtk proxy git diff \| grep -E "^\+" \| wc -l` | **19** ✅ |
+
+**A saída depende do que você quer:** contagem vem de `--numstat`, que é machine-readable e não passa por filtro; linha crua para **classificar** (comentário, string, termo) exige `rtk proxy git diff`, que desvia o filtro. As duas rules que prescreviam a forma ingênua — a densidade de comentário em `parallelism-and-worktrees.md` e o detector de rename em `dotnet-code-style.md` — foram corrigidas por causa disto.
+
 ⛔ **E o complemento de "passou" não é "falhou".** No mesmo `gh pr checks`, tratar `bucket != "pass"` como falha reporta vermelho onde há `pending`: em 02/09/2026 anunciei um check falhando no #287 quando o front ainda estava `IN_PROGRESS`, porque a cascata da pilha havia reiniciado o CI. Estado de terceira via — `pending`, `skipping`, `neutral` — se nomeia, não se deduz por exclusão.
 
 ⚠️ **`| head` num `grep` de investigação é o pior dos três**, porque some com a evidência sem avisar e a saída parece completa. Em busca que vai sustentar conclusão, conte antes (`grep -c`) ou não trunque.

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -27,6 +27,22 @@ Para cada comentário: **veredicto** — aplicar, recusar (com motivo) ou já re
 
 Apresente em tabela curta (comentário → veredicto → plano) e **espere a confirmação antes de tocar no código**. O passo é deliberado: quem revisa conhece contexto que você não tem — algo combinado noutro lugar, mudança que vem em outra PR, enquadramento que ele quer. É o momento mais barato de redirecionar.
 
+### Camada de pilha: a tabela de custos precisa do merge-base
+
+⛔ **PR que é camada de uma pilha muda o cálculo, e o custo que escapa é o das camadas de cima.** Emendar a camada revisada reescreve a história dela, o merge-base das seguintes recua, e o diff delas passa a incluir os commits da camada de baixo — o PR de cima infla sem ninguém ter tocado nele.
+
+Aconteceu em 03/09/2026 no #284, fundo de uma pilha de três. Montei a tabela do caminho "emendar" citando só que o force-push desancora o comentário de linha de quem revisou, e **omiti a inflação do diff**. A escolha foi feita sobre a tabela incompleta e revertida quando o custo apareceu.
+
+| Caminho | Custo |
+| --- | --- |
+| emendar na camada revisada | reescreve as camadas de cima, o merge-base recua e infla o diff delas; o comentário de linha desancora |
+| aplicar na camada **de cima**, ainda sem review | um push; o approve e a âncora do comentário ficam intactos, e a mudança aparece num PR que não é o dela |
+| acrescentar commit na camada revisada | os mesmos pushes que emendar, e ainda um commit de correção no histórico |
+
+**Aplicada noutra camada, a resposta na thread diz qual PR a levou** — senão o comentário fica sem o commit ao lado e quem revisou não acha a correção.
+
+⚠️ Leia a topologia antes de propor caminho: `gh pr view <n> --json baseRefName` em cada PR aberto diz quem aponta para quem.
+
 ## 3. Confira contra o código atual — este é o passo que mais protege
 
 ⛔ **Não confie no diff citado no comentário.** Abra o arquivo na linha real e confirme se o apontamento ainda se sustenta. Comentário sobre código que já mudou é recusa, não mudança.

--- a/.claude/skills/spec-issue/SKILL.md
+++ b/.claude/skills/spec-issue/SKILL.md
@@ -21,11 +21,28 @@ Pergunta feita sem ler é pergunta que o repositório já respondia. Antes do pr
 - **Quando a issue ainda não existe**, não há o que abrir: leia no lugar as issues que ela vai
   encostar — a que ela destrava, a que vai desfazer parte do que ela monta — e confira com
   `gh issue list --state all --search` se alguém já abriu a mesma coisa
-- O **protótipo anexado**, quando houver: o corpo traz um `<img src="https://github.com/user-attachments/...">` e `curl -sL` baixa. Export de tela inteira vem alto demais para uma leitura só — fatiar com `sips` e ler banda a banda
+- O **protótipo anexado**, quando houver: o corpo traz um `<img src="https://github.com/user-attachments/...">` e `curl -sL` baixa. Export de tela inteira vem alto demais para uma leitura só — fatiar com `sips` e ler banda a banda. **Link do Figma** se lê com `get_screenshot`, passando o `fileKey` e o `nodeId` extraídos da URL — em `/design/:fileKey/...?node-id=143-2`, o nó é `143:2`
 - A tela ou o módulo mais parecido que já existe — é dele que saem as opções fundamentadas
 - Os arquivos que a mudança vai tocar, com `Grep` e `Read`
 
 Separar o que foi **encontrado** do que é **suposição**. A suposição vai para o corpo da issue com esse nome.
+
+### O protótipo dá a ideia; o código dá a verdade
+
+⛔ **Onde o protótipo divergir do código, o código vence — e a divergência vai escrita no corpo da issue.** O protótipo foi desenhado numa data e não é reprocessado quando o produto anda: ele carrega copy que a régua já corrigiu, nome que já mudou e elemento que já saiu.
+
+⛔ **O tell é o protótipo mostrando algo que o código contradiz.** Não é um erro de desenho a esclarecer: é o desenho estando velho. Resolver em silêncio, para qualquer um dos lados, é o defeito — quem implementa abre o Figma, vê a diferença e não sabe qual vale.
+
+Quatro na mesma rodada, ao especificar o menu da conta:
+
+| O protótipo dizia | O que valeu, e por quê |
+| --- | --- |
+| "Bem-vindo ao FateConnect" | **"Boas-vindas"**, que é o que o código diz — linguagem neutra, pela `product-copy.md` |
+| "Configurações" no item | **"Preferências"**, porque a seção que o abriga tem esse nome e dois nomes para um conceito é proibido |
+| nenhum nome no popover | **o nome entra**, porque ele era o rótulo acessível do gatilho e sairia de lá |
+| o botão de tema ausente do topo | **decisão de produto**, não detalhe de desenho — virou item de escopo |
+
+**Onde a divergência mora:** uma lista no corpo da issue, junto do link do protótipo, dizendo o que difere e qual lado vale. Sem ela, cada uma volta como pergunta durante a implementação.
 
 ### A premissa do pedido também se mede
 
@@ -34,6 +51,8 @@ Separar o que foi **encontrado** do que é **suposição**. A suposição vai pa
 Aconteceu na #226. O pedido dizia *"o login continua retornando `fullName` mas o front já não usa pra nada"*. Metade certa — o nome do topo vem mesmo do token, mas o aviso de boas-vindas do login ainda lia a resposta. Sem a conferência a issue teria nascido como deleção pura e quebrado o aviso na implementação; com ela, o aviso virou a primeira pergunta, e a resposta — *"esse aviso nem faz sentido"* — mudou o escopo antes de existir código.
 
 **O tell é o verbo no presente sobre o código:** "já não usa", "ninguém chama", "isso é só", "não tem mais". Cada um é um `Grep` que você ainda não fez.
+
+⚠️ **O tell no passado cobra busca mais funda:** "aquela tela que tínhamos antes", "o componente que a gente removeu", "como era na versão anterior". Ali o `Grep` no código atual não responde — precisa do histórico, com `git log --all -S "<termo>" -i --name-only` —, e a resposta pode ser que **nunca existiu**. Aconteceu em 03/09/2026: "aquela tela de em breve que tínhamos antes" não estava no código nem no histórico, e o que havia era um componente do design system escrito para aquele caso e sem consumidor nenhum. Especificar sobre a lembrança teria mandado ressuscitar o inexistente.
 
 ### Issue de "todos os X" começa pelo inventário medido
 


### PR DESCRIPTION
## Objetivo

Registrar por que cinco rules de `.claude/rules/` ficaram fora de contexto durante três PRs de API, e o que fazer para não repetir. Sem `## Issue`: mudança de harness dispensa a issue, não o PR.

## O que aconteceu

Rule com `paths:` carrega quando um arquivo que casa é lido **pela ferramenta `Read`**. `cat`, `sed`, `grep` e heredoc de python leem o mesmo arquivo e não disparam nada — o conteúdo entra na conversa, a rule não.

Nas #255, #253 e #254 eu inspecionei a API inteira por Bash. As cinco rules de `FateConnect/FateConnect.Api/**` — `dotnet-migrations`, `dotnet-testing`, `dotnet-code-style`, `dotnet-code-quality` e `dotnet-authorization` — não carregaram em nenhum momento.

## O custo, medido depois

| O que eu fiz sem a rule | O que a rule já dizia |
| --- | --- |
| Amostrei **dois** arquivos para inferir se o `/// <inheritdoc />` gerado sai da migration, generalizei errado, tirei dos dois e tive que devolver um | `dotnet-migrations.md` diz exatamente quais saem e quais ficam |
| Parseei OpenCover à mão para achar as linhas descobertas, e só depois de ser cobrado pelo número | `./scripts/coverage-changed.sh` existe para isso, e a rule manda rodá-lo **antes** de dizer que acabou |
| Escrevi três testes de borda sobre `DateTime.UtcNow` | *"enquanto a costura não existir, **não escreva o teste que depende do relógio**"* |

As duas últimas viraram violação de verdade e foram corrigidas na #285 — a cobertura fechou em 98,7% pelo script, e a costura passou a existir via `TimeProvider` resolvido pelo `ValidationContext`.

## Alterações

**`harness-evolution.md`** ganha a subseção "O gatilho é o **Read**, e trabalhar por Bash desliga todas elas", dentro da seção que já explica que `paths` é o que dispara. Ela traz o mecanismo, a tabela de custo acima, a mitigação — abrir **um** arquivo da área com o `Read` antes de escrever a primeira linha — e a armadilha de escrever rule sem `paths` para "garantir que carregue", que só troca o problema por custo de contexto permanente.

**`prove-the-mechanism.md`** ganha um quarto caso na seção "O instrumento que alcança metade": o predicado verdadeiro **por vacuidade**. Esperando CI com `until ... | jq -e 'all(.bucket != "pending")'`, o laço saiu na primeira olhada e eu anunciei quatro checks verdes — havia um registrado, e `all()` sobre lista de um elemento é verdadeiro. Faltava âncora de cardinalidade.

## O estado pós-merge, escrito aqui de propósito

⚠️ **Este PR descreve o repositório como a pilha #286 o deixa, não como a `develop` está hoje.** Decidido assim para não custar um segundo PR de harness depois de cada merge — então ele mergeia junto com a pilha, não antes dela.

Procurei todo lugar que os quatro PRs invalidam, e são três:

**`fateconnect-locale-code.md`** — o contrato de cadastro listava `nickname`, que a #255 remove. E o contrato de erro ganhou o `field`: o nome que a **requisição** usa (`fatecEmail`, `phone`, `contactEmail`), hoje mandado só pelo conflito de cadastro, e o que permite ao formulário marcar o campo certo em vez de casar substring da mensagem.

**`dotnet-testing.md`, a costura de estático** — ela dizia que a costura *"já espera por alguém"*. Ela existe: o `MinimumAgeAttribute` pergunta o relógio ao `ValidationContext` e cai para `TimeProvider.System`. O `Ride.ValidateDepartureDateTime` **continua** sem costura, e isso ficou dito. Junto entrou a distinção que esta rodada pagou: depender do relógio não é ser sensível a ele — o que quebra é o caso na borda, e é o teste de **recusa** que cai na virada de meia-noite.

**`dotnet-testing.md`, os números da suíte** — de **24 para 25 fábricas** e de **25 para 26 conexões**, porque a #253 acrescenta uma classe com `IClassFixture`.

Os dois números são **medidos**, não deduzidos: `pg_database` e `pg_stat_activity` consultados durante a corrida, com o pico ao longo de 40 amostras. A primeira medição de conexão devolveu **31** — ela contava os processos de fundo do PostgreSQL, recorte diferente do número original; refeita com `backend_type = 'client backend'`, deu 26. Contar declaração no editor é justamente onde este número já errou antes (17 contra 24 reais).

⚠️ **O "24 fábricas" da `prove-the-mechanism.md` fica como está** — ali é a narrativa do incidente da #237, e 24 era o número naquele dia.

## O que ficou só em memória

Classificar um caso pela consequência em vez da natureza (erro de projeto, não convenção deste repo) e a preferência de pilha nativa ter voltado a valer (a instrução de pilha vive fora deste repositório).

## Evidências

`./scripts/check-harness-paths.sh` sem caminho órfão. Não há teste a rodar: o PR não toca em código.
