### PR TITLE
feat(290): invalidate the token when the session ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Adiciona o botão de fechar nos diálogos quando a tela é estreita: a faixa em volta deles é curta demais para fechar por toque, e alargá-la deixaria o diálogo apertado. No desktop nada muda (#277) [Frontend]
 - Adiciona a marcação da tela atual no topo e no menu lateral, que antes não indicavam onde a pessoa estava; a marca também é anunciada por leitor de tela (#281) [Frontend]
+- Adiciona o encerramento de sessão na API, que invalida o token no servidor em vez de apenas descartá-lo no navegador: depois de sair, nenhum token daquela pessoa é aceito, em qualquer aparelho (#298) [Backend]
 
 ### Changed
 
@@ -19,6 +20,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Passa a dizer qual campo está em uso na resposta de conflito do cadastro, que antes trazia só a mensagem (#284) [Backend]
 - Passa a exigir 18 anos completos no cadastro também na API, que aceitava conta de menor de idade em requisição feita fora do formulário; quem completa 18 anos no dia é aceito (#285) [Backend]
 - Passa a distribuir os campos da conta em dois por linha no cadastro — nascimento com gênero, e-mail com senha —, em vez de três (#287) [Frontend]
+- Passa a recusar os tokens emitidos antes desta versão, que não carregam a versão de sessão e por isso não podem ser invalidados; quem estiver com a sessão aberta no momento da publicação entra de novo, uma vez (#298) [Backend]
 
 ### Fixed
 

--- a/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
+++ b/FateConnect/FateConnect.Api.Tests/ApiFactory.cs
@@ -1,4 +1,8 @@
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
 using FateConnect.Api.Infrastructure.Database;
 using FateConnect.Api.Modules.Auth.Entities;
 using FateConnect.Api.Modules.Auth.Services;
@@ -10,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using static BCrypt.Net.BCrypt;
 
 namespace FateConnect.Api.Tests;
@@ -40,7 +45,7 @@ public class ApiFactory : WebApplicationFactory<Program>
         });
     }
 
-    public static string IssueToken(int userId = 1)
+    public static string IssueToken(int userId = 1, int tokenVersion = 0)
     {
         JwtOptions options = new()
         {
@@ -50,7 +55,39 @@ public class ApiFactory : WebApplicationFactory<Program>
         };
 
         return new TokenService(Options.Create(options))
-            .GenerateJwtToken(new User { Id = userId, FatecEmail = "mariana.rocha@aluno.cps.sp.gov.br" });
+            .GenerateJwtToken(new User
+            {
+                Id = userId,
+                FatecEmail = "mariana.rocha@aluno.cps.sp.gov.br",
+                TokenVersion = tokenVersion
+            });
+    }
+
+    public static string IssueTokenWithoutVersion(int userId = 1)
+    {
+        JwtSecurityTokenHandler handler = new();
+        byte[] securityKey = Encoding.UTF8.GetBytes(FakeSecret);
+
+        ClaimsIdentity claims = new(
+        [
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString(CultureInfo.InvariantCulture)),
+            new Claim(ClaimTypes.Name, "Mariana Alves Rocha"),
+            new Claim(ClaimTypes.Role, "Operator"),
+            new Claim(ClaimTypes.Email, "mariana.rocha@aluno.cps.sp.gov.br")
+        ]);
+
+        SecurityToken token = handler.CreateToken(new SecurityTokenDescriptor
+        {
+            Subject = claims,
+            Expires = DateTime.UtcNow.AddHours(1),
+            Issuer = "FateConnectTest",
+            Audience = "FateConnectTestWeb",
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(securityKey),
+                SecurityAlgorithms.HmacSha256Signature)
+        });
+
+        return handler.WriteToken(token);
     }
 
     public static string UniquePhone() => $"15{Random.Shared.Next(100_000_000, 999_999_999)}";
@@ -119,12 +156,17 @@ public class ApiFactory : WebApplicationFactory<Program>
         return ride.Id;
     }
 
-    public HttpClient CreateClientFor(int userId)
+    public HttpClient CreateClientFor(int userId, int tokenVersion = 0)
     {
         HttpClient client = CreateClient();
         client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", IssueToken(userId));
+            new AuthenticationHeaderValue("Bearer", IssueToken(userId, tokenVersion));
 
         return client;
+    }
+
+    public HttpClient CreateClientForNewUser(string fullName)
+    {
+        return CreateClientFor(SeedUser(fullName).Id);
     }
 }

