### PR TITLE
feat(292): add the routes that have no owner yet and carry denunciations into the navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Adiciona o botão de fechar nos diálogos quando a tela é estreita: a faixa em volta deles é curta demais para fechar por toque, e alargá-la deixaria o diálogo apertado. No desktop nada muda (#277) [Frontend]
 - Adiciona a marcação da tela atual no topo e no menu lateral, que antes não indicavam onde a pessoa estava; a marca também é anunciada por leitor de tela (#281) [Frontend]
 - Adiciona o encerramento de sessão na API, que invalida o token no servidor em vez de apenas descartá-lo no navegador: depois de sair, nenhum token daquela pessoa é aceito, em qualquer aparelho (#298) [Backend]
+- Adiciona Denúncias à navegação e ao menu, e faz perfil, denúncias e notificações abrirem uma tela avisando que a área ainda não está disponível, com a volta ao menu — antes os três endereços caíam na página inicial (#300) [Frontend]
 
 ### Changed
 

--- a/FateConnect/Web/src/constants/navigation.ts
+++ b/FateConnect/Web/src/constants/navigation.ts
@@ -17,4 +17,5 @@ export const LANDING_LINKS: LandingLink[] = [
 export const APP_LINKS: AppLink[] = [
   { path: RoutePathEnum.LOST_AND_FOUND, label: 'Achados & Perdidos' },
   { path: RoutePathEnum.RIDES, label: 'Caronas' },
+  { path: RoutePathEnum.DENUNCIATIONS, label: 'Denúncias' },
 ];

--- a/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
@@ -15,6 +15,7 @@ function renderLayout(initialEntry: RoutePathEnum = RoutePathEnum.MENU) {
         children: [
           { path: RoutePathEnum.MENU, element: <div>menu</div> },
           { path: RoutePathEnum.RIDES, element: <div>caronas</div> },
+          { path: RoutePathEnum.DENUNCIATIONS, element: <div>denúncias</div> },
         ],
       },
     ],
@@ -96,6 +97,20 @@ describe('MainLayout', () => {
     );
     expect(within(drawer).getByRole('link', { name: 'Achados & Perdidos' })).not.toHaveAttribute(
       'aria-current',
+    );
+  });
+
+  it('should carry the denunciations entry in the header and in the drawer', async () => {
+    renderLayout(RoutePathEnum.DENUNCIATIONS);
+
+    expect(screen.getByRole('link', { name: 'Denúncias' })).toHaveAttribute('aria-current', 'page');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Abrir menu', hidden: true }));
+    const drawer = screen.getByRole('presentation');
+
+    expect(within(drawer).getByRole('link', { name: 'Denúncias' })).toHaveAttribute(
+      'aria-current',
+      'page',
     );
   });
 });

--- a/FateConnect/Web/src/pages/Menu/constants/index.ts
+++ b/FateConnect/Web/src/pages/Menu/constants/index.ts
@@ -1,4 +1,4 @@
-import { DirectionsCarIcon, SearchIcon } from '@design-system/icons';
+import { DirectionsCarIcon, SearchIcon, SecurityIcon } from '@design-system/icons';
 
 import { RoutePathEnum } from '@app/routes/paths';
 
@@ -7,8 +7,9 @@ import type { MenuService } from '../@types';
 export const MENU_TITLE = 'Boas-vindas ao FateConnect';
 export const MENU_INTRO = 'Escolha um dos serviços abaixo para começar.';
 
-/** Mesma ordem do produto: achados e perdidos antes de caronas. */
+/** A ordem é a do produto, não alfabética. */
 export const MENU_SERVICES: MenuService[] = [
   { label: 'Achados & Perdidos', path: RoutePathEnum.LOST_AND_FOUND, Icon: SearchIcon },
   { label: 'Caronas', path: RoutePathEnum.RIDES, Icon: DirectionsCarIcon },
+  { label: 'Denúncias', path: RoutePathEnum.DENUNCIATIONS, Icon: SecurityIcon },
 ];

--- a/FateConnect/Web/src/pages/Unavailable/Unavailable.test.tsx
+++ b/FateConnect/Web/src/pages/Unavailable/Unavailable.test.tsx
@@ -1,0 +1,46 @@
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+import { RoutePathEnum } from '@app/routes/paths';
+import { render, screen, userEvent } from '@app/test/testing-library';
+
+import * as C from './constants';
+import { Unavailable, type UnavailableProps } from '.';
+
+const DEFAULT_PROPS: UnavailableProps = { description: C.PROFILE_DESCRIPTION };
+
+function renderComponent(props = DEFAULT_PROPS) {
+  const router = createMemoryRouter(
+    [
+      { path: RoutePathEnum.PROFILE, element: <Unavailable {...props} /> },
+      { path: RoutePathEnum.MENU, element: <div>menu</div> },
+    ],
+    { initialEntries: [RoutePathEnum.PROFILE] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+describe('Unavailable', () => {
+  it('should announce that the area is not available yet', () => {
+    renderComponent();
+
+    expect(screen.getByRole('heading', { name: C.UNAVAILABLE_TITLE })).toBeInTheDocument();
+    expect(screen.getByText(C.PROFILE_DESCRIPTION)).toBeInTheDocument();
+  });
+
+  it('should show the description of the route that rendered it', () => {
+    renderComponent({ description: C.NOTIFICATIONS_DESCRIPTION });
+
+    expect(screen.getByText(C.NOTIFICATIONS_DESCRIPTION)).toBeInTheDocument();
+    expect(screen.queryByText(C.PROFILE_DESCRIPTION)).not.toBeInTheDocument();
+  });
+
+  it('should take the user back to the menu', async () => {
+    const router = renderComponent();
+
+    await userEvent.click(screen.getByRole('link', { name: C.BACK_TO_MENU_LABEL }));
+
+    expect(router.state.location.pathname).toBe(RoutePathEnum.MENU);
+  });
+});

--- a/FateConnect/Web/src/pages/Unavailable/constants/index.ts
+++ b/FateConnect/Web/src/pages/Unavailable/constants/index.ts
@@ -1,0 +1,6 @@
+export const UNAVAILABLE_TITLE = 'Ainda não disponível';
+export const BACK_TO_MENU_LABEL = 'Voltar ao menu';
+
+export const PROFILE_DESCRIPTION = 'A edição do perfil chega em uma próxima versão.';
+export const DENUNCIATIONS_DESCRIPTION = 'O registro de denúncia chega em uma próxima versão.';
+export const NOTIFICATIONS_DESCRIPTION = 'A central de notificações chega em uma próxima versão.';

--- a/FateConnect/Web/src/pages/Unavailable/index.tsx
+++ b/FateConnect/Web/src/pages/Unavailable/index.tsx
@@ -1,0 +1,19 @@
+import { Link as RouterLink } from 'react-router';
+import { Button, PageMessage } from '@design-system';
+
+import { RoutePathEnum } from '@app/routes/paths';
+
+import * as C from './constants';
+
+export type UnavailableProps = Readonly<{ description: string }>;
+
+/** As três rotas sem dono mostram esta tela; só a descrição muda. */
+export function Unavailable({ description }: UnavailableProps) {
+  return (
+    <PageMessage title={C.UNAVAILABLE_TITLE} description={description}>
+      <Button component={RouterLink} to={RoutePathEnum.MENU} variant="contained" color="secondary">
+        {C.BACK_TO_MENU_LABEL}
+      </Button>
+    </PageMessage>
+  );
+}

--- a/FateConnect/Web/src/routes/paths.ts
+++ b/FateConnect/Web/src/routes/paths.ts
@@ -9,6 +9,9 @@ export enum RoutePathEnum {
   MENU = '/menu',
   LOST_AND_FOUND = '/achados-perdidos',
   RIDES = '/caronas',
+  PROFILE = '/perfil',
+  DENUNCIATIONS = '/denuncias',
+  NOTIFICATIONS = '/notificacoes',
 }
 
 /** Fragmentos das seções da landing, usados na navegação por âncora. */

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -7,6 +7,7 @@ import { LOST_AND_FOUND_TITLE } from '@app/pages/LostAndFound/constants';
 import { MENU_TITLE } from '@app/pages/Menu/constants';
 import { RIDES_TITLE } from '@app/pages/Rides/constants';
 import { SIGNUP_TITLE } from '@app/pages/Signup/constants';
+import * as C from '@app/pages/Unavailable/constants';
 import { tokenStorage } from '@app/services/auth/tokenStorage';
 import { render, screen, waitFor, within } from '@app/test/testing-library';
 import { tokenWithName } from '@app/test/token';
@@ -57,6 +58,19 @@ describe('routeConfig', () => {
     renderRoute(path);
 
     await expectTitle(title);
+  });
+
+  it.each([
+    [RoutePathEnum.PROFILE, C.PROFILE_DESCRIPTION],
+    [RoutePathEnum.DENUNCIATIONS, C.DENUNCIATIONS_DESCRIPTION],
+    [RoutePathEnum.NOTIFICATIONS, C.NOTIFICATIONS_DESCRIPTION],
+  ])('should resolve %s with the screen that has no owner yet', async (path, description) => {
+    tokenStorage.save(tokenWithName('Maria da Silva'));
+
+    renderRoute(path);
+
+    await expectTitle(C.UNAVAILABLE_TITLE);
+    expect(screen.getByText(description)).toBeInTheDocument();
   });
 
   it.each([

--- a/FateConnect/Web/src/routes/routeConfig.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.tsx
@@ -11,6 +11,8 @@ import { LostAndFound } from '@app/pages/LostAndFound';
 import { Menu } from '@app/pages/Menu';
 import { Rides } from '@app/pages/Rides';
 import { Signup } from '@app/pages/Signup';
+import { Unavailable } from '@app/pages/Unavailable';
+import * as C from '@app/pages/Unavailable/constants';
 
 import { RoutePathEnum } from './paths';
 
@@ -41,6 +43,18 @@ export const routeConfig: RouteObject[] = [
               { path: RoutePathEnum.MENU, element: <Menu /> },
               { path: RoutePathEnum.LOST_AND_FOUND, element: <LostAndFound /> },
               { path: RoutePathEnum.RIDES, element: <Rides /> },
+              {
+                path: RoutePathEnum.PROFILE,
+                element: <Unavailable description={C.PROFILE_DESCRIPTION} />,
+              },
+              {
+                path: RoutePathEnum.DENUNCIATIONS,
+                element: <Unavailable description={C.DENUNCIATIONS_DESCRIPTION} />,
+              },
+              {
+                path: RoutePathEnum.NOTIFICATIONS,
+                element: <Unavailable description={C.NOTIFICATIONS_DESCRIPTION} />,
+              },
             ],
           },
         ],


### PR DESCRIPTION
## Objetivo

Os popovers do topo e o menu em seções vão apontar para perfil, denúncias e notificações — três destinos que não existiam, e cujos endereços caíam no curinga que leva à landing. Este PR cria as rotas e a tela que elas mostram até as issues donas chegarem, e leva Denúncias para a navegação.

## Alterações

**Três rotas novas na área logada** — `/perfil`, `/denuncias` e `/notificacoes`, em pt-BR como as demais, dentro do `AppRoute`.

**A tela de indisponível** (`src/pages/Unavailable/`) — título, descrição e a ação que volta ao menu.

**Denúncias na navegação** — item do topo, item do menu lateral e o terceiro cartão da tela de menu, com o mesmo `SecurityIcon` que a landing já usa em "Portal de denúncias": mesmo conceito, mesmo desenho.

### Decisões que quem for revisar precisa saber

- **A tela é um componente só**, e recebe a descrição por propriedade — quem monta a rota diz qual é. O título e a ação são iguais nas três, então três telas seriam três cópias.
- **Ela é montada sobre o `PageMessage`**, cujo JSDoc diz servir "tanto para área ainda não disponível quanto para erro não capturado". O segundo caso tinha dois consumidores; o primeiro **nunca teve nenhum**. Este PR escreve o consumidor que faltava, em vez de desenhar outra tela.
- **O comentário acima da lista de serviços do menu envelheceu neste PR** — ele enumerava dois itens ("achados e perdidos antes de caronas") e agora são três. Virou "A ordem é a do produto, não alfabética", que diz a mesma coisa sem enumerar.
- **Cada commit compila sozinho:** o primeiro não cita "Denúncias" em lugar nenhum, e o segundo usa uma rota que já existe no primeiro.

### Irmãs

As telas definitivas vêm na #112 (`/denuncias`), na #118 (`/perfil`) e na #119 (`/notificacoes`) — as três substituem o conteúdo sem recriar a rota. A #294, a #295 e a #296 apontam para estes destinos.

## Issue

- #292

Closes #292

## Evidências

<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/0874eca2-6e4a-40ba-beb5-84c783003726" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/840f2482-6d66-456f-a9c7-6110d902387f" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/64586637-0611-4548-a165-d6bcc447c1b6" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/3ff4ce73-4190-4671-b393-e104a869384b" />


### Gates, com o Node 24.18.0 do `.nvmrc`

| Gate | Resultado |
| --- | --- |
| ESLint nos 9 arquivos | exit 0 |
| `tsc --noEmit` | exit 0 |
| Suíte inteira | 74 arquivos, **524 testes** |
| `yarn test:ci`, o gate do CI | exit 0 — 98,52% statements e 99,27% lines; os arquivos novos e alterados com **100% de linhas** |
| Densidade de comentário | **5 de 124 linhas — 4,0%** |

### Medição dentro da aplicação

As três rotas ficam atrás do guard de sessão, então liguei uma fiação temporária para alcançar o cromo sem entrar, medi, desfiz, e conferi que ela não entrou em commit nenhum.

| O que | Medido |
| --- | --- |
| `/perfil`, `/denuncias`, `/notificacoes` | cada uma com a sua descrição; mesmo título e mesma ação |
| `Denúncias` no topo, na rota dele | `aria-current="page"`, e os vizinhos sem o atributo |
| `Denúncias` na gaveta, na rota dele | `aria-current="page"` |
| `/menu` | três cartões |
| Contraste do texto da tela | **14,22:1** no escuro e **7,03:1** no claro, contra o mínimo de 4,5 |

### Resíduo em aberto

Num dos seis runs da suíte, **1 teste falhou e eu não capturei qual** — o output daquele run não foi salvo. Os quatro runs seguintes e o `yarn test:ci` foram verdes. O mecanismo é desconhecido, então não estou tratando como resolvido.
