### PR TITLE
feat(293): move the theme preference into its own screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Passa a distribuir os campos da conta em dois por linha no cadastro — nascimento com gênero, e-mail com senha —, em vez de três (#287) [Frontend]
 - Passa a recusar os tokens emitidos antes desta versão, que não carregam a versão de sessão e por isso não podem ser invalidados; quem estiver com a sessão aberta no momento da publicação entra de novo, uma vez (#298) [Backend]
 - Clareia o texto de marca e os blocos de carregamento no tema escuro, que ganham contraste contra o fundo (#297) [Frontend]
+- Move a preferência de tema do topo da área logada para uma tela própria, em Preferências, alcançada pelo menu; na página inicial o botão continua no topo, para quem ainda não entrou (#301) [Frontend]
 
 ### Fixed
 

--- a/FateConnect/Web/design-system/icons.ts
+++ b/FateConnect/Web/design-system/icons.ts
@@ -33,6 +33,7 @@ export { default as ScheduleIcon } from '@mui/icons-material/Schedule';
 export { default as SaveIcon } from '@mui/icons-material/Save';
 export { default as SearchIcon } from '@mui/icons-material/Search';
 export { default as SecurityIcon } from '@mui/icons-material/Security';
+export { default as SettingsIcon } from '@mui/icons-material/Settings';
 export { default as VisibilityIcon } from '@mui/icons-material/Visibility';
 export { default as VisibilityOffIcon } from '@mui/icons-material/VisibilityOff';
 

--- a/FateConnect/Web/design-system/index.ts
+++ b/FateConnect/Web/design-system/index.ts
@@ -45,6 +45,7 @@ export type { DialogProps } from './components/Dialog';
 export { ThemeProvider } from './ThemeProvider';
 export { DateLocalizationProvider } from './DateLocalizationProvider';
 export { useThemeMode } from './ThemeProvider/context/ThemeModeContext';
+export type { ThemeMode } from './theme';
 export { ThemeToggleButton } from './components/ThemeToggleButton';
 export { GlobalStyles } from './GlobalStyles';
 export { spacingScale, radiusScale, shadowTokens, iconSizeTokens } from './tokens';

--- a/FateConnect/Web/design-system/theme/contrast.test.ts
+++ b/FateConnect/Web/design-system/theme/contrast.test.ts
@@ -59,6 +59,7 @@ function nonTextColours(theme: Theme): [string, string][] {
     ['the field outline', theme.palette.inputOutline],
     ['the button fill', theme.palette.secondary.main],
     ['the loading skeleton', theme.palette.skeleton],
+    ['the switch track', theme.palette.switchTrack],
   ];
 }
 

--- a/FateConnect/Web/design-system/theme/createAppTheme.ts
+++ b/FateConnect/Web/design-system/theme/createAppTheme.ts
@@ -39,6 +39,7 @@ declare module '@mui/material/styles' {
     inputOutline: string;
     surfaceFloating: string;
     skeleton: string;
+    switchTrack: string;
     statusTag: Record<StatusTagTone, SurfacePair>;
     notification: Record<NotificationVariant, SurfacePair>;
   }
@@ -49,6 +50,7 @@ declare module '@mui/material/styles' {
     inputOutline: string;
     surfaceFloating: string;
     skeleton: string;
+    switchTrack: string;
     statusTag: Record<StatusTagTone, SurfacePair>;
     notification: Record<NotificationVariant, SurfacePair>;
   }

--- a/FateConnect/Web/design-system/theme/palettes.ts
+++ b/FateConnect/Web/design-system/theme/palettes.ts
@@ -58,6 +58,7 @@ export const lightPalette: PaletteOptions = {
   inputOutline: colorTokens.inputOutline,
   surfaceFloating: colorTokens.surfaceWhite,
   skeleton: colorTokens.skeleton,
+  switchTrack: colorTokens.switchTrack,
   statusTag: {
     neutral: { surface: NO_SURFACE, content: INHERITED_CONTENT },
     muted: { surface: colorTokens.mutedBackground, content: colorTokens.mutedText },
@@ -124,6 +125,7 @@ export const darkPalette: PaletteOptions = {
   inputOutline: darkColorTokens.onSurfaceDisabled,
   surfaceFloating: darkColorTokens.surfaceFloating,
   skeleton: darkColorTokens.skeleton,
+  switchTrack: darkColorTokens.switchTrack,
   // No escuro o par da etiqueta e o do aviso invertem de claridade, não de papel.
   statusTag: {
     neutral: { surface: NO_SURFACE, content: INHERITED_CONTENT },

--- a/FateConnect/Web/design-system/tokens/palette.ts
+++ b/FateConnect/Web/design-system/tokens/palette.ts
@@ -55,6 +55,12 @@ export const colorTokens = {
    */
   skeleton: '#848C92',
 
+  /**
+   * Trilho do interruptor desligado. O cinza do iOS fica em 1,2:1 e some sobre
+   * o cartão branco; este alcança os 3:1 da WCAG 1.4.11 para não-texto.
+   */
+  switchTrack: '#848C92',
+
   /** Divisor sobre superfície neutra. */
   divider: '#D9D9D9',
   /** Divisor sobre o cromo colorido, onde a linha precisa ser clara. */
@@ -147,6 +153,9 @@ export const darkColorTokens = {
    * para 2,14:1, abaixo do mínimo de 3:1 para não-texto.
    */
   skeleton: '#818181',
+
+  /** Trilho do interruptor desligado, no mesmo mínimo de 3:1 do tema claro. */
+  switchTrack: '#818181',
 
   onSurfaceHigh: 'rgba(255, 255, 255, 0.87)',
   onSurfaceMedium: 'rgba(255, 255, 255, 0.60)',

--- a/FateConnect/Web/design-system/ui.ts
+++ b/FateConnect/Web/design-system/ui.ts
@@ -22,6 +22,7 @@ export { default as ListItemText } from '@mui/material/ListItemText';
 export { default as ListSubheader } from '@mui/material/ListSubheader';
 export { default as Popover } from '@mui/material/Popover';
 export { default as Stack } from '@mui/material/Stack';
+export { default as Switch } from '@mui/material/Switch';
 export { default as Toolbar } from '@mui/material/Toolbar';
 export { default as Typography } from '@mui/material/Typography';
 

--- a/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
@@ -60,6 +60,18 @@ describe('MainLayout', () => {
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 
+  // É a contagem que denuncia um segundo botão voltando para o topo; buscar
+  // pelo nome do alternador passaria se ele voltasse com outro rótulo.
+  it('should leave the theme toggle out of the header', () => {
+    tokenStorage.save(tokenWithName('Maria da Silva'));
+    renderLayout();
+
+    const header = within(screen.getByRole('banner'));
+
+    expect(header.getAllByRole('button', { hidden: true })).toHaveLength(1);
+    expect(header.getByRole('button', { name: 'Abrir menu', hidden: true })).toBeInTheDocument();
+  });
+
   it('should point the logo to the menu', () => {
     renderLayout();
 

--- a/FateConnect/Web/src/layouts/MainLayout/components/HeaderActions/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/components/HeaderActions/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { InitialsAvatar, ThemeToggleButton } from '@design-system';
+import { InitialsAvatar } from '@design-system';
 
 import { loggedUserName } from '@app/services/auth/loggedUser';
 import { getInitials } from '@app/utils/initials';
@@ -12,10 +12,7 @@ export function HeaderActions() {
   const userName = loggedUserName() ?? '';
   const initials = useMemo(() => getInitials(userName), [userName]);
 
-  return (
-    <>
-      <ThemeToggleButton />
-      {initials ? <InitialsAvatar initials={initials} label={userName} /> : null}
-    </>
-  );
+  if (!initials) return null;
+
+  return <InitialsAvatar initials={initials} label={userName} />;
 }

--- a/FateConnect/Web/src/pages/Preferences/Preferences.test.tsx
+++ b/FateConnect/Web/src/pages/Preferences/Preferences.test.tsx
@@ -1,0 +1,68 @@
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+import { RoutePathEnum } from '@app/routes/paths';
+import { cleanup, render, screen, userEvent } from '@app/test/testing-library';
+
+import * as C from './constants';
+import { Preferences } from '.';
+
+function renderComponent() {
+  const router = createMemoryRouter(
+    [
+      { path: RoutePathEnum.PREFERENCES, element: <Preferences /> },
+      { path: RoutePathEnum.MENU, element: <div>menu</div> },
+    ],
+    { initialEntries: [RoutePathEnum.PREFERENCES] },
+  );
+  render(<RouterProvider router={router} />);
+}
+
+function documentBackground() {
+  return getComputedStyle(document.body).backgroundColor;
+}
+
+function themeSwitch() {
+  return screen.getByRole('switch', { name: C.THEME_SWITCH_LABEL });
+}
+
+describe('Preferences', () => {
+  it('should title the screen and offer the way back to the menu', () => {
+    renderComponent();
+
+    expect(screen.getByRole('heading', { name: C.PREFERENCES_TITLE })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: C.BACK_LABEL })).toHaveAttribute(
+      'href',
+      RoutePathEnum.MENU,
+    );
+  });
+
+  it('should group the theme setting under the system section', () => {
+    renderComponent();
+
+    expect(screen.getByRole('heading', { name: C.APPEARANCE_SECTION_TITLE })).toBeInTheDocument();
+    expect(screen.getByText(C.THEME_LABEL)).toBeInTheDocument();
+    expect(screen.getByText(C.THEME_DESCRIPTION)).toBeInTheDocument();
+  });
+
+  it('should start unchecked in the light theme and turn the theme dark when switched', async () => {
+    renderComponent();
+    const lightBackground = documentBackground();
+
+    expect(themeSwitch()).not.toBeChecked();
+
+    await userEvent.click(themeSwitch());
+
+    expect(themeSwitch()).toBeChecked();
+    expect(documentBackground()).not.toBe(lightBackground);
+  });
+
+  it('should keep the chosen mode when the screen is mounted again', async () => {
+    renderComponent();
+    await userEvent.click(themeSwitch());
+
+    cleanup();
+    renderComponent();
+
+    expect(themeSwitch()).toBeChecked();
+  });
+});

--- a/FateConnect/Web/src/pages/Preferences/constants/index.ts
+++ b/FateConnect/Web/src/pages/Preferences/constants/index.ts
@@ -1,0 +1,7 @@
+export const PREFERENCES_TITLE = 'Preferências';
+export const BACK_LABEL = 'Voltar ao menu';
+
+export const APPEARANCE_SECTION_TITLE = 'Aparência e notificações';
+export const THEME_LABEL = 'Tema';
+export const THEME_DESCRIPTION = 'Claro ou escuro';
+export const THEME_SWITCH_LABEL = 'Tema escuro';

--- a/FateConnect/Web/src/pages/Preferences/index.tsx
+++ b/FateConnect/Web/src/pages/Preferences/index.tsx
@@ -1,0 +1,57 @@
+import { NavLink } from 'react-router';
+import { PageShell, Typography, useThemeMode } from '@design-system';
+import { ArrowBackIcon, DarkModeIcon, LightModeIcon, SettingsIcon } from '@design-system/icons';
+
+import { RoutePathEnum } from '@app/routes/paths';
+
+import * as C from './constants';
+import * as S from './styles';
+
+export function Preferences() {
+  const { mode, toggleMode } = useThemeMode();
+
+  return (
+    <PageShell
+      title={C.PREFERENCES_TITLE}
+      action={
+        <PageShell.Back
+          label={C.BACK_LABEL}
+          icon={<ArrowBackIcon fontSize="small" />}
+          component={NavLink}
+          to={RoutePathEnum.MENU}
+        />
+      }
+    >
+      <S.SettingsCard>
+        <S.SectionHeading variant="h2">
+          <SettingsIcon fontSize="small" />
+          {C.APPEARANCE_SECTION_TITLE}
+        </S.SectionHeading>
+
+        <S.SettingRow>
+          <S.SettingText>
+            <Typography variant="subtitleBold">{C.THEME_LABEL}</Typography>
+            <S.SettingDescription variant="caption">{C.THEME_DESCRIPTION}</S.SettingDescription>
+          </S.SettingText>
+
+          <S.ThemeSwitch
+            disableRipple
+            checked={mode === 'dark'}
+            onChange={toggleMode}
+            slotProps={{ input: { 'aria-label': C.THEME_SWITCH_LABEL } }}
+            icon={
+              <S.SwitchThumb>
+                <LightModeIcon />
+              </S.SwitchThumb>
+            }
+            checkedIcon={
+              <S.SwitchThumb>
+                <DarkModeIcon />
+              </S.SwitchThumb>
+            }
+          />
+        </S.SettingRow>
+      </S.SettingsCard>
+    </PageShell>
+  );
+}

--- a/FateConnect/Web/src/pages/Preferences/styles.ts
+++ b/FateConnect/Web/src/pages/Preferences/styles.ts
@@ -1,0 +1,88 @@
+import {
+  Box,
+  radiusScale,
+  shadowTokens,
+  spacingScale,
+  Stack,
+  styled,
+  Switch,
+  Typography,
+} from '@design-system';
+
+const { none, xxs, xs, sm, md, lg } = spacingScale;
+
+export const SettingsCard = styled(Stack)(({ theme }) => ({
+  flexDirection: 'column',
+  gap: theme.space(md),
+  padding: theme.space(lg),
+  borderRadius: theme.radius(radiusScale.component),
+  backgroundColor: theme.palette.background.paper,
+  boxShadow: shadowTokens.component,
+  color: theme.palette.text.primary,
+}));
+
+export const SectionHeading = styled(Typography)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space(xs),
+}));
+
+export const SettingRow = styled(Stack)(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.space(sm),
+}));
+
+export const SettingText = styled(Stack)(({ theme }) => ({
+  flexDirection: 'column',
+  gap: theme.space(xxs),
+}));
+
+export const SettingDescription = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+}));
+
+/**
+ * O desenho substitui o botão inteiro do interruptor, então ele carrega o
+ * círculo além do glifo. O glifo lê `chrome.main` porque o círculo é branco nos
+ * dois temas: `text.secondary` clareia no escuro e sumiria dentro dele.
+ */
+export const SwitchThumb = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '22px',
+  height: '22px',
+  borderRadius: '50%',
+  backgroundColor: theme.palette.common.white,
+  boxShadow: shadowTokens.component,
+  '& svg': { fontSize: '14px', color: theme.palette.chrome.main },
+}));
+
+/**
+ * Interruptor no desenho do iOS: trilho sólido do tamanho do polegar, sem o véu
+ * translúcido do Material — era ele que deixava o estado desligado em 2,68:1,
+ * abaixo do mínimo de 3:1 para não-texto.
+ */
+export const ThemeSwitch = styled(Switch)(({ theme }) => ({
+  width: '48px',
+  height: '30px',
+  padding: theme.space(none),
+  '& .MuiSwitch-switchBase': {
+    padding: theme.space(xxs),
+    '&.Mui-checked': {
+      transform: 'translateX(18px)',
+      '& + .MuiSwitch-track': {
+        backgroundColor: theme.palette.secondary.main,
+        opacity: 1,
+      },
+    },
+  },
+  '& .MuiSwitch-track': {
+    borderRadius: '15px',
+    backgroundColor: theme.palette.switchTrack,
+    opacity: 1,
+    transition: theme.transitions.create('background-color'),
+  },
+}));