--- a/FateConnect/FateConnect.Api.Tests/AuthorizationTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/AuthorizationTests.cs
@@ -36,9 +36,7 @@ public class AuthorizationTests : IClassFixture<ApiFactory>
     [Fact]
     public async Task RideEndpoints_WithAValidToken_ReachTheController()
     {
-        HttpClient client = _factory.CreateClient();
-        client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", ApiFactory.IssueToken());
+        HttpClient client = _factory.CreateClientForNewUser("Mariana Alves Rocha");
 
         HttpResponseMessage response = await client.GetAsync("/Rides");
 

--- a/FateConnect/FateConnect.Api.Tests/ClaimsPrincipalExtensionsTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/ClaimsPrincipalExtensionsTests.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+using System.Security.Claims;
+using FateConnect.Api.Modules.Auth.Constants;
+using FateConnect.Api.Modules.Auth.Exceptions;
+using FateConnect.Api.Modules.Auth.Extensions;
+
+namespace FateConnect.Api.Tests;
+
+public class ClaimsPrincipalExtensionsTests
+{
+    private const int UserId = 42;
+    private const int TokenVersion = 3;
+
+    [Fact]
+    public void GetUserId_WithTheIdentityClaim_ReturnsTheIdentifier()
+    {
+        ClaimsPrincipal user = PrincipalWith(
+            new Claim(ClaimTypes.NameIdentifier, UserId.ToString(CultureInfo.InvariantCulture)));
+
+        int userId = user.GetUserId();
+
+        Assert.Equal(UserId, userId);
+    }
+
+    [Fact]
+    public void GetUserId_WithoutTheIdentityClaim_Throws()
+    {
+        ClaimsPrincipal user = PrincipalWith();
+
+        Assert.Throws<UnidentifiedUserException>(() => user.GetUserId());
+    }
+
+    [Fact]
+    public void GetTokenVersion_WithTheVersionClaim_ReturnsIt()
+    {
+        ClaimsPrincipal user = PrincipalWith(
+            new Claim(TokenClaimNames.TokenVersion, TokenVersion.ToString(CultureInfo.InvariantCulture)));
+
+        int version = user.GetTokenVersion();
+
+        Assert.Equal(TokenVersion, version);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("nao-e-numero")]
+    public void GetTokenVersion_WithAnUnreadableVersionClaim_Throws(string version)
+    {
+        ClaimsPrincipal user = PrincipalWith(new Claim(TokenClaimNames.TokenVersion, version));
+
+        Assert.Throws<UnidentifiedTokenException>(() => user.GetTokenVersion());
+    }
+
+    [Fact]
+    public void GetTokenVersion_WithoutTheVersionClaim_Throws()
+    {
+        ClaimsPrincipal user = PrincipalWith();
+
+        Assert.Throws<UnidentifiedTokenException>(() => user.GetTokenVersion());
+    }
+
+    private static ClaimsPrincipal PrincipalWith(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims));
+}

