### PR TITLE
feat(295): add the notifications bell and its anchored panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Adiciona o encerramento de sessão na API, que invalida o token no servidor em vez de apenas descartá-lo no navegador: depois de sair, nenhum token daquela pessoa é aceito, em qualquer aparelho (#298) [Backend]
 - Adiciona Denúncias à navegação e ao menu, e faz perfil, denúncias e notificações abrirem uma tela avisando que a área ainda não está disponível, com a volta ao menu — antes os três endereços caíam na página inicial (#300) [Frontend]
 - Adiciona o menu da conta no avatar do topo, com o caminho para perfil, para preferências e a saída de sessão — que até aqui não existia em lugar nenhum da área logada; sair invalida o token no servidor, leva à página inicial, e encerra a sessão do mesmo jeito quando a chamada falha (#302) [Frontend]
+- Adiciona a campainha de notificações no topo da área logada, com o painel ancorado nela e o caminho para a central; sem notificação ainda, ele mostra o estado vazio, que é o único que existe até a API passar a emiti-las (#307) [Frontend]
 
 ### Changed
 

--- a/FateConnect/Web/design-system/components/AnchoredPopover/AnchoredPopover.test.tsx
+++ b/FateConnect/Web/design-system/components/AnchoredPopover/AnchoredPopover.test.tsx
@@ -1,75 +1,109 @@
-import { render, screen, userEvent, waitFor } from '@app/test/testing-library';
+import { useState } from 'react';
 
-import { AnchoredPopover, type AnchoredPopoverProps } from '.';
+import { act, render, screen, userEvent } from '@app/test/testing-library';
 
-const PANEL_LABEL = 'Notificações';
-const PANEL_CONTENT = 'Miolo do painel';
+import { ARROW_OFFSET_VARIABLE } from './styles';
+import { AnchoredPopover } from '.';
 
-const trigger = document.createElement('button');
-document.body.append(trigger);
+const TRIGGER_LABEL = 'Abrir painel';
+const PANEL_LABEL = 'Painel de teste';
 
-const DEFAULT_PROPS: AnchoredPopoverProps = {
-  anchorEl: trigger,
-  open: true,
-  onClose: vi.fn(),
-  label: PANEL_LABEL,
-  children: PANEL_CONTENT,
-};
+const TRIGGER_LEFT = 100;
+const TRIGGER_WIDTH = 40;
+const PANEL_WIDTH = 200;
+const PANEL_RIGHT = 260;
+const PANEL_RIGHT_AFTER_RESIZE = 300;
 
-const renderComponent = (props = DEFAULT_PROPS) => render(<AnchoredPopover {...props} />);
+/** O gatilho tem 40px e o centro dele cai em 120: `260 - 120` sobra da direita. */
+const EXPECTED_OFFSET = '60px';
+const EXPECTED_OFFSET_AFTER_RESIZE = '20px';
 
-function backdropElement(): HTMLElement {
-  const backdrop = document.querySelector('.MuiBackdrop-root');
-  if (!(backdrop instanceof HTMLElement)) throw new Error('Popover backdrop not rendered');
+function stubGeometry(panelRight: number) {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    if (this.getAttribute('aria-label') === TRIGGER_LABEL)
+      return { left: TRIGGER_LEFT, width: TRIGGER_WIDTH } as DOMRect;
 
-  return backdrop;
+    return { right: panelRight, width: PANEL_WIDTH } as DOMRect;
+  });
+}
+
+function stubWidths(panelWidth: number) {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.getAttribute('aria-label') === TRIGGER_LABEL) return TRIGGER_WIDTH;
+
+      return panelWidth;
+    },
+  });
+}
+
+function Harness() {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  return (
+    <>
+      <button aria-label={TRIGGER_LABEL} onClick={(event) => setAnchorEl(event.currentTarget)}>
+        gatilho
+      </button>
+
+      <AnchoredPopover
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        label={PANEL_LABEL}
+      >
+        conteúdo
+      </AnchoredPopover>
+    </>
+  );
+}
+
+function panel(): HTMLElement {
+  return screen.getByRole('dialog', { name: PANEL_LABEL });
 }
 
 describe('AnchoredPopover', () => {
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(HTMLElement.prototype, 'offsetWidth');
   });
 
