### PR TITLE
docs: record what the session-logout and popover rounds taught

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,7 +22,7 @@ Planejamento e rastreio ficam no **GitHub** (issues + Project board do repositó
 
 ## Fluxo de trabalho
 
-- Branch base: **`develop`**. ⛔ **Nunca commitar direto nela** — toda mudança sai numa branch a partir da `develop` e volta por PR, **inclusive mudança em `.claude/`**. Nomear branch como `<tipo>/<número-da-issue>` (ex.: `chore/48`); quando não houver issue, um slug descritivo (`docs/spec-issue-skill`).
+- Branch base: **`develop`**. ⛔ **Nunca commitar direto nela** — toda mudança sai numa branch a partir da `develop` e volta por PR, **inclusive mudança em `.claude/`**. Nomear branch como `<tipo>/<número-da-issue>` (ex.: `chore/48`); quando não houver issue, um slug descritivo **em inglês** (`docs/spec-issue-skill`) — o idioma do fluxo git, como no commit e no título do PR.
 - Toda correção ou alteração começa por uma **issue no GitHub** — o número dela alimenta a branch, o título do PR e o corpo do PR.
 - Abrir PR: usar a skill `pr-creator`. Commitar: usar a skill `write-commit` — e **pedir confirmação antes de qualquer comando git**.
 - ⛔ **Nunca escrever changelog à mão** — usar a skill `changelog-writer`. À mão sai um bullet por commit, que é o oposto do formato: uma entrada principal descrevendo o efeito para quem usa. O formato está em `.claude/rules/changelog-format.md`.

--- a/.claude/rules/dotnet-authorization.md
+++ b/.claude/rules/dotnet-authorization.md
@@ -33,6 +33,24 @@ O nível depende de o controller ser homogêneo ou misto, e são casos diferente
 
 Endpoint novo entra na teoria de rotas do `AuthorizationTests`, que prova por HTTP (401 sem token, 200 com token). O par positivo é obrigatório — ver `dotnet-testing.md`.
 
+## Encerrar sessão exige estado no servidor
+
+⛔ **Limpar o token no cliente não encerra nada.** O JWT é uma string assinada e autossuficiente: a API não guarda registro dele, só confere a assinatura e lê as claims. O `exp` está **dentro** do payload assinado, e quem interceptou o token tem a própria cópia — apagar o `localStorage` apaga a cópia de quem saiu.
+
+Para um token que era válido parar de passar, o servidor tem de lembrar de algo. São **três** famílias, e todas guardam estado; o que se escolhe é onde ele mora:
+
+| Caminho | O que o servidor guarda |
+| --- | --- |
+| lista de revogados (`jti`) | os tokens mortos, mais o descarte dos vencidos |
+| **versão de sessão** | um inteiro por usuário — o que está implementado |
+| access curto + refresh | o refresh token |
+
+⚠️ **Memória de processo não é opção:** reinício esquece tudo e o token volta a valer, e reinício acontece em **todo deploy**.
+
+**O que está de pé:** `Users.TokenVersion` viaja como claim em cada token, `POST /Auth/logout` incrementa a coluna, e o gancho `OnTokenValidated` recusa quem carrega valor diferente. O login **lê** a coluna e estampa o valor atual — ⛔ nunca incremente no login: depois de emitir você mata o token que acabou de entregar, e antes de emitir você encerra as outras sessões da pessoa a cada entrada.
+
+⚠️ **Requisição autenticada passa a exigir que o usuário exista**, porque a comparação lê a coluna. Fixture que emite token para um id sem semear usuário recebe 401 — e um token de conta apagada deixa de ser aceito, o que é o comportamento desejado.
+
 ## Perfil ainda não se cobra
 
 O token já emite o perfil como `ClaimTypes.Role` (`TokenService.BuildUserClaims`), então gate por perfil é `[Authorize(Roles = ...)]` na action — não precisa de guard próprio, o ASP.NET Core já entrega o atributo.

--- a/.claude/rules/dotnet-testing.md
+++ b/.claude/rules/dotnet-testing.md
@@ -25,6 +25,8 @@ O relatório sai do `dotnet test` em formato **OpenCover** (`--collect:"XPlat Co
 
 Ele roda a suíte com cobertura, cruza o relatório com os arquivos de produção do diff e **sai com erro** listando quem ficou abaixo dos 90%.
 
+⛔ **Commite antes de medir.** O script cruza o relatório com `git diff origin/develop` — o estado **commitado**. Rodado com o trabalho solto na árvore ele mede o conjunto de arquivos errado e sai com **exit 0** dizendo que todos atingem 90%. Em 03/09/2026 isso aconteceu duas vezes na mesma sessão: uma sobre **zero** arquivos (`nenhum arquivo de produção da API no diff`), outra listando 8 e deixando de fora justamente os dois novos, porque o diff commitado ainda descrevia o desenho anterior. **O sinal é a contagem não bater com os arquivos que você mexeu.**
+
 ⛔ **Rode antes de dizer que acabou.** `dotnet build` + `dotnet test` não medem nada, e o portão do Sonar aceita 33% — as duas coisas ficam verdes sobre uma regra violada. Aconteceu na #222: o PR chegou a 79,5% no Sonar com o `AuthService` em **22,7%**, porque não existia um único teste de login. O que fechou o buraco foram três testes; o que impede a repetição é este comando.
 
 **Linha que não dá para cobrir se marca, não se ignora.** Construtor privado que existe só para impedir instanciação nunca é chamado: `[ExcludeFromCodeCoverage]` nele tira a linha do denominador e diz por quê. Baixar o alvo, não.

--- a/.claude/rules/parallelism-and-worktrees.md
+++ b/.claude/rules/parallelism-and-worktrees.md
@@ -68,6 +68,12 @@ Aconteceu na #171. O agente relatou, de boa-fé, ter medido a página selecionad
 
 **O que rodar:** suba a aplicação, ligue o componente numa tela de verdade — fiação temporária, fora de commit — e meça com `getComputedStyle` **ali**. Depois desfaça a fiação e confira que ela não entrou em commit nenhum.
 
+⛔ **A fiação vai no cromo de verdade, não numa barra própria.** Andaime com `zIndex` acima do Modal do MUI (1300) cria um mundo onde o backdrop não intercepta nada — e ali o componente ganha defeitos que não tem. Na #291 uma barra em `zIndex: 1500` produziu **três** achados aparentes: dois popovers abertos ao mesmo tempo, clique no gatilho que não fechava, e a seta de um coberta pelo papel do outro. No `Header` real (`AppBar` em 1100) o pixel sobre o gatilho pertence ao backdrop e os três desaparecem.
+
+⚠️ Baixar o `zIndex` do andaime não resolve: a 1100 ele empata com o cromo real e os cliques deixam de alcançar qualquer coisa. O caminho é passar os gatilhos como `actions` do próprio `Header`.
+
+⛔ **Fiação que existe para o Victor capturar evidência vive até ele dizer que acabou** — ela é ferramenta dele, não resíduo meu. Commitar e desmontar o andaime parecem o mesmo gesto de limpeza e não são: o commit fecha o meu trabalho, o andaime fecha o dele. Na #291 eu desmontei ao empurrar, tendo escrito *"me avise quando terminar de capturar"*, e a devolução foi *"eu preciso da demo pra coletar as evidências"*.
+
 ## Fatiação do agente: cada commit precisa compilar sozinho
 
 ⛔ **Confira o corte, não só o conteúdo.** O agente agrupa por assunto e esquece a ordem de dependência, e nenhum gate pega: eles rodam sempre na ponta da branch, nunca em cada commit.

--- a/.claude/rules/parallelism-and-worktrees.md
+++ b/.claude/rules/parallelism-and-worktrees.md
@@ -74,6 +74,20 @@ Aconteceu na #171. O agente relatou, de boa-fé, ter medido a página selecionad
 
 ⛔ **Fiação que existe para o Victor capturar evidência vive até ele dizer que acabou** — ela é ferramenta dele, não resíduo meu. Commitar e desmontar o andaime parecem o mesmo gesto de limpeza e não são: o commit fecha o meu trabalho, o andaime fecha o dele. Na #291 eu desmontei ao empurrar, tendo escrito *"me avise quando terminar de capturar"*, e a devolução foi *"eu preciso da demo pra coletar as evidências"*.
 
+## Dois servidores no ar, um painel de navegador só
+
+⛔ **O agente da worktree sobe o servidor dele, e o painel do navegador é compartilhado.** A aba que parece sua pode estar servindo o checkout do vizinho, em outra branch — e a página é idêntica o bastante para você não desconfiar.
+
+Aconteceu em 03/09/2026: eu media a #292 na 5173 enquanto o agente da #293 media a dele na 5293. Uma captura minha pegou a 5293 e mostrou **dois** cartões no menu onde a minha branch tinha três. Ia virar defeito da minha própria mudança.
+
+**A âncora é a porta, lida da própria página, junto de toda medição:**
+
+```js
+({ porta: location.port, rota: location.pathname })
+```
+
+E `lsof -nP -iTCP -sTCP:LISTEN | grep 517` diz quantos servidores existem. Mais de um ⇒ nenhuma medição vale sem dizer de qual porta veio.
+
 ## Fatiação do agente: cada commit precisa compilar sozinho
 
 ⛔ **Confira o corte, não só o conteúdo.** O agente agrupa por assunto e esquece a ordem de dependência, e nenhum gate pega: eles rodam sempre na ponta da branch, nunca em cada commit.

--- a/.claude/rules/product-copy.md
+++ b/.claude/rules/product-copy.md
@@ -89,9 +89,17 @@ Diz o que aconteceu e o que fazer: `Erro ao carregar os itens. Tente novamente.`
 
 ## Caixa: sentence case
 
-Rótulo de botão, aba e título de diálogo levam maiúscula **só na primeira palavra** — "Cadastrar item", "Confirmar exclusão". Nome próprio e sigla mantêm a caixa.
+Rótulo de botão, aba, título de diálogo e **cabeçalho de seção** levam maiúscula **só na primeira palavra** — "Cadastrar item", "Confirmar exclusão", "Dados para contato". Nome próprio e sigla mantêm a caixa.
 
 ⚠️ **Dívida conhecida:** caronas e cadastro ainda usam Title Case ("Ofertar Carona", "Salvar Alterações"), herdado do protótipo. Achados e perdidos já está em sentence case; a conversão do resto acontece quando alguém tocar em cada tela.
+
+## Cabeçalho de seção nomeia o que está dentro
+
+Frase nominal curta dizendo o conteúdo, como o cadastro já faz: `Endereço` e `Dados para contato`.
+
+⛔ **Não nomeie a seção pela natureza do ajuste.** `Ajustes do sistema` não separa nada para quem lê — a tela inteira é o sistema — e "ajustes" repete o nome da tela que a contém. Em preferências, a seção que reúne tema, e-mails e notificações chama-se `Aparência e notificações`.
+
+⚠️ **Nomeie pelo que a seção vai reunir, não só pelo que já está dentro dela.** Enquanto não houver usuários no sistema, descrever uma linha que ainda vai entrar custa menos que renomear a seção depois — é a mesma tolerância da exceção de escopo planejado acima, aplicada dentro da aplicação.
 
 ## Tooltip
 

--- a/.claude/rules/prove-the-mechanism.md
+++ b/.claude/rules/prove-the-mechanism.md
@@ -75,6 +75,23 @@ Ele imprimiu `seções fundidas:` com a lista vazia, e nada mais. O `git rebase`
 
 ⚠️ **O sinal é a saída vazia onde deveria haver enumeração.** "0 arquivos alterados", "nenhuma seção", "nada a fazer" — num passo que existe justamente para alterar algo, isso não é sucesso, é o instrumento dizendo que não entendeu a entrada.
 
+## O artefato publicado não é o que você quis escrever
+
+⛔ **Antes de afirmar o que um PR, uma issue ou um comentário seu diz, releia o publicado.** A lembrança guarda a **decisão** de registrar algo, e ela se lê exatamente igual a ter registrado — não há sensação diferente entre as duas.
+
+Aconteceu em 03/09/2026, fechando a rodada do #297. Eu disse que o resíduo de contraste do popover estava declarado no corpo do PR, *"junto das duas alternativas medidas e recusadas"*. O corpo não mencionava a paleta em linha nenhuma, e o único comentário do PR era o do Sonar. Eu tinha decidido registrar aquilo enquanto media, e li a decisão como o registro.
+
+**O gatilho é a frase que descreve conteúdo seu no passado** — "está no corpo do PR", "já registrei na issue", "o comentário explica". Cada uma é um comando que você ainda não rodou:
+
+```bash
+gh pr view <n> --json body -q .body
+gh api repos/<dono>/<repo>/issues/<n>/comments --jq '.[].body'
+```
+
+⚠️ **O custo não é a frase errada, é o que ela desliga.** Quem lê para de procurar: o Victor ia mergear achando que a limitação estava documentada para quem viesse depois.
+
+⚠️ **É diferente de afirmar sobre o que não li.** Ali a fonte é de outra pessoa e eu pulei a leitura; aqui a fonte é minha, e é justamente por isso que releitura não parece necessária.
+
 ## O que esta rule não é
 
 Não é ordem de esgotar toda dúvida antes de abrir a boca. Ela vale no **fechamento** — ao dizer "pronto", abrir PR ou pedir confirmação. No meio do trabalho, resíduo em aberto é normal, e dizer que está em aberto é o certo.

--- a/.claude/rules/say-what-you-chose.md
+++ b/.claude/rules/say-what-you-chose.md
@@ -1,0 +1,15 @@
+---
+description: Escolha que você tomou no lugar do Victor se anuncia na mensagem em que ela acontece — "depois eu sinalizo" é o instante em que ela vira decisão dele sem ele saber
+---
+
+# Diga o que você escolheu
+
+⛔ **Decidiu algo que ninguém te pediu? Diga na mesma mensagem.** Não no fim da tarefa, não no corpo do PR, não "mais para frente". Escolha não anunciada não fica pendente — ela vira decisão do Victor aos olhos de quem lê o código depois, inclusive dele.
+
+⛔ Aconteceu em 03/09/2026, na tela de preferências. A skill de UX writing propôs `Aparência clara ou escura` para a frase de apoio da linha do tema; o Victor decidiu **outra coisa ali perto** — o cabeçalho da seção — e eu troquei o texto por `Claro ou escuro` sozinho, para não repetir "Aparência" duas linhas seguidas. Eu sabia que precisava contar: escrevi para mim mesmo que ia sinalizar em uma linha. Não sinalizei. A cobrança veio como *"vc deixou o texto de suporte apenas como 'Claro ou escuro', foi uma decisão minha?"*.
+
+**O tell é a intenção de contar depois.** Se você está anotando que precisa avisar, você já não vai avisar — o turno acaba, o assunto muda, e a escolha some. Uma linha resolve: *"troquei X por Y porque Z; reverte se não for isso"*.
+
+⚠️ **O risco cresce quando ele acabou de decidir algo vizinho.** A resposta dele sobre o item ao lado dá a sensação de que a área inteira foi aprovada, e a sua escolha entra de carona. Decisão sobre o cabeçalho não é decisão sobre a linha de baixo.
+
+**Isto não é pedido de permissão.** Escolher para conseguir seguir é certo e esperado; o que não pode é a escolha ficar invisível. O custo de dizer é uma frase, e o de não dizer é ele descobrir num código que já passou por review.

--- a/.claude/rules/web-styling.md
+++ b/.claude/rules/web-styling.md
@@ -161,6 +161,22 @@ Medido de três jeitos na #291, e os dois primeiros levaram a conclusões errada
 
 ⚠️ **Quem reclama é sempre a pessoa que olha a tela**, porque o número mente com confiança: eu tinha `32px` de um lado e `32px` do outro, e mesmo assim estava torto. Ao receber "não está alinhado" sobre algo que você mediu, desconfie do **que** foi medido antes de duvidar do relato.
 
+## Propriedade em transição devolve o valor congelado
+
+⛔ **Com o painel do navegador oculto a página não compõe quadros, e a transição CSS não avança** — `getComputedStyle` devolve o valor do estado **anterior**, por mais que você espere.
+
+Medido em 03/09/2026 no interruptor de tema: desligado, sem a classe `Mui-checked`, com a única regra que casava dizendo `background-color: rgb(0, 0, 0)`, o computado devolvia o vermelho do estado ligado — em três leituras seguidas, com 800ms de espera cada. Ia para o relatório como "o interruptor parece sempre ligado", defeito que não existe.
+
+**O controle é desligar a transição antes de ler:**
+
+```js
+elemento.style.transition = 'none';
+const cor = getComputedStyle(elemento).backgroundColor;
+elemento.style.transition = '';
+```
+
+⚠️ **O sinal é o computado discordar da folha de estilo.** Antes de concluir que a cor está errada, liste as regras que de fato casam com o elemento — percorrer `document.styleSheets` testando `elemento.matches(regra.selectorText)`. Uma regra só, dizendo outra coisa, é a transição respondendo no lugar dela.
+
 ## Sobrescrever estado do MUI: repita a classe do componente
 
 ⛔ **`& .Mui-selected` empata com o seletor da biblioteca e perde no desempate por ordem de fonte.** Use `& .MuiPaginationItem-root.Mui-selected` — a classe do componente mais a do estado —, que sobe a especificidade acima da do MUI. Vale para `.Mui-selected`, `.Mui-disabled`, `.Mui-focused`, `.Mui-checked` e companhia.

--- a/.claude/rules/web-styling.md
+++ b/.claude/rules/web-styling.md
@@ -175,6 +175,8 @@ const cor = getComputedStyle(elemento).backgroundColor;
 elemento.style.transition = '';
 ```
 
+⚠️ **E o fundo contra o qual você mede pode não pintar nada.** `getComputedStyle(elemento).backgroundColor` devolve `rgba(0, 0, 0, 0)` no elemento transparente, e a fórmula de contraste trata isso como **preto** — no tema claro o número despenca e parece reprovação. Suba na árvore até o primeiro fundo com alfa diferente de zero antes de calcular. Medido na mesma tela: **2,66:1** contra o transparente e **7,89:1** contra o branco real do cartão.
+
 ⚠️ **O sinal é o computado discordar da folha de estilo.** Antes de concluir que a cor está errada, liste as regras que de fato casam com o elemento — percorrer `document.styleSheets` testando `elemento.matches(regra.selectorText)`. Uma regra só, dizendo outra coisa, é a transição respondendo no lugar dela.
 
 ## Sobrescrever estado do MUI: repita a classe do componente

--- a/.claude/rules/web-styling.md
+++ b/.claude/rules/web-styling.md
@@ -145,6 +145,20 @@ Medido em 01/09/2026, no X do diálogo: a arte ocupa **14px numa caixa de 24px**
 
 **Como medir o desenho:** `path.getBBox()` no `svg`, convertido para a escala da tela pela razão entre a largura renderizada e a do `viewBox`. Para texto, `Range.selectNodeContents` no elemento — a caixa do parágrafo inclui entrelinha que o olho não vê.
 
+### Vão entre elementos: da tinta até a **faixa de fundo** do vizinho
+
+⛔ **Vão entre um rótulo e o item abaixo dele não se mede de caixa a caixa nem de tinta a tinta.** O item de lista tem 48px de altura e a tinta dele fica no meio; o que o olho vê começar é o **fundo**. A medida que corresponde ao que se enxerga é da tinta do rótulo até a borda da faixa do item.
+
+Medido de três jeitos na #291, e os dois primeiros levaram a conclusões erradas:
+
+| Instrumento | Respondeu | O que produziu |
+| --- | --- | --- |
+| caixa → caixa | **0px**, antes e depois da correção | quase concluí que a correção não pegou |
+| tinta → tinta | 20px | pareceu folgado, e a devolução foi *"ainda ta mto colado"* |
+| tinta → **faixa de fundo** | **6px** | era o número |
+
+⚠️ **O sinal é o número que não se move.** `padding` acrescentado a um elemento para afastá-lo do vizinho **não altera** a distância entre as caixas — só `margin` alteraria. Se a medida é a mesma depois de uma correção que você sabe que aplicou, o instrumento está medindo a caixa.
+
 ⚠️ **Quem reclama é sempre a pessoa que olha a tela**, porque o número mente com confiança: eu tinha `32px` de um lado e `32px` do outro, e mesmo assim estava torto. Ao receber "não está alinhado" sobre algo que você mediu, desconfie do **que** foi medido antes de duvidar do relato.
 
 ## Sobrescrever estado do MUI: repita a classe do componente

--- a/.claude/skills/spec-issue/SKILL.md
+++ b/.claude/skills/spec-issue/SKILL.md
@@ -84,6 +84,14 @@ Priorize o que trava decisão adiante: contrato e modelo de dados primeiro, depo
 
 ⛔ Aconteceu na #163. A sabatina perguntou onde a rota morava, como os links abriam e se o rodapé linkava — implementação, toda ela — e **fechou calada as duas decisões que eram de produto**: que o texto seria renderizado como página React, e que entraria como rascunho. As duas foram para o corpo da issue escritas como decisão, sem nunca terem sido oferecidas como opção. As duas foram derrubadas durante a implementação, uma em cada mensagem — *"não ter texto na página, a ideia é que os links abram o PDF numa nova guia"* —, e o que já estava construído foi jogado fora. A cobrança foi exatamente esta: *"vc tomou uma decisão de renderizar o texto na página sem nem abordar outras opções e nem me perguntar"*.
 
+### Mecanismo recomendado se confere contra o roteiro
+
+⛔ **Antes de recomendar um mecanismo, procure no roteiro o que ele **também** vai ter de servir.** Um desenho que resolve o pedido de hoje e não alcança o item de três semanas adiante é uma recomendação errada — e o custo aparece com o código já escrito.
+
+⛔ Aconteceu na #290. Recomendei lista de revogados por `jti` para o encerramento de sessão, e o Victor escolheu. O que eu não pesei: a **#114** tem *"troca de senha exigindo a senha atual"* no escopo, e a lista de revogados **não consegue** invalidar ali — ela guarda os tokens já revogados, não os que estão vivos, então na troca de senha não há o que revogar. A saída correta era versão de sessão, que derruba todos incrementando uma coluna. A troca custou reescrever a branch inteira.
+
+**A conferência é uma busca:** `gh issue list --state open --search "<o conceito>"` e a leitura do escopo das que aparecerem. Vale sobretudo quando o mecanismo guarda ou invalida estado — sessão, permissão, cache —, porque é aí que um item futuro muda a resposta.
+
 ### A resposta em texto livre é a que muda o desenho
 
 A opção que o usuário digita vale mais que as que você ofereceu — e costuma contradizer algo já decidido. **Antes do bloco seguinte, reconcilie.**


### PR DESCRIPTION
## Objetivo

Registrar o que a rodada de especificação e os PRs #297 e #298 ensinaram. **Este PR fica aberto e vai sendo populado** conforme a rodada de issues render mais descobertas.

Só `.claude/` — nenhum código de aplicação.

## Alterações

### `dotnet-authorization.md` — encerrar sessão exige estado no servidor

⛔ Limpar o token no cliente não encerra nada: o JWT é autossuficiente, a API não guarda registro dele, e o `exp` está dentro do payload assinado. Quem interceptou tem a própria cópia.

A rule passa a listar as **três** famílias que resolvem, todas guardando estado, e a razão de memória de processo não ser opção — reinício esquece tudo, e reinício acontece em todo deploy. Registra também o que está de pé (`Users.TokenVersion` + `POST /Auth/logout` + `OnTokenValidated`), por que o **login lê e nunca incrementa**, e a consequência de fixture: requisição autenticada passou a exigir que o usuário exista.

### `spec-issue` — mecanismo recomendado se confere contra o roteiro

⛔ Antes de recomendar um mecanismo, procurar no roteiro o que ele **também** vai ter de servir.

Ancorado no caso que pagou: recomendei lista de revogados por `jti` para o logout, e a **#114** tem troca de senha no escopo — a lista não consegue invalidar ali, porque guarda os tokens revogados e não os vivos. A saída certa era versão de sessão. A troca custou reescrever a branch inteira, com o código já escrito.

### `dotnet-testing.md` — o script de cobertura mede o **commitado**

⛔ `coverage-changed.sh` cruza o relatório com `git diff origin/develop`. Rodado com o trabalho solto na árvore, ele mede o conjunto errado e sai com **exit 0**.

Aconteceu duas vezes na mesma sessão: uma sobre **zero** arquivos, outra listando 8 e deixando de fora justamente os dois novos, porque o diff commitado ainda descrevia o desenho anterior. O sinal é a contagem não bater com os arquivos que se mexeu.

### `web-styling.md` — vão se mede da tinta até a faixa de fundo do vizinho

⛔ Vão entre um rótulo e o item abaixo dele não se mede de caixa a caixa nem de tinta a tinta: o item tem 48px e a tinta fica no meio, então o que o olho vê começar é o **fundo**.

Medido de três jeitos no #297, e os dois primeiros levaram a conclusões erradas — 0px (caixa a caixa, igual antes e depois da correção), 20px (tinta a tinta, "pareceu folgado"), e **6px**, que era o número. Com o sinal que fecha o buraco: `padding` não altera distância entre caixas, então **medida que não se move depois de uma correção aplicada denuncia o instrumento**.

### `parallelism-and-worktrees.md` — onde a sonda vive, e até quando

⛔ A fiação temporária vai no **cromo de verdade**, não numa barra própria. Andaime acima do Modal do MUI (1300) cria um mundo sem backdrop: no #297 uma barra em `zIndex: 1500` produziu três achados aparentes — dois popovers abertos, clique que não fecha, seta coberta — e os três desapareceram no `Header` real (`AppBar` em 1100). Baixar o `zIndex` do andaime não resolve: ele passa a empatar com o cromo e os cliques não alcançam nada.

⛔ E fiação que existe para o Victor capturar evidência **vive até ele dizer que acabou**. Eu desmontei ao empurrar os commits, tendo escrito "me avise quando terminar de capturar".

### `CLAUDE.md` — o idioma da branch onde a branch é batizada

A exigência de nome de branch em inglês **já existia** em dois lugares, e eu a quebrei nesta mesma rodada batizando a branch deste PR de `docs/harness-medicao-e-logout`. O problema não era a ausência da regra, era o lugar: a linha que se lê ao batizar uma branch descrevia só o formato. A exigência desceu para lá; as outras duas menções ficam.

## Evidências

`./scripts/check-harness-paths.sh` — nenhum caminho órfão.

Não há teste a rodar: o PR não toca em código. Os quatro commits agrupam por assunto, não por arquivo — o de medição leva `web-styling` e `parallelism-and-worktrees` juntos porque são a mesma pergunta, e o do logout leva a `spec-issue` porque a lição dela nasceu daquele mecanismo.
