### PR TITLE
docs: record what the past-departure fix taught about testing

### DIFF
--- a/.claude/rules/parallelism-and-worktrees.md
+++ b/.claude/rules/parallelism-and-worktrees.md
@@ -33,7 +33,7 @@ Issue que declara "Depende de" só começa quando a base estiver **com o escopo 
 ## Mecânica de worktree
 
 - **A worktree não nasce na branch atual.** Na #123 ela nasceu 16 commits atrás, sem o commit do contrato. Conferir com `git log --oneline -1` e corrigir com `git merge --ff-only <branch-da-tarefa>` **antes** de escrever qualquer linha.
-- ⛔ **A worktree nasce rastreando a base, e um `git push` vai para ela.** `git worktree add -b <nova> <caminho> origin/develop` deixa a branch nova com `origin/develop` como upstream — e a `develop` não aceita commit direto. Desarmar logo depois de criar:
+- ⛔ **Branch criada a partir de `origin/<base>` nasce rastreando a base, e um `git push` vai para ela.** Vale para `git worktree add -b <nova> <caminho> origin/develop` **e** para o `git checkout -b <nova> origin/develop` do checkout principal: os dois deixam `origin/develop` como upstream, e a `develop` não aceita commit direto. Desarmar logo depois de criar:
 
   ```bash
   git branch --unset-upstream <nova>

--- a/.claude/rules/prove-the-mechanism.md
+++ b/.claude/rules/prove-the-mechanism.md
@@ -57,6 +57,8 @@ Medido em 03/09/2026 sobre um diff de 18 adições:
 
 ⛔ **E o complemento de "passou" não é "falhou".** No mesmo `gh pr checks`, tratar `bucket != "pass"` como falha reporta vermelho onde há `pending`: em 02/09/2026 anunciei um check falhando no #287 quando o front ainda estava `IN_PROGRESS`, porque a cascata da pilha havia reiniciado o CI. Estado de terceira via — `pending`, `skipping`, `neutral` — se nomeia, não se deduz por exclusão.
 
+⛔ **`performance.getEntriesByType('resource')` não enxerga requisição que falha na conexão.** Em 04/09/2026, provando que um formulário deixara de chamar a API, ele devolveu **zero** nos dois casos — no que não devia chamar e no que devia. O zero era do instrumento. Quem responde é o log de rede do navegador (`read_network_requests`), que registra a tentativa com o motivo da falha; e o par positivo — o caso que **deve** disparar a requisição — é o que separa "não chamou" de "não medi".
+
 ⚠️ **`| head` num `grep` de investigação é o pior dos três**, porque some com a evidência sem avisar e a saída parece completa. Em busca que vai sustentar conclusão, conte antes (`grep -c`) ou não trunque.
 
 ⛔ **Regra nova se prova nas duas formas.** O controle positivo de uma regra de lint não é só "reprova o que deve" — é também "aceita o que deve". Ao estender a de tag crua, rodei um arquivo com `<div>` **e** `<strong>` no mesmo JSX: o primeiro reprova, o segundo passa. Sem a segunda metade eu teria proibido ênfase de texto sem perceber.

--- a/.claude/rules/web-forms.md
+++ b/.claude/rules/web-forms.md
@@ -21,6 +21,10 @@ Padrão estabelecido no cartão de login e válido para as telas de formulário 
 - `autoComplete` coerente com o campo; em senha, alternar entre `current-password` e `off` conforme a visibilidade.
 - Ação dentro do campo vai em `InputAdornment` com `IconButton`, `aria-label` descrevendo a **ação** e `aria-pressed` comunicando o estado.
 
+⛔ **Campo que ganha a primeira regra de validação precisa ganhar a prop de erro junto.** Enquanto ele não tem regra, ninguém sente falta da ligação — e no dia em que a regra entra, o schema recusa e a **tela fica muda**: o envio trava e nada explica por quê.
+
+Aconteceu na #309, no `Complemento` do endereço. Ele era o único campo opcional e sem limite, então nasceu sem `error={errors.complement?.message}`. O limite de comprimento entrou e o formulário passou a recusar em silêncio. ⚠️ **O teste de schema não vê isso** — o schema estava certo; quem não exibia era o campo. Quem pegou foi a medição na aplicação, e o caso que protege agora é de componente, não de schema.
+
 ## Ícone reflete estado
 
 O ícone mostra a situação atual, não o destino do clique: olho aberto quando o texto está visível. O rótulo acessível continua descrevendo a ação.

--- a/.claude/rules/web-testing-practices.md
+++ b/.claude/rules/web-testing-practices.md
@@ -42,6 +42,30 @@ O import saía de graça em 48 arquivos e ninguém percebia porque o teste passa
 - Não testar detalhe de implementação: nada de asserção sobre estado interno, nome de classe CSS ou ordem de chamada de hook.
 - Não duplicar no teste a lógica que ele verifica — valor esperado é literal, não recalculado.
 
+## Suíte verde não prova que ela pega o defeito
+
+⛔ **Quebre o código de propósito e confira que o teste cai.** É a única forma de saber se ele testa o que o nome dele diz — e o caso clássico aqui não é o teste frouxo, é o teste que **alimenta o formato errado**.
+
+Aconteceu em 04/09/2026, na #309. A regra de partida futura do formulário de carona nunca disparava: o campo guarda `22/05/2026` e ela lia com `parseISO`, que só entende ISO. O teste passava verde porque montava a entrada com o formato da **API** — ele passaria igual com a regra apagada. Quatro mutações fecharam a rodada, cada uma derrubando o teste escrito para ela: voltar o `parseISO`, tirar a conversão de fuso, tirar um `.max()` do schema e tirar a prop de erro de um campo.
+
+**Restaure a árvore ao fim de cada mutação** e confirme com `git status` que nada sobrou.
+
+## O fuso do processo vem fixado, e a linha de comando não o vence
+
+⛔ **`vitest.setup.ts` executa `process.env.TZ = 'America/Sao_Paulo'` para toda a suíte.** Rodar `TZ=UTC npx vitest` **não muda nada**: o setup roda depois e sobrescreve.
+
+Isso importa porque o fuso do produto é exatamente onde uma comparação feita no relógio local e uma feita no fuso do produto **concordam** — nenhum teste as distingue enquanto o processo estiver ali. Na #309 o controle rodou `TZ=UTC` na linha de comando, a suíte passou 9/9 com a conversão de fuso removida, e a conclusão natural teria sido que a conversão era desnecessária.
+
+Para discriminar, troque a variável **dentro do caso** e restaure ao fim — medido, funciona a partir da atribuição:
+
+```ts
+process.env.TZ = 'UTC';
+// … a asserção que só passa lendo o fuso do produto
+process.env.TZ = PRODUCT_TIME_ZONE;
+```
+
+⚠️ **O sinal é o controle passar quando você esperava que falhasse.** Antes de concluir que o código sob mutação é desnecessário, pergunte se o cenário chega a alcançá-lo.
+
 ## O nome no `getByRole` sai da constante, nunca do texto
 
 ⛔ **Nunca escreva o rótulo literal — nem string, nem regex — para achar um controle.** Importe a constante que o componente usa. Copy muda, e o literal não muda junto: ou o teste quebra, ou — pior — passa a casar **outro** controle.


### PR DESCRIPTION
## Objetivo

Registrar as cinco coisas que a rodada da #309 ensinou. É um PR só de harness: `.claude/rules/`, nada de código de aplicação.

Mudança de harness dispensa issue, não o PR; a branch não segue `<tipo>/<número>`, então não há seção de issue.

## Alterações

### `docs: record how to prove a front test catches the defect`

| Rule | O que entrou |
| --- | --- |
| `web-testing-practices.md` | **Suíte verde não prova que ela pega o defeito** — quebrar o código de propósito e conferir que o teste cai. O caso clássico aqui não é o teste frouxo: é o teste que **alimenta o formato errado** e passaria igual com a regra apagada |
| `web-testing-practices.md` | **O fuso do processo vem fixado, e a linha de comando não o vence** — o `vitest.setup.ts` atribui `process.env.TZ = 'America/Sao_Paulo'`, então `TZ=UTC npx vitest` não muda nada. Para discriminar, trocar a variável dentro do caso |

Os dois nasceram juntos e um explica o outro. Na #309 a regra de partida futura nunca disparava e o teste dela passava verde, porque montava a entrada no formato da API em vez do formato do campo. Ao mutar o código para conferir se a suíte pegava, o controle do fuso passou 9/9 com a conversão removida — e a conclusão natural teria sido que a conversão era desnecessária. O culpado era o `TZ` fixado: o fuso do produto é exatamente onde as duas formas de comparar concordam.

⚠️ **A `dotnet-testing.md` tem uma seção com o mesmo título.** Não é duplicação: as duas rules têm `paths` de áreas diferentes e nunca carregam juntas, e o que cada uma ancora é diferente — lá o risco é o build da mutação falhar em silêncio, aqui é a fixture no formato errado.

### `docs: record the traps this round paid`

| Rule | O que entrou |
| --- | --- |
| `web-forms.md` | **Campo que ganha a primeira regra de validação precisa ganhar a prop de erro junto** — sem ela o schema recusa e a tela fica muda, travando o envio sem explicar |
| `prove-the-mechanism.md` | **`performance.getEntriesByType('resource')` não enxerga requisição que falha na conexão** — ele devolveu zero no caso que devia chamar a API e no que não devia |
| `parallelism-and-worktrees.md` | O aviso de upstream deixa de ser só da worktree: **`git checkout -b <nova> origin/develop` no checkout principal também** deixa a `develop` como upstream |

O do formulário custou um defeito real: o `Complemento` do endereço era o único campo opcional e sem limite, então nunca recebeu a ligação com o erro. O limite entrou pela #309 e o formulário passou a recusar em silêncio — e **o teste de schema não via**, porque o schema estava certo. Quem pegou foi a medição na aplicação.

O do `performance` é da mesma família: o instrumento devolveu o número tranquilizador. Quem respondeu foi o log de rede do navegador, e o que separou "não chamou" de "não medi" foi o par positivo — o caso que **deve** disparar a requisição.

## Como foi verificado

`./scripts/check-harness-paths.sh` sem caminho órfão. Não há teste a rodar — o PR não toca em código.

A varredura de fechamento rodou **antes** do `gh pr create`, como a `harness-evolution.md` manda: reli a rodada inteira atrás de correção sua e de armadilha paga. Dos cinco itens, só o primeiro veio de pedido seu; os outros quatro saíram dessa releitura.

Dois itens foram examinados e **ficaram de fora**, por já estarem cobertos:

- **A rota como âncora da medição.** Medi o cadastro estando logado e o guard me mandou para `/menu` — o número saiu de outra tela. A `parallelism-and-worktrees.md` já manda ler `{ porta, rota }` junto de toda medição, e foi ela que me salvou.
- **O formulário só validar depois do primeiro envio.** Não é armadilha, é o padrão do `react-hook-form`; medir antes de submeter mede o estado certo de um formulário que ainda não foi enviado.

## Evidências
