### PR TITLE
fix: paint the autofilled field with the app palette in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige a recusa de cadastro sem data de nascimento, que respondia em inglês enquanto os outros erros da API já vinham em português (#285) [Backend]
 - Corrige o erro de cadastro já em uso, que avisava sempre sobre o e-mail mesmo quando o repetido era o telefone; agora ele aparece embaixo do campo certo, que recebe o foco (#287) [Frontend]
 - Corrige o atraso ao sair da conta: a sessão só era encerrada depois da resposta do servidor, então o clique ficava esperando a rede; agora ela sai no clique e a invalidação segue por trás (#304) [Frontend]
+- Corrige a cor do campo preenchido pelo autocompletar no tema escuro, que o navegador pintava de azul e destoava do resto da tela; o tema claro segue como estava (#305) [Frontend]
 
 ### Removed
 

--- a/FateConnect/Web/design-system/theme/components.ts
+++ b/FateConnect/Web/design-system/theme/components.ts
@@ -4,6 +4,9 @@ import { radiusScale, shadowTokens, spacingScale, typographyTokens } from '../to
 import { radius } from './helpers/radius';
 import { spacing } from './helpers/spacing';
 
+/** Fundo suficiente para cobrir o campo inteiro, de qualquer altura. */
+const AUTOFILL_COVER_PX = 100;
+
 const { none, xxs, xs, md } = spacingScale;
 
 const SELECT_OPTION_MIN_HEIGHT_PX = 48;
@@ -85,8 +88,32 @@ export const components: Components<Theme> = {
     styleOverrides: {
       // O raio de 10px vale para cartão, diálogo e botão — não para o campo, que
       // no produto usa o raio padrão do Material.
-      root: { borderRadius: radius(radiusScale.sm) },
+      root: ({ theme }) => ({
+        borderRadius: radius(radiusScale.sm),
+        // A sombra abaixo alcança só o `input`, e o campo com adorno é mais
+        // largo que ele: sem isto a faixa atrás do botão fica com a cor do
+        // cartão e o campo sai em dois tons.
+        '&:has(input:-webkit-autofill)': { backgroundColor: theme.palette.inputAutofill },
+      }),
       notchedOutline: ({ theme }) => ({ borderColor: theme.palette.inputOutline }),
+      // O navegador pinta o campo preenchido pela folha dele, e `background-color`
+      // não vence: o fundo se cobre com sombra interna, e o glifo e o cursor têm
+      // chaves próprias. Cada estado repete a regra porque o Chrome repinta a
+      // cada hover e foco.
+      input: ({ theme }) => {
+        const filled: CSSObject = {
+          boxShadow: `inset 0 0 0 ${AUTOFILL_COVER_PX}px ${theme.palette.inputAutofill}`,
+          WebkitTextFillColor: theme.palette.text.primary,
+          caretColor: theme.palette.text.primary,
+        };
+
+        return {
+          '&:-webkit-autofill': filled,
+          '&:-webkit-autofill:hover': filled,
+          '&:-webkit-autofill:focus': filled,
+          '&:-webkit-autofill:active': filled,
+        };
+      },
     },
   },
   MuiFormHelperText: {

--- a/FateConnect/Web/design-system/theme/contrast.test.ts
+++ b/FateConnect/Web/design-system/theme/contrast.test.ts
@@ -36,6 +36,8 @@ describe('contrastRatio', () => {
 
 type Par = [string, string, string];
 
+const TRANSPARENT = 'transparent';
+
 /** Toda cor de conteúdo é medida contra **todas** as superfícies daqui. */
 function surfaces(theme: Theme): [string, string][] {
   return [
@@ -79,6 +81,18 @@ function floatingSurfaceText(theme: Theme): Par[] {
     ['secondary text on a floating surface', palette.text.secondary, palette.surfaceFloating],
     ['brand text on a floating surface', palette.brandText, palette.surfaceFloating],
   ];
+}
+
+/**
+ * O campo preenchido pelo navegador carrega texto, então precisa do par. No
+ * claro o valor é `transparent` de propósito — quem pinta ali é o navegador, e
+ * não há cor nossa para medir.
+ */
+function autofilledFieldText(theme: Theme): Par[] {
+  const { palette } = theme;
+  if (palette.inputAutofill === TRANSPARENT) return [];
+
+  return [['body text on an autofilled field', palette.text.primary, palette.inputAutofill]];
 }
 
 function floatingSurfaceNonText(theme: Theme): Par[] {
@@ -126,12 +140,14 @@ describe.each([
   ['light', lightTheme],
   ['dark', darkTheme],
 ])('%s theme contrast', (_, theme) => {
-  it.each([...against(theme, contentColours), ...boundPairs(theme), ...floatingSurfaceText(theme)])(
-    'should meet AA for %s',
-    (_name, foreground, background) => {
-      expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
-    },
-  );
+  it.each([
+    ...against(theme, contentColours),
+    ...boundPairs(theme),
+    ...floatingSurfaceText(theme),
+    ...autofilledFieldText(theme),
+  ])('should meet AA for %s', (_name, foreground, background) => {
+    expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+  });
 
   it.each([...against(theme, nonTextColours), ...floatingSurfaceNonText(theme)])(
     'should meet the non-text threshold for %s',

--- a/FateConnect/Web/design-system/theme/createAppTheme.ts
+++ b/FateConnect/Web/design-system/theme/createAppTheme.ts
@@ -36,6 +36,7 @@ declare module '@mui/material/styles' {
   interface Palette {
     brandText: string;
     chrome: ChromeColors;
+    inputAutofill: string;
     inputOutline: string;
     surfaceFloating: string;
     skeleton: string;
@@ -47,6 +48,7 @@ declare module '@mui/material/styles' {
   interface PaletteOptions {
     brandText: string;
     chrome: ChromeColors;
+    inputAutofill: string;
     inputOutline: string;
     surfaceFloating: string;
     skeleton: string;

--- a/FateConnect/Web/design-system/theme/palettes.ts
+++ b/FateConnect/Web/design-system/theme/palettes.ts
@@ -55,6 +55,7 @@ export const lightPalette: PaletteOptions = {
    * Borda do campo de formulário. O padrão do MUI é mais claro que o do produto
    * (23% contra 38%), o que deixaria todo formulário mais lavado que hoje.
    */
+  inputAutofill: colorTokens.inputAutofill,
   inputOutline: colorTokens.inputOutline,
   surfaceFloating: colorTokens.surfaceWhite,
   skeleton: colorTokens.skeleton,
@@ -122,6 +123,7 @@ export const darkPalette: PaletteOptions = {
     hover: darkColorTokens.hover,
   },
   /** 38% de branco é a ênfase desabilitada do sistema de cor do Material Design. */
+  inputAutofill: darkColorTokens.inputAutofill,
   inputOutline: darkColorTokens.onSurfaceDisabled,
   surfaceFloating: darkColorTokens.surfaceFloating,
   skeleton: darkColorTokens.skeleton,

--- a/FateConnect/Web/design-system/tokens/palette.ts
+++ b/FateConnect/Web/design-system/tokens/palette.ts
@@ -59,6 +59,12 @@ export const colorTokens = {
    * Trilho do interruptor desligado. O cinza do iOS fica em 1,2:1 e some sobre
    * o cartão branco; este alcança os 3:1 da WCAG 1.4.11 para não-texto.
    */
+  /**
+   * Fundo do campo preenchido pelo navegador. `transparent` de propósito: no
+   * claro o azul que o Chrome pinta já fica a 1,15 do cartão branco, e cobri-lo
+   * trocaria um realce leve por nenhum.
+   */
+  inputAutofill: 'transparent',
   switchTrack: '#848C92',
 
   /** Divisor sobre superfície neutra. */
@@ -155,6 +161,11 @@ export const darkColorTokens = {
   skeleton: '#818181',
 
   /** Trilho do interruptor desligado, no mesmo mínimo de 3:1 do tema claro. */
+  /**
+   * O azul-aço que o Chrome pinta no escuro fica muito além do realce do claro.
+   * Este tom repete o afastamento de lá — 1,16 contra o cartão `#1E1E1E`.
+   */
+  inputAutofill: '#2A2A2A',
   switchTrack: '#818181',
 
   onSurfaceHigh: 'rgba(255, 255, 255, 0.87)',


### PR DESCRIPTION
## Objetivo

No tema escuro, campo preenchido pelo autocompletar do navegador saía com um azul-aço que o Chrome pinta por conta própria — fora da paleta e muito mais berrante que o realce discreto do tema claro. Este PR faz esse realce usar a cor do tema, mantendo o claro exatamente como está.

## Alterações

A cor virou token de paleta, `inputAutofill`, declarado nos dois temas:

| Tema | Valor | Por quê |
| --- | --- | --- |
| Claro | `transparent` | sombra transparente não pinta nada, então o navegador continua desenhando o azul pálido dele — que é o realce que se queria manter |
| Escuro | `#2A2A2A` | mesmo grau de realce do claro, sobre o cartão escuro |

**O grau de realce foi medido, não escolhido a olho.** O azul pálido do Chrome fica a **1,15** do cartão branco; `#2A2A2A` fica a **1,16** do cartão `#1E1E1E`. `#383838`, que seria o reflexo natural por já existir como superfície flutuante, ficaria a 1,42 — quase o dobro, e voltaria a chamar atenção demais.

Como `background-color` não vence a folha do navegador, o fundo é coberto por sombra interna, e o glifo e o cursor têm chaves próprias (`-webkit-text-fill-color` e `caret-color`), que o navegador também sobrescreve.

**O invólucro do campo é pintado junto.** A sombra alcança só o `<input>`, e o campo com botão de ícone — o olho da senha — é mais largo que ele: sem isso a faixa atrás do botão ficava com a cor do cartão e o campo saía em dois tons.

## Como foi verificado

- O texto sobre o campo preenchido entrou no teste de contraste, que já mede todo par de conteúdo e superfície. No escuro dá **10,67:1**; no claro o par não existe, porque ali não há cor nossa para medir.
- Na aplicação de pé: a regra é emitida nos quatro estados que o navegador repinta (base, `hover`, `focus`, `active`), com `rgb(42, 42, 42)` e o texto em `rgba(255, 255, 255, 0.87)`.
- `yarn typecheck` e `yarn lint` limpos; `yarn test:ci` com **565 testes em 78 arquivos**, todos passando.

### Resíduos declarados

**O `:has()` do invólucro ainda não foi visto funcionando com autofill real.** O `:-webkit-autofill` só casa quando o navegador preenche de verdade, e o navegador de teste não tem dado salvo — o que se confirmou daqui é que a regra é emitida com o valor certo e que o motor suporta o seletor.

**Uma regra azul concorrente aparece no navegador de teste, e não foi explicada.** Ela pinta os mesmos campos com `rgb(38, 103, 152)` e some quando a regra deste PR é removida. Foi descartado que venha do nosso código (nenhuma ocorrência de autofill fora deste PR) e do `@mui` (nenhuma nos pacotes de campo). A hipótese aberta é reescrita de cor do próprio painel de teste, que teve tema e viewport emulados na mesma aba. **Não reproduz no Chrome real**, onde o campo aparece com o cinza deste PR.

## Evidências