--- a/FateConnect/FateConnect.Api.Tests/LogoutTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/LogoutTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FateConnect.Api.Modules.Auth.DTOs;
+
+namespace FateConnect.Api.Tests;
+
+public class LogoutTests : IClassFixture<ApiFactory>
+{
+    private const string LogoutRoute = "/Auth/logout";
+    private const string SessionRoute = "/Auth/session";
+    private const int VersionAfterOneLogout = 1;
+    private const string KnownPassword = "SenhaForte123!";
+
+    private readonly ApiFactory _factory;
+
+    public LogoutTests(ApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Logout_WithoutToken_RespondsUnauthorized()
+    {
+        HttpResponseMessage response = await _factory.CreateClient().PostAsync(LogoutRoute, null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Logout_WithAValidToken_RespondsNoContent()
+    {
+        HttpClient client = _factory.CreateClientForNewUser("Mariana Alves Rocha");
+
+        HttpResponseMessage response = await client.PostAsync(LogoutRoute, null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WithTheSameToken_IsAcceptedBeforeLogout()
+    {
+        HttpClient client = _factory.CreateClientForNewUser("Bruno Carvalho Souza");
+
+        HttpResponseMessage response = await client.GetAsync(SessionRoute);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WithTheSameToken_IsRefusedAfterLogout()
+    {
+        HttpClient client = _factory.CreateClientForNewUser("Ana Beatriz Nogueira");
+        await client.PostAsync(LogoutRoute, null);
+
+        HttpResponseMessage response = await client.GetAsync(SessionRoute);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WithAnotherTokenOfTheSamePerson_IsRefusedAfterLogout()
+    {
+        SeededUser person = _factory.SeedUser("Carla Ribeiro Matos");
+        HttpClient laptop = _factory.CreateClientFor(person.Id);
+        HttpClient phone = _factory.CreateClientFor(person.Id);
+        await phone.PostAsync(LogoutRoute, null);
+
+        HttpResponseMessage response = await laptop.GetAsync(SessionRoute);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WithATokenIssuedAfterLogout_IsAccepted()
+    {
+        SeededUser person = _factory.SeedUser("Diego Nunes Peixoto");
+        await _factory.CreateClientFor(person.Id).PostAsync(LogoutRoute, null);
+
+        HttpClient afterSigningInAgain = _factory.CreateClientFor(person.Id, VersionAfterOneLogout);
+
+        HttpResponseMessage response = await afterSigningInAgain.GetAsync(SessionRoute);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WithATokenFromSigningInAgainAfterLogout_IsAccepted()
+    {
+        (_, string fatecEmail) = _factory.SeedUserWithPassword("Helena Braga Vieira", KnownPassword);
+        HttpClient before = await ClientBySigningIn(fatecEmail);
+        await before.PostAsync(LogoutRoute, null);
+
+        HttpClient after = await ClientBySigningIn(fatecEmail);
+
+        HttpResponseMessage response = await after.GetAsync(SessionRoute);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WithTheTokenFromBeforeSigningInAgain_StaysRefused()
+    {
+        (_, string fatecEmail) = _factory.SeedUserWithPassword("Igor Salgado Ferraz", KnownPassword);
+        HttpClient before = await ClientBySigningIn(fatecEmail);
+        await before.PostAsync(LogoutRoute, null);
+        await ClientBySigningIn(fatecEmail);
+
+        HttpResponseMessage response = await before.GetAsync(SessionRoute);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Logout_CalledTwiceWithTheSameToken_RespondsUnauthorizedOnTheSecondCall()
+    {
+        HttpClient client = _factory.CreateClientForNewUser("Eduardo Prado Lima");
+        await client.PostAsync(LogoutRoute, null);
+
+        HttpResponseMessage response = await client.PostAsync(LogoutRoute, null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WithATokenCarryingNoVersion_IsRefused()
+    {
+        SeededUser person = _factory.SeedUser("Fernanda Alves Pinto");
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue(
+                "Bearer", ApiFactory.IssueTokenWithoutVersion(person.Id));
+
+        HttpResponseMessage response = await client.GetAsync(SessionRoute);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WithATokenOfSomeoneWhoNoLongerExists_IsRefused()
+    {
+        const int nobody = 987654;
+        HttpClient client = _factory.CreateClientFor(nobody);
+
+        HttpResponseMessage response = await client.GetAsync(SessionRoute);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private async Task<HttpClient> ClientBySigningIn(string fatecEmail)
+    {
+        HttpResponseMessage response = await _factory.CreateClient()
+            .PostAsJsonAsync("/Auth/login", new { fatecEmail, password = KnownPassword });
+
+        TokenResponseDto body = (await response.Content.ReadFromJsonAsync<TokenResponseDto>())!;
+
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", body.Token);
+
+        return client;
+    }
+}

--- a/FateConnect/FateConnect.Api.Tests/SessionEndpointTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/SessionEndpointTests.cs
@@ -8,9 +8,7 @@ public class SessionEndpointTests(ApiFactory factory) : IClassFixture<ApiFactory
     [Fact]
     public async Task Session_WithAValidToken_AnswersNoContent()
     {
-        HttpClient client = factory.CreateClient();
-        client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", ApiFactory.IssueToken());
+        HttpClient client = factory.CreateClientForNewUser("Bruno Carvalho Souza");
 
         HttpResponseMessage response = await client.GetAsync("/Auth/session");
 

--- a/FateConnect/FateConnect.Api.Tests/UnderPostingTests.cs
+++ b/FateConnect/FateConnect.Api.Tests/UnderPostingTests.cs
@@ -50,9 +50,7 @@ public class UnderPostingTests : IClassFixture<ApiFactory>
     [Fact]
     public async Task CreateRide_WithSeatsOutOfRange_AnswersTheDomainMessage()
     {
-        HttpClient client = _factory.CreateClient();
-        client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", ApiFactory.IssueToken());
+        HttpClient client = _factory.CreateClientForNewUser("Ana Beatriz Nogueira");
 
         HttpResponseMessage response = await client.PostAsJsonAsync("/Rides", new
         {

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260903171131_AddUserTokenVersion.Designer.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260903171131_AddUserTokenVersion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FateConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FateConnect.Api.Infrastructure.Database.Migrations
 {
     [DbContext(typeof(FateConnectDbContext))]
-    partial class FateConnectDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260903171131_AddUserTokenVersion")]
+    partial class AddUserTokenVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260903171131_AddUserTokenVersion.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Database/Migrations/20260903171131_AddUserTokenVersion.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FateConnect.Api.Infrastructure.Database.Migrations
+{
+    public partial class AddUserTokenVersion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TokenVersion",
+                table: "Users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TokenVersion",
+                table: "Users");
+        }
+    }
+}

--- a/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
+++ b/FateConnect/FateConnect.Api/Infrastructure/Middlewares/GlobalExceptionMiddleware.cs
@@ -47,7 +47,7 @@ public partial class GlobalExceptionMiddleware(
                 conflictingField = ex.Field;
                 break;
 
-            case UnidentifiedUserException or InvalidCredentialsException:
+            case UnidentifiedUserException or UnidentifiedTokenException or InvalidCredentialsException:
                 statusCode = HttpStatusCode.Unauthorized;
                 errorMessage = exception.Message;
                 break;

--- a/FateConnect/FateConnect.Api/Modules/Auth/Constants/TokenClaimNames.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Constants/TokenClaimNames.cs
@@ -1,0 +1,6 @@
+namespace FateConnect.Api.Modules.Auth.Constants;
+
+public static class TokenClaimNames
+{
+    public const string TokenVersion = "token_version";
+}

--- a/FateConnect/FateConnect.Api/Modules/Auth/Controllers/AuthController.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Controllers/AuthController.cs
@@ -1,5 +1,7 @@
 using FateConnect.Api.Modules.Auth.Interfaces;
 using FateConnect.Api.Modules.Auth.DTOs;
+using FateConnect.Api.Modules.Auth.Extensions;
+using FateConnect.Api.Modules.Common.DTOs;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -23,6 +25,17 @@ public class AuthController : ControllerBase
     {
         var response = await _authService.LoginAsync(dto);
         return Ok(response);
+    }
+
+    [HttpPost("logout")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResponseDto), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> LogoutAsync()
+    {
+        await _authService.LogoutAsync(User.GetUserId());
+
+        return NoContent();
     }
 
     [HttpGet("session")]

--- a/FateConnect/FateConnect.Api/Modules/Auth/Exceptions/UnidentifiedTokenException.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Exceptions/UnidentifiedTokenException.cs
@@ -1,0 +1,4 @@
+namespace FateConnect.Api.Modules.Auth.Exceptions;
+
+public class UnidentifiedTokenException()
+    : Exception("Sessão encerrada. Entre novamente para continuar.");

--- a/FateConnect/FateConnect.Api/Modules/Auth/Extensions/ClaimsPrincipalExtensions.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Extensions/ClaimsPrincipalExtensions.cs
@@ -2,6 +2,7 @@ namespace FateConnect.Api.Modules.Auth.Extensions;
 
 using System.Globalization;
 using System.Security.Claims;
+using FateConnect.Api.Modules.Auth.Constants;
 using FateConnect.Api.Modules.Auth.Exceptions;
 
 public static class ClaimsPrincipalExtensions
@@ -16,5 +17,17 @@ public static class ClaimsPrincipalExtensions
             throw new UnidentifiedUserException();
 
         return userId;
+    }
+
+    public static int GetTokenVersion(this ClaimsPrincipal user)
+    {
+        string? version = user.FindFirstValue(TokenClaimNames.TokenVersion);
+
+        bool isValidVersion = int.TryParse(version, CultureInfo.InvariantCulture, out int tokenVersion);
+
+        if (!isValidVersion)
+            throw new UnidentifiedTokenException();
+
+        return tokenVersion;
     }
 }

--- a/FateConnect/FateConnect.Api/Modules/Auth/Interfaces/IAuthService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Interfaces/IAuthService.cs
@@ -5,4 +5,5 @@ namespace FateConnect.Api.Modules.Auth.Interfaces;
 public interface IAuthService
 {
     Task<TokenResponseDto> LoginAsync(LoginDto dto);
+    Task LogoutAsync(int userId);
 }

--- a/FateConnect/FateConnect.Api/Modules/Auth/Services/AuthService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Services/AuthService.cs
@@ -32,6 +32,11 @@ public class AuthService : IAuthService
         return new TokenResponseDto { Token = generatedToken };
     }
 
+    public async Task LogoutAsync(int userId)
+    {
+        await _userRepository.IncrementTokenVersionAsync(userId);
+    }
+
     private static bool AreCredentialsInvalid(User? user, string providedPassword)
     {
         if (user == null)

--- a/FateConnect/FateConnect.Api/Modules/Auth/Services/TokenService.cs
+++ b/FateConnect/FateConnect.Api/Modules/Auth/Services/TokenService.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using FateConnect.Api.Modules.Auth.Constants;
 using FateConnect.Api.Modules.Auth.Entities;
 using FateConnect.Api.Modules.Auth.Interfaces;
 using FateConnect.Api.Modules.Users.Entities;
@@ -47,6 +48,7 @@ public class TokenService : ITokenService
         Claim[] claims =
         [
             new Claim(ClaimTypes.NameIdentifier, user.Id.ToString(CultureInfo.InvariantCulture)),
+            new Claim(TokenClaimNames.TokenVersion, user.TokenVersion.ToString(CultureInfo.InvariantCulture)),
             new Claim(ClaimTypes.Name, user.FullName),
             new Claim(ClaimTypes.Email, user.FatecEmail),
             new Claim(ClaimTypes.Role, user.ProfileType.ToString())

--- a/FateConnect/FateConnect.Api/Modules/Users/Entities/User.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Entities/User.cs
@@ -13,6 +13,7 @@ public class User
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public EnumProfileType ProfileType { get; set; }
+    public int TokenVersion { get; set; }
     public ICollection<Address> Addresses { get; set; } = [];
     public ICollection<Contact> Contacts { get; set; } = [];
 }

--- a/FateConnect/FateConnect.Api/Modules/Users/Interfaces/IUserRepository.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Interfaces/IUserRepository.cs
@@ -9,4 +9,6 @@ public interface IUserRepository
     Task<bool> ContactEmailExistsAsync(string contactEmail);
     Task<User?> GetByEmailAsync(string email);
     Task AddAsync(User user);
+    Task<int?> GetTokenVersionAsync(int userId);
+    Task IncrementTokenVersionAsync(int userId);
 }

--- a/FateConnect/FateConnect.Api/Modules/Users/Repositories/UserRepository.cs
+++ b/FateConnect/FateConnect.Api/Modules/Users/Repositories/UserRepository.cs
@@ -14,6 +14,22 @@ public class UserRepository : IUserRepository
         _context = context;
     }
 
+    public async Task<int?> GetTokenVersionAsync(int userId)
+    {
+        return await _context.Users
+            .Where(user => user.Id == userId)
+            .Select(user => (int?)user.TokenVersion)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task IncrementTokenVersionAsync(int userId)
+    {
+        await _context.Users
+            .Where(user => user.Id == userId)
+            .ExecuteUpdateAsync(update =>
+                update.SetProperty(user => user.TokenVersion, user => user.TokenVersion + 1));
+    }
+
     public async Task<bool> EmailExistsAsync(string email)
     {
         return await _context.Users.AnyAsync(u => u.FatecEmail == email);

--- a/FateConnect/FateConnect.Api/Program.cs
+++ b/FateConnect/FateConnect.Api/Program.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 namespace FateConnect.Api;
 
+using System.Globalization;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json.Serialization;
 using DotNetEnv;
@@ -8,6 +10,7 @@ using FateConnect.Api.Infrastructure.Converters;
 using FateConnect.Api.Infrastructure.Database;
 using FateConnect.Api.Infrastructure.Middlewares;
 using FateConnect.Api.Modules.Auth.Entities;
+using FateConnect.Api.Modules.Auth.Constants;
 using FateConnect.Api.Modules.Auth.Interfaces;
 using FateConnect.Api.Modules.Auth.Services;
 using FateConnect.Api.Modules.Rides.Interfaces;
@@ -151,6 +154,10 @@ public class Program
                     IssuerSigningKey = new SymmetricSecurityKey(key),
                     ClockSkew = TimeSpan.Zero
                 };
+                options.Events = new JwtBearerEvents
+                {
+                    OnTokenValidated = RejectRevokedTokenAsync
+                };
             });
 
         builder.Services.AddAuthorizationBuilder()
@@ -183,5 +190,29 @@ public class Program
         app.MapControllers();
 
         app.Run();
+    }
+
+    private static async Task RejectRevokedTokenAsync(TokenValidatedContext context)
+    {
+        string? carriedVersion = context.Principal?.FindFirstValue(TokenClaimNames.TokenVersion);
+        string? identifier = context.Principal?.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        bool isVersionReadable = int.TryParse(carriedVersion, CultureInfo.InvariantCulture, out int tokenVersion);
+        bool isIdentifierReadable = int.TryParse(identifier, CultureInfo.InvariantCulture, out int userId);
+        bool canCompareVersions = isVersionReadable && isIdentifierReadable;
+
+        if (!canCompareVersions)
+        {
+            context.Fail("The token carries no readable version and cannot be checked against the current one.");
+
+            return;
+        }
+
+        IUserRepository users = context.HttpContext.RequestServices.GetRequiredService<IUserRepository>();
+
+        int? currentVersion = await users.GetTokenVersionAsync(userId);
+
+        if (currentVersion != tokenVersion)
+            context.Fail("The token version no longer matches the one the session carries.");
     }
 }


### PR DESCRIPTION
## Objetivo

A API não tinha encerramento de sessão. Sair da aplicação apagaria o token do navegador e nada mais: ele seguiria **válido até o `exp`** — medido, **8 horas** —, então quem o tivesse interceptado continuaria autenticado e podendo fazer requisições no nome da pessoa.

Este PR acrescenta `POST /Auth/logout`, autenticado, que faz o token parar de ser aceito **no servidor**.

## Por que o servidor precisa guardar algo

Um JWT não pode ser invalidado: ele é uma string assinada e autossuficiente, e o servidor não guarda nada sobre ela — ao receber, só confere a assinatura e lê o que está escrito dentro. Não existe registro daquele token para se alterar, e o `exp` está **dentro** do payload assinado. O front remover do `localStorage` remove a cópia dele, não a de quem interceptou.

Para um token que era válido parar de passar, o servidor tem que lembrar de algo. Só há três famílias, e todas guardam estado — o que se escolhe é **onde** ele mora:

| Caminho | O que o servidor guarda |
| --- | --- |
| Lista de revogados | os tokens mortos |
| **Versão de sessão** (este PR) | **um inteiro por usuário** |
| Access curto + refresh | o refresh token |

Memória do processo seria a opção sem banco, e é a pior aqui: reinício esquece tudo e o token volta a valer — e reinício acontece em todo deploy.

## Alterações

**A versão de sessão.** `Users` ganha uma coluna `TokenVersion`, e cada token emitido carrega o valor dela numa claim. A validação do JWT compara a claim com a coluna, no gancho `OnTokenValidated`, antes de qualquer controller. O logout incrementa a coluna com um `UPDATE` atômico, e todo token que carrega o valor anterior deixa de casar.

Não há tabela, migration de tabela nem descarte de registro vencido: o estado é **um `integer`** numa linha que a requisição já precisa ler.

### Por que esta família, e não a lista de revogados

A primeira versão deste PR era `jti` mais lista de revogados, que dá granularidade por token — sair no celular não encerraria o laptop. Ela foi trocada por um motivo que decide:

⛔ **A lista de revogados não consegue invalidar na troca de senha.** Ela guarda os tokens já revogados, não os que estão vivos — então na troca de senha não há o que revogar, e os tokens antigos continuariam válidos pelas horas restantes. A **#114** tem no escopo *"Troca de senha exigindo a senha atual, regravando com BCrypt"*, na milestone de 28/09. Com versão de sessão, incrementar a coluna derruba todos.

E a granularidade que a lista comprava **não tem consumidor**: não há tela de sessões nem lista de aparelhos no produto, nem issue prevendo uma.

### Consequências

⚠️ **Sair encerra a sessão em todos os aparelhos** daquela pessoa. É o preço desta família, e está no changelog.

⚠️ **Token sem a claim de versão é recusado.** Todo token emitido antes desta versão não a carrega, então **quem estiver com a sessão aberta no momento da publicação é desconectado uma vez** e entra de novo. Aceitá-los abriria uma janela de 8 horas em que a invalidação não funcionaria. Decidido explicitamente; está no changelog, em `Changed`.

⚠️ **Requisição autenticada passa a exigir que o usuário exista**, porque a comparação lê a coluna. Isso corrigiu as fixtures: os testes que emitiam token para um id sem semear usuário passaram a semear, e a suíte ficou mais fiel ao caminho real. Um token de conta apagada deixa de ser aceito — hoje inalcançável, porque não há exclusão de conta na API.

### Fora de escopo

- **Reduzir as 8 horas de validade.** Sem refresh token, reduzir só empurra a pessoa a entrar de novo no meio do uso.
- **Refresh token.** É a terceira família da tabela acima, e um projeto próprio: endpoint de renovação, rotação, interceptor no front e corrida entre requisições paralelas.

### Destrava

O "Sair" do popover do avatar, que é a **#294** — ela depende deste PR, e é por isso que a API entrou antes. Hoje nenhum usuário da web alcança o endpoint.

## Issue

- #290

Closes #290

## Evidências

### Gates

| Gate | Resultado |
| --- | --- |
| `dotnet build` da solução | 0 erros, 0 warnings |
| `dotnet test` | **116 testes**, todos passando (eram 101; 15 novos) |
| `./scripts/coverage-changed.sh` | **exit 0** — os 9 arquivos de produção do diff acima de 90%, agregado **99,1%** |

Oito dos nove em **100%**, inclusive `TokenService`, `UserRepository`, `ClaimsPrincipalExtensions`, `AuthService`, `AuthController` e a entidade; o `Program.cs` em 98,0%.

Os quatro commits compilam sozinhos, conferido com `dotnet build` em cada SHA. A primeira tentativa de corte reprovou aqui — o commit da claim vinha antes do commit da coluna que ela lê —, e a ordem foi corrigida para a coluna primeiro.

### O par positivo

O **mesmo token** responde `204` em `GET /Auth/session` **antes** do logout e `401` **depois**. Sem o primeiro caso, a suíte passaria numa API que recusa tudo. E há o par do lado oposto: um token emitido **depois** do logout, com a versão nova, é aceito — o que prova que a pessoa consegue entrar de novo.

Os 9 testes de endpoint cobrem: logout sem token dá 401; com token válido dá 204; a sessão aceita antes e recusa depois; **outro token da mesma pessoa também é recusado**; token emitido após o logout é aceito; logout repetido dá 401 na segunda chamada; token sem claim de versão é recusado; e token de alguém que não existe é recusado. Mais 6 testes de unidade das extensions, com cada caminho de recusa.

### As mutações

Cada uma com o build da mutação verificado em 0 antes de rodar a suíte — sem isso, `dotnet test --no-build` rodaria a DLL anterior e a mutação pareceria sobreviver.

| Mutação | Testes que caem |
| --- | --- |
| não comparar a versão | 4 |
| aceitar token sem a claim de versão | 1 |
| o incremento não persistir | 4 |

As restaurações conferidas byte a byte com `cmp`, e a árvore confirmada limpa depois.

### A migration

`Up()` tem só `AddColumn` com `defaultValue: 0` — nenhum `DropTable`, `DropColumn` nem perda de dado; os usuários existentes nascem na versão 0. `Down()` remove a coluna nova. Os três `/// <inheritdoc />` que o `dotnet ef` escreve foram removidos; o `// <auto-generated />` do `.Designer.cs` ficou, porque ali o marcador é funcional.

Zero comentários em C#.