--- a/FateConnect/Web/src/routes/paths.ts
+++ b/FateConnect/Web/src/routes/paths.ts
@@ -9,6 +9,7 @@ export enum RoutePathEnum {
   MENU = '/menu',
   LOST_AND_FOUND = '/achados-perdidos',
   RIDES = '/caronas',
+  PREFERENCES = '/preferencias',
   PROFILE = '/perfil',
   DENUNCIATIONS = '/denuncias',
   NOTIFICATIONS = '/notificacoes',

--- a/FateConnect/Web/src/routes/routeConfig.test.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.test.tsx
@@ -5,6 +5,7 @@ import { server } from '@app/mocks/server';
 import { DESCRIPTION_TITLE } from '@app/pages/Home/components/LandingDescription/constants';
 import { LOST_AND_FOUND_TITLE } from '@app/pages/LostAndFound/constants';
 import { MENU_TITLE } from '@app/pages/Menu/constants';
+import { PREFERENCES_TITLE } from '@app/pages/Preferences/constants';
 import { RIDES_TITLE } from '@app/pages/Rides/constants';
 import { SIGNUP_TITLE } from '@app/pages/Signup/constants';
 import * as C from '@app/pages/Unavailable/constants';
@@ -52,6 +53,7 @@ describe('routeConfig', () => {
     [RoutePathEnum.MENU, MENU_TITLE],
     [RoutePathEnum.LOST_AND_FOUND, LOST_AND_FOUND_TITLE],
     [RoutePathEnum.RIDES, RIDES_TITLE],
+    [RoutePathEnum.PREFERENCES, PREFERENCES_TITLE],
   ])('should resolve %s with a session', async (path, title) => {
     tokenStorage.save(tokenWithName('Maria da Silva'));
 

--- a/FateConnect/Web/src/routes/routeConfig.tsx
+++ b/FateConnect/Web/src/routes/routeConfig.tsx
@@ -9,6 +9,7 @@ import { RootLayout } from '@app/layouts/RootLayout';
 import { Home } from '@app/pages/Home';
 import { LostAndFound } from '@app/pages/LostAndFound';
 import { Menu } from '@app/pages/Menu';
+import { Preferences } from '@app/pages/Preferences';
 import { Rides } from '@app/pages/Rides';
 import { Signup } from '@app/pages/Signup';
 import { Unavailable } from '@app/pages/Unavailable';
@@ -43,6 +44,7 @@ export const routeConfig: RouteObject[] = [
               { path: RoutePathEnum.MENU, element: <Menu /> },
               { path: RoutePathEnum.LOST_AND_FOUND, element: <LostAndFound /> },
               { path: RoutePathEnum.RIDES, element: <Rides /> },
+              { path: RoutePathEnum.PREFERENCES, element: <Preferences /> },
               {
                 path: RoutePathEnum.PROFILE,
                 element: <Unavailable description={C.PROFILE_DESCRIPTION} />,


### PR DESCRIPTION
## Objetivo

A preferência de tema era um botão no topo, visível em qualquer largura. Ela passa a morar numa tela própria, e o topo da área logada fica livre para a campainha e o avatar — que é o desenho para onde o cromo está indo.

## Alterações

**Tela de preferências** (`/preferencias`, dentro da área logada) — cabeçalho de seção "Aparência e notificações" e a linha do tema: rótulo, frase de apoio e um interruptor que liga o tema escuro. A escolha continua sobrevivendo ao recarregamento.

**O botão de tema sai do topo de quem está logado**, em qualquer largura.

**Design system** — os barrels passam a expor o interruptor e o ícone de engrenagem, e a paleta ganha a chave `switchTrack`, declarada nos dois temas.

### Decisões que quem for revisar precisa saber

- **A landing mantém o botão de tema.** A remoção é do topo da área logada; quem não entrou não alcança `/preferencias`, e tirá-lo de lá deixaria essa pessoa sem nenhuma forma de trocar o tema.
- **O interruptor é o desenho do iOS**, não o do Material: 48×30 com polegar de 22px e trilho sólido. O trilho translúcido do Material deixava o estado desligado em **2,68:1**, abaixo do mínimo de 3:1 para elemento não-textual; o sólido resolve porque a cor é escolhida, não derivada de opacidade.
- **A cor do trilho é chave de paleta, não valor no componente** (`switchTrack`), e entrou na lista de não-texto do `contrast.test.ts` — o mínimo de 3:1 passa a ser verificado por teste. **Controle positivo:** com o cinza do próprio iOS (`#E9E9EA`) o teste reprova os dois pares; com o nosso, passa.
- **O ícone dentro do polegar mostra o tema atual** — sol no claro, lua no escuro —, igual ao botão que continua na landing e ao que a `web-forms.md` pede.
- **O glifo lê `chrome.main`, e isso não é escolha estética.** O polegar é branco nos dois temas; com `text.secondary` a lua saía **branca sobre branco no tema escuro — 1:1, invisível**. `chrome.main` é escuro nos dois.
- **O alternador inline do menu lateral não entra aqui** — é escopo da #296. Trocar de tema passa de um toque para dois no desktop e três no celular até lá.

## Issue

- #293

Closes #293

## Evidências

<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/cf4fa0ef-6474-4e00-a3c6-8f88569cf3b2" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/9385c5aa-aa09-46f6-91b6-263cc6c33389" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/f6d8b99c-9e2f-4f2a-97b4-5dac020bbbf4" />


### Gates, com o Node 24.18.0 do `.nvmrc`

| Gate | Resultado |
| --- | --- |
| ESLint nos arquivos alterados | exit 0 |
| `tsc --noEmit` | exit 0 |
| Suíte inteira | 76 arquivos, **545 testes** |
| Densidade de comentário | **4,4%** das linhas adicionadas |

### Medição dentro da aplicação

A rota fica atrás do guard de sessão, então liguei uma fiação temporária para alcançá-la sem entrar, medi, desfiz, e conferi que ela não entrou em commit nenhum.

| | Claro (desligado) | Escuro (ligado) |
| --- | --- | --- |
| Cabeçalho da seção e rótulo da linha | 7,89:1 | 12,84:1 |
| Frase de apoio | 5,27:1 | 6,77:1 |
| Glifo dentro do polegar | 7,89:1 (sol) | 16,67:1 (lua) |
| **Trilho contra o cartão** | **3,42:1** | **3,24:1** |

Os dois estados do trilho passam o mínimo de 3:1. O interruptor mede 48×30 com polegar de 22px, o tema muda de fato (fundo de `#F0F2F4` para `#121212`), a escolha sobrevive ao recarregamento, e o topo não tem mais o botão de tema em 1280px nem em 375px.

### Três medições erradas antes da certa

Registrando porque duas quase viraram defeito relatado:

| Sonda | O que dizia | O que era |
| --- | --- | --- |
| trilho vermelho com o interruptor desligado | "parece sempre ligado" | **transição CSS congelada** — com o painel do navegador oculto a página não compõe quadros, e `getComputedStyle` devolve o valor do estado anterior. Com `transition: none`, computa a cor certa |
| contraste 2,66 no tema claro | "reprova o mínimo" | medi contra `rgba(0,0,0,0)`, porque peguei o elemento errado como fundo do cartão |
| papel `checkbox` no teste | "o interruptor não existe" | o MUI 9 dá `role="switch"` |

A primeira virou regra em `web-styling.md`, no PR de harness (#299).