-  it('should name the panel by the label it was given and render its content', () => {
-    renderComponent();
+  it('should point the arrow at the centre of the trigger', async () => {
+    stubGeometry(PANEL_RIGHT);
+    stubWidths(PANEL_WIDTH);
+    render(<Harness />);
 
-    expect(screen.getByRole('dialog')).toHaveAccessibleName(PANEL_LABEL);
-    expect(screen.getByText(PANEL_CONTENT)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: TRIGGER_LABEL }));
+
+    expect(panel().style.getPropertyValue(ARROW_OFFSET_VARIABLE)).toBe(EXPECTED_OFFSET);
   });
 
-  it('should stay out of the page while it is closed', () => {
-    renderComponent({ ...DEFAULT_PROPS, open: false });
+  it('should point the arrow again after the window is resized', async () => {
+    stubGeometry(PANEL_RIGHT);
+    stubWidths(PANEL_WIDTH);
+    render(<Harness />);
+    await userEvent.click(screen.getByRole('button', { name: TRIGGER_LABEL }));
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    stubGeometry(PANEL_RIGHT_AFTER_RESIZE);
+    act(() => window.dispatchEvent(new Event('resize')));
+
+    expect(panel().style.getPropertyValue(ARROW_OFFSET_VARIABLE)).toBe(
+      EXPECTED_OFFSET_AFTER_RESIZE,
+    );
   });
 
-  it('should close when the user presses escape', async () => {
-    const onClose = vi.fn();
-    renderComponent({ ...DEFAULT_PROPS, onClose });
+  // O positivo acima usa a mesma consulta, então a ausência aqui significa que
+  // a medida não aconteceu — e não que a consulta está errada.
+  it('should leave the arrow alone while the panel has no width to measure', async () => {
+    stubGeometry(PANEL_RIGHT);
+    stubWidths(0);
+    render(<Harness />);
 
-    await userEvent.keyboard('{Escape}');
+    await userEvent.click(screen.getByRole('button', { name: TRIGGER_LABEL }));
 
-    expect(onClose).toHaveBeenCalledOnce();
-  });
-
-  it('should close when the user clicks outside of it', async () => {
-    const onClose = vi.fn();
-    renderComponent({ ...DEFAULT_PROPS, onClose });
-
-    await userEvent.click(backdropElement());
-
-    expect(onClose).toHaveBeenCalledOnce();
-  });
-
-  it('should return the focus to the trigger after it closes', async () => {
-    trigger.focus();
-    const { rerender } = renderComponent({ ...DEFAULT_PROPS, open: false });
-
-    rerender(<AnchoredPopover {...DEFAULT_PROPS} open />);
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-
-    rerender(<AnchoredPopover {...DEFAULT_PROPS} open={false} />);
-
-    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(panel().style.getPropertyValue(ARROW_OFFSET_VARIABLE)).toBe('');
   });
 });

--- a/FateConnect/Web/design-system/components/AnchoredPopover/index.tsx
+++ b/FateConnect/Web/design-system/components/AnchoredPopover/index.tsx
@@ -1,10 +1,12 @@
-import type { ReactNode } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState, type ReactNode } from 'react';
 import type { PopoverOrigin } from '@mui/material/Popover';
 
 import * as S from './styles';
 
 const ANCHOR_ORIGIN: PopoverOrigin = { vertical: 'bottom', horizontal: 'right' };
 const TRANSFORM_ORIGIN: PopoverOrigin = { vertical: 'top', horizontal: 'right' };
+
+const HALF = 2;
 
 export type AnchoredPopoverProps = Readonly<{
   anchorEl: HTMLElement | null;
@@ -26,6 +28,51 @@ export function AnchoredPopover({
   label,
   children,
 }: AnchoredPopoverProps) {
+  // Estado, e não `ref`: na primeira abertura o papel entra num commit depois
+  // deste, e um `ref` não avisaria ninguém — a seta ficaria no fallback.
+  const [paper, setPaper] = useState<HTMLDivElement | null>(null);
+
+  const pointArrowAtTrigger = useCallback(() => {
+    if (!paper?.offsetWidth || !anchorEl?.offsetWidth) return;
+
+    const trigger = anchorEl.getBoundingClientRect();
+    const panel = paper.getBoundingClientRect();
+    // O retângulo vem em pixel da tela e a propriedade recebe pixel de CSS: os
+    // dois divergem quando a página está sob escala, como na emulação de
+    // dispositivo do navegador. O gatilho não é transformado, então a razão dele
+    // converte um no outro.
+    const pageScale = trigger.width / anchorEl.offsetWidth;
+    const triggerCentre = trigger.left + trigger.width / HALF;
+    // Medido a partir da borda **direita** do papel, que é a origem da
+    // transformação de entrada: ela não se move enquanto o painel cresce, e a
+    // esquerda sim. Pela esquerda a conta erraria durante a animação inteira.
+    const fromRight = (panel.right - triggerCentre) / pageScale;
+
+    paper.style.setProperty(S.ARROW_OFFSET_VARIABLE, `${paper.offsetWidth - fromRight}px`);
+  }, [anchorEl, paper]);
+
+  // Efeito de **layout**, e antes do primeiro quadro: o `Popover` posiciona o
+  // papel nos efeitos dele, que rodam antes deste por serem de um filho. Medir
+  // mais cedo pega o papel ainda em `left: 0`; medir depois da transição faz a
+  // seta nascer no meio e saltar.
+  useLayoutEffect(() => {
+    if (!open || !paper) return;
+
+    pointArrowAtTrigger();
+  }, [open, paper, pointArrowAtTrigger]);
+
+  // De novo depois da pintura, porque o `Popover` reposiciona o papel num efeito
+  // passivo — que roda **depois** do de layout acima. Reabrindo o painel numa
+  // largura diferente, a medida de cima usaria a posição da abertura anterior.
+  useEffect(() => {
+    if (!open || !paper) return;
+
+    pointArrowAtTrigger();
+    window.addEventListener('resize', pointArrowAtTrigger);
+
+    return () => window.removeEventListener('resize', pointArrowAtTrigger);
+  }, [open, paper, pointArrowAtTrigger]);
+
   return (
     <S.PopoverSurface
       open={open}
@@ -33,7 +80,9 @@ export function AnchoredPopover({
       onClose={onClose}
       anchorOrigin={ANCHOR_ORIGIN}
       transformOrigin={TRANSFORM_ORIGIN}
-      slotProps={{ paper: { role: 'dialog', 'aria-label': label } }}
+      slotProps={{
+        paper: { ref: setPaper, role: 'dialog', 'aria-label': label },
+      }}
     >
       {children}
     </S.PopoverSurface>

--- a/FateConnect/Web/design-system/components/AnchoredPopover/styles.ts
+++ b/FateConnect/Web/design-system/components/AnchoredPopover/styles.ts
@@ -9,12 +9,17 @@ const { component } = radiusScale;
 const ARROW_SIZE_PX = 10;
 
 /**
- * Do centro da seta até a borda direita do papel, que o `anchorOrigin` alinha
- * com a do gatilho. É **metade** do controle padrão de 40px — o `IconButton` —,
- * então a seta cai no centro dele. Gatilho de outro tamanho desalinha a seta
- * pela diferença: o consumidor envolve o conteúdo num controle de 40px.
+ * Até onde a seta pode chegar perto da borda do papel: metade dela mais o raio,
+ * senão a ponta entra no canto arredondado e aparece cortada.
  */
-const ARROW_CENTRE_FROM_RIGHT_PX = 20;
+const ARROW_MIN_INSET_PX = 20;
+
+/**
+ * Onde o centro do gatilho cai dentro do papel. Quem mede é o componente, na
+ * abertura e a cada redimensionamento — o `50%` só vale no quadro em que a
+ * medida ainda não chegou.
+ */
+export const ARROW_OFFSET_VARIABLE = '--anchored-popover-arrow-offset';
 
 export const PopoverSurface = styled(Popover)(({ theme }) => ({
   '& .MuiPopover-paper': {
@@ -30,11 +35,14 @@ export const PopoverSurface = styled(Popover)(({ theme }) => ({
       content: '""',
       position: 'absolute',
       top: 0,
-      right: `${ARROW_CENTRE_FROM_RIGHT_PX}px`,
+      // O papel se desloca quando não cabe alinhado ao gatilho, e uma distância
+      // fixa da borda dele levaria a seta junto. O `clamp` prende a ponta dentro
+      // do papel quando o gatilho fica fora do alcance dela.
+      left: `clamp(${ARROW_MIN_INSET_PX}px, var(${ARROW_OFFSET_VARIABLE}, 50%), calc(100% - ${ARROW_MIN_INSET_PX}px))`,
       width: `${ARROW_SIZE_PX}px`,
       height: `${ARROW_SIZE_PX}px`,
       backgroundColor: 'inherit',
-      transform: 'translate(50%, -50%) rotate(45deg)',
+      transform: 'translate(-50%, -50%) rotate(45deg)',
     },
   },
 }));

--- a/FateConnect/Web/design-system/icons.ts
+++ b/FateConnect/Web/design-system/icons.ts
@@ -28,6 +28,7 @@ export { default as LocationOnIcon } from '@mui/icons-material/LocationOn';
 export { default as LogoutIcon } from '@mui/icons-material/Logout';
 export { default as MenuIcon } from '@mui/icons-material/Menu';
 export { default as NoBackpackOutlinedIcon } from '@mui/icons-material/NoBackpackOutlined';
+export { default as NotificationsIcon } from '@mui/icons-material/Notifications';
 export { default as PersonIcon } from '@mui/icons-material/Person';
 export { default as PhoneIcon } from '@mui/icons-material/Phone';
 export { default as RestoreIcon } from '@mui/icons-material/Restore';

--- a/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/MainLayout.test.tsx
@@ -5,11 +5,12 @@ import { tokenStorage } from '@app/services/auth/tokenStorage';
 import { render, screen, userEvent, waitFor, within } from '@app/test/testing-library';
 import { tokenWithName } from '@app/test/token';
 
-import { TRIGGER_LABEL } from './components/AccountMenu/constants';
+import { TRIGGER_LABEL as ACCOUNT_TRIGGER_LABEL } from './components/AccountMenu/constants';
+import { TRIGGER_LABEL as NOTIFICATIONS_TRIGGER_LABEL } from './components/NotificationsMenu/constants';
 import { MainLayout } from '.';
 
-/** O botão de menu e o gatilho do menu da conta. */
-const HEADER_BUTTONS = 2;
+/** O botão de menu, a campainha e o gatilho do menu da conta. */
+const HEADER_BUTTONS = 3;
 
 function renderLayout(initialEntry: RoutePathEnum = RoutePathEnum.MENU) {
   const router = createMemoryRouter(
@@ -74,7 +75,8 @@ describe('MainLayout', () => {
 
     expect(header.getAllByRole('button', { hidden: true })).toHaveLength(HEADER_BUTTONS);
     expect(header.getByRole('button', { name: 'Abrir menu', hidden: true })).toBeInTheDocument();
-    expect(header.getByRole('button', { name: TRIGGER_LABEL })).toBeInTheDocument();
+    expect(header.getByRole('button', { name: NOTIFICATIONS_TRIGGER_LABEL })).toBeInTheDocument();
+    expect(header.getByRole('button', { name: ACCOUNT_TRIGGER_LABEL })).toBeInTheDocument();
   });
 
   it('should point the logo to the menu', () => {

--- a/FateConnect/Web/src/layouts/MainLayout/components/NotificationsMenu/NotificationsMenu.test.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/components/NotificationsMenu/NotificationsMenu.test.tsx
@@ -1,0 +1,79 @@
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+import { RoutePathEnum } from '@app/routes/paths';
+import { render, screen, userEvent, waitFor } from '@app/test/testing-library';
+
+import * as C from './constants';
+import { NotificationsMenu } from '.';
+
+function renderMenu() {
+  const router = createMemoryRouter(
+    [
+      { path: RoutePathEnum.MENU, element: <NotificationsMenu /> },
+      { path: RoutePathEnum.NOTIFICATIONS, element: <div>notificações</div> },
+    ],
+    { initialEntries: [RoutePathEnum.MENU] },
+  );
+  render(<RouterProvider router={router} />);
+
+  return router;
+}
+
+async function openPanel() {
+  await userEvent.click(screen.getByRole('button', { name: C.TRIGGER_LABEL }));
+}
+
+function backdropElement(): HTMLElement {
+  const backdrop = document.querySelector('.MuiBackdrop-root');
+  if (!(backdrop instanceof HTMLElement)) throw new Error('Popover backdrop not rendered');
+
+  return backdrop;
+}
+
+describe('NotificationsMenu', () => {
+  it('should keep the panel closed until the bell is used', () => {
+    renderMenu();
+
+    expect(screen.getByRole('button', { name: C.TRIGGER_LABEL })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should open a panel named after the title, with the empty state', async () => {
+    renderMenu();
+
+    await openPanel();
+
+    expect(screen.getByRole('dialog', { name: C.PANEL_TITLE })).toBeInTheDocument();
+    expect(screen.getByText(C.EMPTY_STATUS)).toBeInTheDocument();
+    expect(screen.getByText(C.EMPTY_DESCRIPTION)).toBeInTheDocument();
+  });
+
+  it('should navigate to the notifications screen and close the panel', async () => {
+    const router = renderMenu();
+    await openPanel();
+
+    await userEvent.click(screen.getByRole('link', { name: C.ALL_NOTIFICATIONS_LABEL }));
+
+    expect(router.state.location.pathname).toBe(RoutePathEnum.NOTIFICATIONS);
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('should close on Escape and give the focus back to the trigger', async () => {
+    renderMenu();
+    await openPanel();
+
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: C.TRIGGER_LABEL })).toHaveFocus();
+  });
+
+  it('should close when the click lands outside the panel', async () => {
+    renderMenu();
+    await openPanel();
+
+    await userEvent.click(backdropElement());
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+});

--- a/FateConnect/Web/src/layouts/MainLayout/components/NotificationsMenu/constants/index.ts
+++ b/FateConnect/Web/src/layouts/MainLayout/components/NotificationsMenu/constants/index.ts
@@ -1,0 +1,5 @@
+export const TRIGGER_LABEL = 'Abrir notificações';
+export const PANEL_TITLE = 'Notificações';
+export const EMPTY_STATUS = 'Nenhuma notificação';
+export const EMPTY_DESCRIPTION = 'Avisos sobre seus itens e caronas aparecem aqui.';
+export const ALL_NOTIFICATIONS_LABEL = 'Conferir todas as notificações';

--- a/FateConnect/Web/src/layouts/MainLayout/components/NotificationsMenu/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/components/NotificationsMenu/index.tsx
@@ -1,0 +1,53 @@
+import { useCallback, useState, type MouseEvent } from 'react';
+import { Link as RouterLink } from 'react-router';
+import { AnchoredPopover, IconButton, Typography } from '@design-system';
+import { NotificationsIcon } from '@design-system/icons';
+
+import { RoutePathEnum } from '@app/routes/paths';
+
+import * as C from './constants';
+import * as S from './styles';
+
+export function NotificationsMenu() {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleOpen = useCallback(
+    (event: MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget),
+    [],
+  );
+  const handleClose = useCallback(() => setAnchorEl(null), []);
+
+  return (
+    <>
+      <IconButton color="inherit" label={C.TRIGGER_LABEL} onClick={handleOpen}>
+        <NotificationsIcon />
+      </IconButton>
+
+      <AnchoredPopover
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        label={C.PANEL_TITLE}
+      >
+        <S.PanelColumn>
+          <S.PanelTitle variant="subtitleBold">{C.PANEL_TITLE}</S.PanelTitle>
+
+          <S.EmptyState>
+            <Typography variant="captionBold">{C.EMPTY_STATUS}</Typography>
+            <S.EmptyDescription variant="caption">{C.EMPTY_DESCRIPTION}</S.EmptyDescription>
+          </S.EmptyState>
+
+          <S.PanelFooter>
+            <S.AllNotificationsLink
+              component={RouterLink}
+              to={RoutePathEnum.NOTIFICATIONS}
+              onClick={handleClose}
+            >
+              {C.ALL_NOTIFICATIONS_LABEL}
+            </S.AllNotificationsLink>
+          </S.PanelFooter>
+        </S.PanelColumn>
+      </AnchoredPopover>
+    </>
+  );
+}

--- a/FateConnect/Web/src/layouts/MainLayout/components/NotificationsMenu/styles.ts
+++ b/FateConnect/Web/src/layouts/MainLayout/components/NotificationsMenu/styles.ts
@@ -1,0 +1,52 @@
+import type { ElementType } from 'react';
+import type { LinkProps } from 'react-router';
+import { Button, spacingScale, Stack, styled, Typography } from '@design-system';
+
+const { none, xxs, sm, md, lg } = spacingScale;
+
+const PANEL_WIDTH_PX = 320;
+
+/**
+ * No celular os 320px do protótipo ocupam quase quatro quintos da tela e o
+ * painel deixa de parecer um painel. O piso é o rodapé numa linha só: o rótulo
+ * dele mede 214px, e abaixo de 240 ele quebra.
+ */
+const NARROW_PANEL_WIDTH_PX = 240;
+
+type LinkedButtonProps = { component?: ElementType; to: LinkProps['to'] };
+
+export const PanelColumn = styled(Stack)(({ theme }) => ({
+  flexDirection: 'column',
+  width: `${PANEL_WIDTH_PX}px`,
+
+  [theme.breakpoints.down('md')]: { width: `${NARROW_PANEL_WIDTH_PX}px` },
+}));
+
+export const PanelTitle = styled(Typography)(({ theme }) => ({
+  padding: theme.space(sm, md),
+  borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+export const EmptyState = styled(Stack)(({ theme }) => ({
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: theme.space(xxs),
+  padding: theme.space(lg, md),
+  textAlign: 'center',
+}));
+
+export const EmptyDescription = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+}));
+
+export const PanelFooter = styled(Stack)(({ theme }) => ({
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: theme.space(xxs, none),
+  borderTop: `1px solid ${theme.palette.divider}`,
+}));
+
+/** O vermelho da marca como texto — `color="secondary"` dá 2,28:1 no escuro. */
+export const AllNotificationsLink = styled(Button)<LinkedButtonProps>(({ theme }) => ({
+  color: theme.palette.brandText,
+}));

--- a/FateConnect/Web/src/layouts/MainLayout/index.tsx
+++ b/FateConnect/Web/src/layouts/MainLayout/index.tsx
@@ -17,6 +17,7 @@ import { LandingSectionEnum, RoutePathEnum } from '@app/routes/paths';
 
 import * as S from '../shell.styles';
 import { AccountMenu } from './components/AccountMenu';
+import { NotificationsMenu } from './components/NotificationsMenu';
 
 const MENU_BUTTON_LABEL = 'Abrir menu';
 
@@ -31,7 +32,12 @@ export function MainLayout() {
     <S.ShellRoot>
       <Header
         logo={<BrandLogo to={RoutePathEnum.MENU} />}
-        actions={<AccountMenu />}
+        actions={
+          <>
+            <NotificationsMenu />
+            <AccountMenu />
+          </>
+        }
         menuButtonLabel={MENU_BUTTON_LABEL}
         onMenuClick={handleMenuClick}
         navigation={APP_LINKS.map(({ path, label }) => (


### PR DESCRIPTION
## Objetivo

A área logada não tinha campainha — o topo levava só o menu da conta. Este PR acrescenta a campainha, visível em qualquer largura, e o painel ancorado nela com o estado vazio que é o que vai ao ar agora.

## Alterações

| Elemento | Texto |
| --- | --- |
| Título | `Notificações` |
| Estado vazio | `Nenhuma notificação` · `Avisos sobre seus itens e caronas aparecem aqui.` |
| Rodapé | `Conferir todas as notificações`, levando a `/notificacoes` |
| Rótulo do gatilho | `Abrir notificações` |

`NotificationsIcon` entra no barrel de ícones. **O `Badge` continua fora**, como a issue decidiu: sem contador não haveria o que mostrar, e ele entra na #119 junto dele.

### A seta do popover passou a seguir o gatilho

O `AnchoredPopover` desenhava a seta a **20px fixos da borda direita do papel**. Isso acertava por uma coincidência aritmética: o `anchorOrigin` alinha a borda direita do papel com a do gatilho, e num gatilho de 40px o centro dele também está a 20px da borda. A suposição é que as duas bordas sempre coincidem.

Elas não coincidem quando o painel não cabe alinhado: o MUI o empurra para dentro da tela, o papel se move, a seta vai junto e o gatilho fica para trás. Com o painel de 320px do protótipo, a 390px isso dava **74px** de desvio — a seta apontando para o nada.

Agora a seta é posicionada onde o centro do gatilho cai **dentro do papel**, medido na abertura e a cada redimensionamento, com `clamp` para a ponta não entrar no canto arredondado.

⚠️ **O painel continua estreitando no celular**, e não por causa da seta: os 320px do protótipo ocupam quase quatro quintos de uma tela de 412px e o painel deixa de parecer um painel. Abaixo do breakpoint ele vai a **240px**, com piso no rodapé numa linha só — o rótulo dele mede 214px.

**Três armadilhas pagas para chegar nisto**, todas com comentário no código:

1. **Medir pela borda esquerda erra durante a animação.** O `Grow` escala o papel a partir do canto superior direito: a borda direita é o ponto fixo, a esquerda se move. A conta parte da direita.
2. **O retângulo é pixel de tela, a propriedade é pixel de CSS.** Sob escala de página — a emulação de dispositivo do navegador, por exemplo — os dois divergem pelo fator. O gatilho não é transformado, então a razão dele converte um no outro.
3. **A medida precisa acontecer em dois momentos.** Num efeito de layout, senão a seta nasce no meio do painel e salta; e de novo depois da pintura, porque o `Popover` reposiciona o papel num efeito passivo — verificado no código do MUI, não deduzido.

⚠️ **O rodapé usa `palette.brandText`, não `color="secondary"`.** A issue pede o vermelho da marca e não o `error`, e está mantido — mas `secondary.main` como texto dá **2,28:1** sobre a superfície flutuante escura. `brandText` dá **4,53:1**, e é o mesmo que o menu da conta já faz.

## Como foi verificado

`yarn typecheck` e `yarn lint` limpos; `yarn test:ci` com **568 testes em 79 arquivos**, no estado integrado sobre a ponta da `develop`. O componente do popover ancorado ganhou teste próprio e está em **100% de linhas e de branches** — a lógica da seta não é alcançada pelo teste do painel, porque em jsdom a geometria é toda zero.

Medido na aplicação de pé, em porta própria (**5497**), sempre com carga limpa e primeira abertura:

| Largura | Painel | Ocupa da tela | Desvio da seta |
| --- | --- | --- | --- |
| 1280 | 320px | 25% | **0** |
| 412 | 240px | 58% | **0** |
| 390 | 240px | 62% | **0** |
| 320 | 240px | 75% | **0** |

O rodapé fica numa linha só nas quatro.

O valor é escrito **20ms após o clique**, antes da transição terminar — é o que garante que a seta nasce no lugar em vez de saltar.

**Sem regressão no consumidor que já estava mergeado:** o menu da conta, com gatilho de 40px e painel de 146px, fica a **−0,4px** do centro do gatilho.

### Resíduo declarado

**A reabertura depois de redimensionar com o painel fechado não foi medida de forma conclusiva.** O painel de teste não fecha o popover de modo confiável por script, e as leituras desse cenário vieram contaminadas por estado da medição anterior. O que sustenta esse caminho é o efeito passivo, cuja necessidade foi confirmada lendo o código do `Popover` — não uma medição.

## Issue

- #295

Closes #295

## Evidências
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/692ef385-d34c-4310-93c6-0f9d17009a29" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/bb88fe88-6c90-42ae-b55f-9e213cb39889" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/41f4e2f4-c6d5-40a0-9131-027d8d8bb79b" />

