### PR TITLE
fix(309): refuse a past departure and hold the signup lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige o erro de cadastro já em uso, que avisava sempre sobre o e-mail mesmo quando o repetido era o telefone; agora ele aparece embaixo do campo certo, que recebe o foco (#287) [Frontend]
 - Corrige o atraso ao sair da conta: a sessão só era encerrada depois da resposta do servidor, então o clique ficava esperando a rede; agora ela sai no clique e a invalidação segue por trás (#304) [Frontend]
 - Corrige a cor do campo preenchido pelo autocompletar no tema escuro, que o navegador pintava de azul e destoava do resto da tela; o tema claro segue como estava (#305) [Frontend]
+- Corrige a oferta de carona, que aceitava data e hora já passadas e deixava a recusa para a API: o formulário passa a recusar no próprio campo, no mesmo fuso em que a API valida, e o calendário não oferece mais dia anterior a hoje (#312) [Frontend]
+- Corrige o cadastro, que aceitava texto acima do limite da API em sete campos e recebia de volta um erro que não dizia qual deles reprovou; cada campo passa a avisar o máximo que aceita (#312) [Frontend]
 
 ### Removed
 

--- a/FateConnect/Web/package.json
+++ b/FateConnect/Web/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-query": "^5.101.4",
     "axios": "^1.19.0",
     "date-fns": "^4.4.0",
+    "date-fns-tz": "^3.2.0",
     "notistack": "^3.0.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormFields/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormFields/index.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from 'react';
 import { Input } from '@design-system';
+import { toZonedTime } from 'date-fns-tz';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import type { RideFormInput, RideFormValues } from '../schema';
@@ -11,6 +13,9 @@ export function RideFormFields() {
     register,
     formState: { errors },
   } = useFormContext<RideFormInput, unknown, RideFormValues>();
+  // No fuso do produto, e não no de quem preenche: a leste daqui o dia já virou,
+  // e o calendário desabilitaria uma partida que a API ainda aceita.
+  const today = useMemo(() => toZonedTime(new Date(), C.PRODUCT_TIME_ZONE), []);
 
   return (
     <S.FieldsGrid>
@@ -35,6 +40,7 @@ export function RideFormFields() {
             onChange={field.onChange}
             onBlur={field.onBlur}
             disabled={field.disabled}
+            minDate={today}
             error={errors.departureDate?.message}
           />
         )}

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/constants/index.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/constants/index.ts
@@ -6,6 +6,13 @@ import { RIDE_TYPE_OPTIONS } from '@app/pages/Rides/helpers/rideType';
 
 import type { RideFormMode } from '../types';
 
+/**
+ * O fuso em que a API valida a partida (`Ride.ValidateDepartureDateTime`). Sem
+ * ele o formulário julga pelo relógio de quem preenche e aceita o que o
+ * servidor recusa.
+ */
+export const PRODUCT_TIME_ZONE = 'America/Sao_Paulo';
+
 /** Limites do `CreateCaronaDto` e da entidade `Carona`, espelhados no front. */
 export const RIDE_LIMITS = {
   minDestination: 3,

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.test.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.test.ts
@@ -1,16 +1,21 @@
-import { RideTypeEnum } from '@app/services/rides/types';
-import { toApiDate } from '@app/utils/apiDate';
+import { format } from 'date-fns';
 
-import { RIDE_FORM_MESSAGES, RIDE_LIMITS } from '../constants';
+import { RideTypeEnum } from '@app/services/rides/types';
+
+import { PRODUCT_TIME_ZONE, RIDE_FORM_MESSAGES, RIDE_LIMITS } from '../constants';
 import { rideFormSchema, type RideFormInput } from '.';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DAYS_AHEAD = 30;
-const AN_HOUR_MS = 60 * 60 * 1000;
+
+/** O que o campo guarda, e não o que a API recebe — é o que o schema lê. */
+function toFieldDate(date: Date): string {
+  return format(date, 'dd/MM/yyyy');
+}
 
 const VALID: RideFormInput = {
   destination: 'Fatec Sorocaba',
-  departureDate: toApiDate(new Date(Date.now() + DAYS_AHEAD * DAY_MS)),
+  departureDate: toFieldDate(new Date(Date.now() + DAYS_AHEAD * DAY_MS)),
   departureTime: '07:30',
   rideType: RideTypeEnum.SOLIDARITY,
   seats: '3',
@@ -55,15 +60,43 @@ describe('rideFormSchema', () => {
     expect(firstErrorOf({ departureTime: '' })).toBe(RIDE_FORM_MESSAGES.departureTimeRequired);
   });
 
-  it('should refuse a departure that already happened', () => {
-    const pastMoment = new Date(Date.now() - AN_HOUR_MS);
+  it('should stay quiet while the date is still half typed', () => {
+    expect(firstErrorOf({ departureDate: '22/0' })).toBeUndefined();
+  });
 
-    expect(
-      firstErrorOf({
-        departureDate: toApiDate(pastMoment),
-        departureTime: `${String(pastMoment.getHours()).padStart(2, '0')}:00`,
-      }),
-    ).toBe(RIDE_FORM_MESSAGES.departureInPast);
+  // Relógio fixo porque a partida é lida no fuso do produto: sem isso, a máquina
+  // que roda o teste decide de que lado do limite a hora cai. Às 12:00 em UTC são
+  // 09:00 em São Paulo, então 08:00 já passou e 10:00 ainda não.
+  describe('at a fixed clock', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-22T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should refuse a departure that already happened', () => {
+      expect(firstErrorOf({ departureDate: '22/05/2026', departureTime: '08:00' })).toBe(
+        RIDE_FORM_MESSAGES.departureInPast,
+      );
+    });
+
+    it('should accept a departure still to come on the same day', () => {
+      expect(firstErrorOf({ departureDate: '22/05/2026', departureTime: '10:00' })).toBeUndefined();
+    });
+
+    // A suíte fixa o fuso do processo no do produto, que é onde os dois jeitos de
+    // comparar concordam — sem trocá-lo, nada aqui prova que a leitura é do fuso
+    // do produto e não do de quem preenche.
+    it('should read the departure in the product time zone, not in the reader one', () => {
+      process.env.TZ = 'UTC';
+
+      expect(firstErrorOf({ departureDate: '22/05/2026', departureTime: '10:00' })).toBeUndefined();
+
+      process.env.TZ = PRODUCT_TIME_ZONE;
+    });
   });
 
   it('should require a ride type from the api vocabulary', () => {

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.ts
@@ -1,11 +1,14 @@
-import { isValid, parseISO } from 'date-fns';
+import { isValid, parse } from 'date-fns';
+import { fromZonedTime } from 'date-fns-tz';
 import { z } from 'zod';
 
 import { isRideType } from '@app/pages/Rides/helpers/rideType';
 
-import { RIDE_FORM_MESSAGES, RIDE_LIMITS } from '../constants';
+import { PRODUCT_TIME_ZONE, RIDE_FORM_MESSAGES, RIDE_LIMITS } from '../constants';
 
 const REQUIRED = 1;
+/** Os campos entregam o que a pessoa digitou, não o formato da API. */
+const DEPARTURE_FORMAT = 'dd/MM/yyyy HH:mm';
 
 type DepartureFields = { departureDate: string; departureTime: string };
 
@@ -23,10 +26,10 @@ function isSeatCount(value: string): boolean {
 function isFutureDeparture({ departureDate, departureTime }: DepartureFields): boolean {
   if (!departureDate || !departureTime) return true;
 
-  const departure = parseISO(`${departureDate}T${departureTime}`);
+  const departure = parse(`${departureDate} ${departureTime}`, DEPARTURE_FORMAT, new Date());
   if (!isValid(departure)) return true;
 
-  return departure.getTime() > Date.now();
+  return fromZonedTime(departure, PRODUCT_TIME_ZONE).getTime() > Date.now();
 }
 
 export const rideFormSchema = z

--- a/FateConnect/Web/src/pages/Signup/Signup.test.tsx
+++ b/FateConnect/Web/src/pages/Signup/Signup.test.tsx
@@ -11,13 +11,16 @@ import { render, screen, userEvent, waitFor, within } from '@app/test/testing-li
 
 import { SignupConflictFieldEnum } from './@types';
 import { PASSWORD_TOGGLE_LABEL } from './components/AccountSection/constants';
-import { SIGNUP_MESSAGES } from './schema';
+import { maxLengthMessage, SIGNUP_MESSAGES } from './schema';
 import * as C from './constants';
 import { Signup } from '.';
 
 const SIGNUP_URL = 'https://api.fateconnect.test/users/signup';
 const SIGNUP_TOKEN = 'token-do-cadastro';
 const ZIP_URL = 'https://viacep.com.br/ws/:zipCode/json/';
+/** O que o `CreateAddressDto` aceita no complemento. */
+const COMPLEMENT_MAX_LENGTH = 100;
+const ONE_CHARACTER = 1;
 
 const VALID_SIGNUP = {
   fullName: 'Maria Silva',
@@ -122,6 +125,18 @@ describe('Signup', () => {
     await submit();
 
     expect(await screen.findByText(FATEC_EMAIL_MESSAGE)).toBeInTheDocument();
+  });
+
+  // O complemento é o único campo opcional com limite de comprimento: o schema
+  // recusa, e sem a prop de erro no campo a mensagem não chega à tela.
+  it('should show the length message on the optional complement', async () => {
+    renderSignup();
+    await userEvent.click(screen.getByLabelText(C.FIELD_LABELS.complement));
+    await userEvent.paste('a'.repeat(COMPLEMENT_MAX_LENGTH + ONE_CHARACTER));
+
+    await submit();
+
+    expect(await screen.findByText(maxLengthMessage(COMPLEMENT_MAX_LENGTH))).toBeInTheDocument();
   });
 
   it('should reject a phone number outside ten or eleven digits', async () => {

--- a/FateConnect/Web/src/pages/Signup/components/AddressSection/index.tsx
+++ b/FateConnect/Web/src/pages/Signup/components/AddressSection/index.tsx
@@ -108,6 +108,7 @@ export function AddressSection() {
         <Input
           {...register('complement')}
           label={FIELD_LABELS.complement}
+          error={errors.complement?.message}
           fullWidth
           type="text"
           autoComplete="address-line2"

--- a/FateConnect/Web/src/pages/Signup/schema/index.ts
+++ b/FateConnect/Web/src/pages/Signup/schema/index.ts
@@ -11,6 +11,25 @@ const MIN_PHONE_DIGITS = 10;
 const ZIP_CODE_DIGITS = 8;
 const MAX_PHONE_DIGITS = 11;
 
+/**
+ * Comprimento máximo de cada campo, como o `CreateUserDto`, o
+ * `CreateAddressDto` e o `CreateContactDto` os declaram. Sem eles a API recusa
+ * com o 400 genérico, que não diz qual campo passou do limite.
+ */
+const MAX_LENGTH = {
+  fullName: 200,
+  fatecEmail: 150,
+  street: 200,
+  streetNumber: 20,
+  complement: 100,
+  city: 100,
+  contactEmail: 150,
+};
+
+export function maxLengthMessage(max: number): string {
+  return `Máximo de ${max} caracteres`;
+}
+
 /** Mensagens iguais às do produto. */
 export const SIGNUP_MESSAGES = {
   fullNameRequired: 'Informe o nome completo',
@@ -63,10 +82,14 @@ function hasBrazilianPhoneLength(value: string): boolean {
 }
 
 export const signupSchema = z.object({
-  fullName: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.fullNameRequired),
+  fullName: z
+    .string()
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.fullNameRequired)
+    .max(MAX_LENGTH.fullName, maxLengthMessage(MAX_LENGTH.fullName)),
   fatecEmail: z
     .string()
     .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.fatecEmailRequired)
+    .max(MAX_LENGTH.fatecEmail, maxLengthMessage(MAX_LENGTH.fatecEmail))
     .regex(FATEC_EMAIL_PATTERN, FATEC_EMAIL_MESSAGE),
   birthDate: z
     .string()
@@ -83,10 +106,19 @@ export const signupSchema = z.object({
     .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.zipCodeRequired)
     .refine(isCompleteZipCode, SIGNUP_MESSAGES.zipCodeIncomplete),
   state: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.stateRequired),
-  city: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.cityRequired),
-  street: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.streetRequired),
-  streetNumber: z.string().min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.streetNumberRequired),
-  complement: z.string(),
+  city: z
+    .string()
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.cityRequired)
+    .max(MAX_LENGTH.city, maxLengthMessage(MAX_LENGTH.city)),
+  street: z
+    .string()
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.streetRequired)
+    .max(MAX_LENGTH.street, maxLengthMessage(MAX_LENGTH.street)),
+  streetNumber: z
+    .string()
+    .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.streetNumberRequired)
+    .max(MAX_LENGTH.streetNumber, maxLengthMessage(MAX_LENGTH.streetNumber)),
+  complement: z.string().max(MAX_LENGTH.complement, maxLengthMessage(MAX_LENGTH.complement)),
   phone: z
     .string()
     .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.phoneRequired)
@@ -94,6 +126,7 @@ export const signupSchema = z.object({
   contactEmail: z
     .string()
     .min(REQUIRED_MIN_LENGTH, SIGNUP_MESSAGES.contactEmailRequired)
+    .max(MAX_LENGTH.contactEmail, maxLengthMessage(MAX_LENGTH.contactEmail))
     .pipe(z.email(SIGNUP_MESSAGES.emailInvalid)),
   acceptTerms: z.boolean().refine((accepted) => accepted, SIGNUP_MESSAGES.termsRequired),
   acceptMarketing: z.boolean(),

--- a/FateConnect/Web/src/pages/Signup/schema/schema.test.ts
+++ b/FateConnect/Web/src/pages/Signup/schema/schema.test.ts
@@ -3,6 +3,15 @@ import { formatBirthDate, latestBirthDate } from '../helpers/birthDate';
 import { SIGNUP_DEFAULT_VALUES, signupSchema, type SignupFormValues } from '.';
 
 const ONE_DAY_MS = 86_400_000;
+const ONE_CHARACTER = 1;
+
+/** Os campos de texto que a API corta por comprimento. */
+type TextField =
+  'fullName' | 'fatecEmail' | 'street' | 'streetNumber' | 'complement' | 'city' | 'contactEmail';
+
+function textOfLength(total: number, suffix: string): string {
+  return 'a'.repeat(total - suffix.length) + suffix;
+}
 
 const VALID: SignupFormValues = {
   ...SIGNUP_DEFAULT_VALUES,
@@ -95,6 +104,28 @@ describe('signupSchema', () => {
     expect(parse({ birthDate: formatBirthDate(eighteenToday) }).success).toBe(true);
     expect(firstIssuePath(parse({ birthDate: formatBirthDate(oneDayShort) }))).toEqual([
       'birthDate',
+    ]);
+  });
+
+  /**
+   * Cada campo com o comprimento que o DTO da API declara, e o sufixo que o
+   * valor precisa manter para continuar válido — sem ele o e-mail deixaria de
+   * ser e-mail antes de estourar o limite.
+   */
+  const MAX_LENGTHS: [TextField, number, string][] = [
+    ['fullName', 200, ''],
+    ['fatecEmail', 150, '@aluno.cps.sp.gov.br'],
+    ['street', 200, ''],
+    ['streetNumber', 20, ''],
+    ['complement', 100, ''],
+    ['city', 100, ''],
+    ['contactEmail', 150, '@exemplo.com'],
+  ];
+
+  it.each(MAX_LENGTHS)('should hold %s to the length the api accepts', (field, max, suffix) => {
+    expect(parse({ [field]: textOfLength(max, suffix) }).success).toBe(true);
+    expect(firstIssuePath(parse({ [field]: textOfLength(max + ONE_CHARACTER, suffix) }))).toEqual([
+      field,
     ]);
   });
 

--- a/FateConnect/Web/yarn.lock
+++ b/FateConnect/Web/yarn.lock
@@ -1883,6 +1883,11 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns-tz@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-3.2.0.tgz#647dc56d38ac33a3e37b65e9d5c4cda5af5e58e6"
+  integrity sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==
+
 date-fns@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.4.0.tgz#806539edf45c616b2b76b5f78b88c56ed3c7e036"


### PR DESCRIPTION
## Objetivo

Ofertar carona aceitava data e hora que já passaram, e quem recusava era a API — com o aviso genérico de dados inválidos, que não diz qual campo reprovou. A varredura pedida na issue mostrou que o mesmo tipo de divergência existia no cadastro, em sete campos.

## O defeito não era a regra faltando — era a regra morta

`isFutureDeparture` já existia no `rideFormSchema`. Ela nunca disparou:

```ts
const departure = parseISO(`${departureDate}T${departureTime}`);
if (!isValid(departure)) return true;
```

O campo guarda a data **no formato de exibição** — `22/05/2026` —, e `parseISO` só entende ISO. O `Invalid Date` caía na guarda de "ilegível passa", que existe para o campo pela metade não acusar erro antes da hora, e engolia **toda** data real. Medido com o `date-fns` do projeto:

| Entrada | `isValid` | A regra devolvia |
| --- | --- | --- |
| `22/05/2026T07:30` | `false` | **válido**, pela guarda |
| `01/01/2020T07:30` | `false` | **válido**, pela guarda |

A tela irmã já fazia certo: `lostItemFormSchema` lê com `parse(value, 'dd/MM/yyyy', new Date())`, sob um comentário que nomeia esta armadilha. A correção é essa, não uma invenção nova.

⚠️ **O teste concordava com o bug.** Ele montava a entrada com `toApiDate(...)`, que produz `2026-09-04` — o formato da **API**, não o do campo. Passava verde sobre uma regra morta, e continuaria passando se a regra fosse apagada. A fixture do arquivo inteiro usava o formato errado, então ela mudou junto.

## Alterações

### Caronas

- A partida é lida com o formato que o campo guarda, e não com `parseISO`
- O calendário recebe `minDate`, então não oferece mais dia passado. **Hoje continua selecionável**, porque carona mais tarde no mesmo dia é legítima
- A comparação passou a acontecer em `America/Sao_Paulo` — o mesmo fuso de `Ride.ValidateDepartureDateTime`. Antes ela usava o relógio de quem preenche, então quem preenchesse de outro fuso veria o formulário aceitar o que o servidor recusa

⚠️ **Entra `date-fns-tz@3.2.0`**, por decisão explícita registrada na issue. Ela declara `peerDependencies: { "date-fns": "^3.0.0 || ^4.0.0" }`, e o projeto já usa `date-fns@^4.4.0`.

### Cadastro

Sete campos não declaravam o comprimento máximo que a API corta, então texto longo voltava como `400` genérico:

| Campo | Máximo |
| --- | --- |
| `fullName` | 200 |
| `fatecEmail` | 150 |
| `street` | 200 |
| `streetNumber` | 20 |
| `complement` | 100 |
| `city` | 100 |
| `contactEmail` | 150 |

A mensagem é `Máximo de N caracteres`, no registro terso que o formulário já usa em `Mínimo de 8 caracteres`.

### Um achado que só a medição na aplicação pegou

O `Complemento` não recebia `error={errors.complement?.message}` — ele nunca tivera regra de validação, então nunca precisou da ligação. Com o limite de comprimento isso virou defeito: o schema recusava e a **tela ficava muda**, travando o envio sem explicar por quê. O teste de schema passava, porque o schema estava certo. Foi corrigido junto, e ganhou um caso no `Signup.test.tsx` que cai quando a prop sai.

## Como foi verificado

Quatro mutações, cada uma derrubando o teste escrito para ela:

| Mutação | O que cai |
| --- | --- |
| voltar o `parseISO` | o caso da data passada |
| tirar o `fromZonedTime` | o caso do fuso |
| tirar um `.max()` do cadastro | o caso daquele campo |
| tirar a prop de erro do `Complemento` | o caso de componente |

⚠️ **Uma descoberta sobre a suíte que vale para o próximo teste de data.** O `vitest.setup.ts` fixa `process.env.TZ = 'America/Sao_Paulo'` para todos os casos — que é justamente o fuso onde os dois jeitos de comparar concordam. A primeira tentativa de controle rodou `TZ=UTC` na linha de comando e **não desligou nada**: o valor do setup vence. O caso do fuso só discrimina porque troca `process.env.TZ` dentro dele e restaura depois.

Medido na aplicação de pé, em porta própria (**5497**), a 1280px:

| O que | Resultado |
| --- | --- |
| `01/01/2020 08:00` e enviar | erro no campo (`A carona deve ser em data e hora futuras`) e **nenhum `POST`** no log de rede |
| `01/01/2030 08:00` e enviar | sem erro, e o `POST /api/rides` sai |
| Calendário, com hoje em 04/09/2026 | dias **1, 2 e 3** desabilitados; dia **4** habilitado |
| Cadastro, campo a campo | no limite cala, acima avisa o máximo — `Complemento` incluído, depois da correção |

⚠️ O `POST` falha com `ERR_UNSAFE_PORT`: o ambiente de conferência aponta para um endereço morto, que é o que mantém a sessão de pé sem API. O que se mede ali é **se a requisição partiu**, e ela é o que separa os dois casos.

`yarn typecheck` e `yarn lint` limpos nos 8 arquivos; `yarn test:ci` com **588 testes em 81 arquivos** e 100% de linhas e ramos em cada arquivo do diff. O primeiro commit foi conferido sozinho, em worktree própria: `tsc` limpo e 123 testes passando.

## Issue

- #309

Closes #309

## Evidências
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/29cddabc-697f-402a-bd28-313cfd6e94f1" />

> Obs.: O campo de data e hora serão unificados numa próxima tarefa, por isso não foi corrigido a mensagem de erro aparecendo no campo de data invés do de hora.
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/f51a6d3e-e968-469d-8108-8e1e46e56f4e" />
