### PR TITLE
feat(311): merge the ride departure into one field and follow the theme in native controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Move a preferência de tema do topo da área logada para uma tela própria, em Preferências, alcançada pelo menu; na página inicial o botão continua no topo, para quem ainda não entrou (#301) [Frontend]
 - Divide o menu lateral da área logada em seções — serviços e conta —, cada item com o seu ícone e a saída de sessão separada no rodapé; ele passa a levar também a notificações, ao perfil e às preferências, e abaixo do desktop passa a ser o único caminho para a conta, com o avatar saindo do topo onde o botão de menu aparece (#306) [Frontend]
 - Renomeia para `Excluir` a ação que remove item e carona, antes chamada `Cancelar` e lida como desistir da operação em vez de destruir o registro; a confirmação, os avisos, a etiqueta e o filtro acompanham, o botão que dispensa o diálogo volta a ser `Cancelar`, e recuperar um item excluído passa a ser `Restaurar`. A nota do item excluído passa a distinguir a exclusão manual da automática por inatividade, e deixa de existir quando o motivo não vem — antes ela repetia a palavra da etiqueta ao lado (#314) [Frontend]
+- Junta data e hora da carona num campo só, digitado com máscara e com um painel que a aplicação desenha, mostrando o dia e a hora um passo por vez com o valor escolhido no topo: o campo de hora usava o seletor do navegador, que saía claro sobre o diálogo escuro e com moldura que não é a dos nossos campos. O formulário passa a recusar a partida escrita pela metade, que antes seguia com a data vazia (#316) [Frontend]
 
 ### Fixed
 
@@ -38,6 +39,7 @@ O formato segue o [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrige o cartão de entrar da página inicial, que era estreito demais para o e-mail institucional completo e o cortava dentro do campo — e é o único formato de e-mail que a tela aceita (#278) [Frontend]
 - Corrige a explicação do tipo de carona, inalcançável no celular: ela abria só ao passar o ponteiro, e agora abre ao toque, num alvo grande o bastante e sem levar o foco para o campo (#279) [Frontend]
 - Corrige o espaçamento dos botões dentro dos campos — o do calendário e o do relógio —, que ficavam mais para dentro que a seta dos campos de seleção ao lado (#279) [Frontend]
+- Corrige os controles que o navegador desenha por conta — como a listinha do campo de hora dos filtros —, que saíam sempre no claro por mais escuro que o tema estivesse (#316) [Frontend]
 - Corrige o logo dentro do menu lateral, que navegava e deixava o menu aberto por cima da tela nova (#281) [Frontend]
 - Corrige o realce de passar o ponteiro no topo e no menu lateral: no topo ele não chegava a aparecer, e no menu clareava tanto que apagava o próprio rótulo (#281) [Frontend]
 - Corrige a recusa de cadastro sem data de nascimento, que respondia em inglês enquanto os outros erros da API já vinham em português (#285) [Backend]

--- a/FateConnect/Web/design-system/DateLocalizationProvider/index.tsx
+++ b/FateConnect/Web/design-system/DateLocalizationProvider/index.tsx
@@ -3,10 +3,20 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { ptBR } from 'date-fns/locale/pt-BR';
 
+/**
+ * O adaptador crava `MMM d` na data curta, em qualquer idioma, e o cabeçalho do
+ * seletor sairia `nov 20`. Em pt-BR o dia vem antes do mês.
+ */
+const DATE_FORMATS = { shortDate: 'd MMM' };
+
 /** A tradução da interface do calendário vem do tema, não daqui. */
 export function DateLocalizationProvider({ children }: Readonly<{ children: ReactNode }>) {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ptBR}>
+    <LocalizationProvider
+      dateAdapter={AdapterDateFns}
+      adapterLocale={ptBR}
+      dateFormats={DATE_FORMATS}
+    >
       {children}
     </LocalizationProvider>
   );

--- a/FateConnect/Web/design-system/ThemeProvider/ThemeProvider.test.tsx
+++ b/FateConnect/Web/design-system/ThemeProvider/ThemeProvider.test.tsx
@@ -43,6 +43,16 @@ describe('ThemeProvider', () => {
     expect(probe()).toHaveTextContent('dark');
   });
 
+  // Sem esta declaração o Chrome desenha todo controle nativo no claro, por mais
+  // escuro que o tema esteja — e nada no produto acusa.
+  it('should tell the browser which scheme to draw its own controls in', () => {
+    themeModeStorage.save('dark');
+
+    render(<ModeProbe />);
+
+    expect(getComputedStyle(document.documentElement).colorScheme).toBe('dark');
+  });
+
   it('should remember the mode the reader switches to', async () => {
     render(<ModeProbe />);
 

--- a/FateConnect/Web/design-system/ThemeProvider/index.tsx
+++ b/FateConnect/Web/design-system/ThemeProvider/index.tsx
@@ -35,7 +35,11 @@ export function ThemeProvider({ children, defaultMode = 'light' }: ThemeProvider
   return (
     <ThemeModeContext.Provider value={themeMode}>
       <MuiThemeProvider theme={theme}>
-        <CssBaseline />
+        {/*
+          Sem a prop o `CssBaseline` não declara `color-scheme`, e o Chrome
+          desenha todo controle nativo no claro por mais escuro que o tema seja.
+        */}
+        <CssBaseline enableColorScheme />
         <GlobalStyles />
         {children}
       </MuiThemeProvider>

--- a/FateConnect/Web/design-system/components/Input/Input.test.tsx
+++ b/FateConnect/Web/design-system/components/Input/Input.test.tsx
@@ -1,4 +1,4 @@
-import { createRef } from 'react';
+import { createRef, useState } from 'react';
 
 import {
   act,
@@ -9,8 +9,14 @@ import {
   waitFor,
   within,
 } from '@app/test/testing-library';
+import { themeModeStorage } from '@ds-root/ThemeProvider/storage/themeModeStorage';
 
-import { DATE_PICKER_LABEL, HELP_TRIGGER_LABEL_PREFIX, TIME_PICKER_LABEL } from './constants';
+import {
+  DATE_PICKER_LABEL,
+  DATE_TIME_PICKER_LABEL,
+  HELP_TRIGGER_LABEL_PREFIX,
+  TIME_PICKER_LABEL,
+} from './constants';
 import { Input, type InputProps } from '.';
 
 const DEFAULT_PROPS: InputProps = { label: 'Destino' };
@@ -201,7 +207,9 @@ describe('Input.Select', () => {
 
     expect(await screen.findByRole('tooltip')).toHaveTextContent(HELP_TEXT);
   });
+});
 
+describe('Input.Date', () => {
   it('should not offer a day after the max date', async () => {
     const pickedDay = new Date(2026, 7, 10);
     render(<Input.Date label="Data" value="10/08/2026" maxDate={pickedDay} onChange={vi.fn()} />);
@@ -211,5 +219,224 @@ describe('Input.Select', () => {
     const calendar = within(await screen.findByRole('grid'));
     expect(calendar.getByRole('gridcell', { name: '10' })).toBeEnabled();
     expect(calendar.getByRole('gridcell', { name: '11' })).toBeDisabled();
+  });
+
+  it('should close the calendar once the day is picked, which is all it asks for', async () => {
+    render(<Input.Date label="Data" value="10/08/2026" onChange={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: DATE_PICKER_LABEL }));
+
+    await userEvent.click(
+      within(await screen.findByRole('grid')).getByRole('gridcell', { name: '11' }),
+    );
+
+    await waitFor(() => expect(screen.queryByRole('grid')).not.toBeInTheDocument());
+  });
+});
+
+const DEPARTURE = '22/05/2026 18:30';
+const DEPARTURE_HOUR = '18:30';
+/** Dia antes do mês: o adaptador crava a ordem inversa em qualquer idioma. */
+const DEPARTURE_SHORT_DATE = '22 mai';
+const DEPARTURE_YEAR = '2026';
+/** Vem do idioma da biblioteca, não das nossas constantes. */
+const PICKER_TITLE = 'Selecione data e hora';
+
+function DateTimeHarness() {
+  const [departure, setDeparture] = useState('');
+
+  return <Input.DateTime label="Data e hora" value={departure} onChange={setDeparture} />;
+}
+
+const openDateTimePicker = () =>
+  userEvent.click(screen.getByRole('button', { name: DATE_TIME_PICKER_LABEL }));
+
+describe('Input.DateTime', () => {
+  it('should offer the day and the hour behind one tab each, not both at once', async () => {
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={vi.fn()} />);
+
+    await openDateTimePicker();
+
+    expect(await screen.findByRole('grid')).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('should reach the hour through the other tab', async () => {
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={vi.fn()} />);
+    await openDateTimePicker();
+    const [, hourTab] = await screen.findAllByRole('tab');
+
+    await userEvent.click(hourTab as HTMLElement);
+
+    expect(await screen.findAllByRole('listbox')).not.toHaveLength(0);
+    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+  });
+
+  it('should show what was picked so far, since the panel covers the field', async () => {
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={vi.fn()} />);
+
+    await openDateTimePicker();
+
+    // O topo do painel parte o valor em botões, um por trecho editável.
+    const top = (await screen.findByText(PICKER_TITLE)).parentElement;
+
+    expect(top).toHaveTextContent(DEPARTURE_SHORT_DATE);
+    expect(top).toHaveTextContent(DEPARTURE_HOUR);
+  });
+
+  it('should keep the hour already typed when the day changes', async () => {
+    const onChange = vi.fn();
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={onChange} />);
+    await openDateTimePicker();
+
+    await userEvent.click(
+      within(await screen.findByRole('grid')).getByRole('gridcell', { name: '23' }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith('23/05/2026 18:30');
+  });
+
+  it('should go straight to the hour once the day is picked, panel still open', async () => {
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={vi.fn()} />);
+    await openDateTimePicker();
+
+    await userEvent.click(
+      within(await screen.findByRole('grid')).getByRole('gridcell', { name: '23' }),
+    );
+
+    expect(await screen.findAllByRole('listbox')).not.toHaveLength(0);
+    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+  });
+
+  // O painel não traz botão nenhum: os da biblioteca não funcionam num painel
+  // que não é dono do próprio ciclo. Quem fecha é escolher o minuto.
+  it('should close itself once the minute is picked, and offer no button', async () => {
+    render(<DateTimeHarness />);
+    const field = screen.getByRole('textbox', { name: /Data e hora/ });
+    await userEvent.type(field, '22052026');
+    await openDateTimePicker();
+    // Escolher o dia é o que leva à hora — o painel não tem botão de avançar.
+    await userEvent.click(
+      within(await screen.findByRole('grid')).getByRole('gridcell', { name: '23' }),
+    );
+    // O nome acessível da opção traz a unidade junto (`18 horas`); o texto, não.
+    const [hours, minutes] = await screen.findAllByRole('listbox');
+    await userEvent.click(within(hours as HTMLElement).getByText('18'));
+
+    await userEvent.click(within(minutes as HTMLElement).getByText('30'));
+
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    expect(field).toHaveValue('23/05/2026 18:30');
+  });
+
+  // O caminho de quem edita: a hora já está certa e só o minuto muda. Aqui não
+  // há troca de vista nenhuma — as duas colunas ficam na tela ao mesmo tempo.
+  it('should close when only the minute changes, without the day being touched', async () => {
+    render(<DateTimeHarness />);
+    const field = screen.getByRole('textbox', { name: /Data e hora/ });
+    await userEvent.type(field, '220520261830');
+    await openDateTimePicker();
+    const [, hourTab] = await screen.findAllByRole('tab');
+    await userEvent.click(hourTab as HTMLElement);
+    const [, minutes] = await screen.findAllByRole('listbox');
+
+    await userEvent.click(within(minutes as HTMLElement).getByText('45'));
+
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    expect(field).toHaveValue('22/05/2026 18:45');
+  });
+
+  it('should leave the year out of the panel top, since the calendar already shows it', async () => {
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={vi.fn()} />);
+
+    await openDateTimePicker();
+
+    const top = (await screen.findByText(PICKER_TITLE)).parentElement;
+    expect(top).not.toHaveTextContent(DEPARTURE_YEAR);
+  });
+
+  it('should size the day and the hour at the top alike', async () => {
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={vi.fn()} />);
+    await openDateTimePicker();
+
+    const top = (await screen.findByText(PICKER_TITLE)).parentElement as HTMLElement;
+    const [day, hour] = [...top.querySelectorAll('button')];
+
+    expect(getComputedStyle(hour as HTMLElement).fontSize).toBe(
+      getComputedStyle(day as HTMLElement).fontSize,
+    );
+  });
+
+  // A sobrescrita vive no `styles.ts` do campo, porque a biblioteca desenha o
+  // título sem gancho no tema — e ela some sem nada acusar.
+  it('should draw the panel title in our own type, not in the library caps', async () => {
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={vi.fn()} />);
+
+    await openDateTimePicker();
+
+    expect(getComputedStyle(await screen.findByText(PICKER_TITLE)).textTransform).toBe('none');
+  });
+
+  it('should not offer a day before the min date', async () => {
+    const minDay = new Date(2026, 4, 22);
+    render(
+      <Input.DateTime label="Data e hora" value={DEPARTURE} minDate={minDay} onChange={vi.fn()} />,
+    );
+
+    await openDateTimePicker();
+
+    const calendar = within(await screen.findByRole('grid'));
+    expect(calendar.getByRole('gridcell', { name: '22' })).toBeEnabled();
+    expect(calendar.getByRole('gridcell', { name: '21' })).toBeDisabled();
+  });
+
+  it('should mask what is typed and stop at the minute', async () => {
+    render(<DateTimeHarness />);
+
+    const field = screen.getByRole('textbox', { name: /Data e hora/ });
+    await userEvent.type(field, '22052026183099');
+
+    expect(field).toHaveValue(DEPARTURE);
+  });
+
+  it('should leave the caret where the typing was, not at the end of the field', async () => {
+    render(<DateTimeHarness />);
+    const field: HTMLInputElement = screen.getByRole('textbox', { name: /Data e hora/ });
+    await userEvent.type(field, '22052026');
+
+    await userEvent.type(field, '9', { initialSelectionStart: 1, initialSelectionEnd: 1 });
+
+    expect(field).toHaveValue('29/20/5202 6');
+    expect(field.selectionStart).toBe(2);
+  });
+});
+
+/**
+ * A cor primária do tema claro **é** a cor de texto, então lá as duas coincidem
+ * e nada distingue a sobrescrita da ausência dela. O defeito mora só no escuro,
+ * onde a primária é a superfície do cromo e como texto fica em 4,11:1.
+ */
+describe('Input.DateTime in the dark theme', () => {
+  beforeEach(() => {
+    themeModeStorage.save('dark');
+  });
+
+  afterEach(() => {
+    themeModeStorage.save('light');
+  });
+
+  it('should draw the panel text in the reading colour, not in the chrome one', async () => {
+    render(<Input.DateTime label="Data e hora" value={DEPARTURE} onChange={vi.fn()} />);
+    await openDateTimePicker();
+    await screen.findByRole('grid');
+
+    const [dayTab] = screen.getAllByRole('tab');
+    const readingColour = getComputedStyle(document.body).color;
+
+    const top = (await screen.findByText(PICKER_TITLE)).parentElement as HTMLElement;
+    const [day] = [...top.querySelectorAll('button')];
+
+    expect(getComputedStyle(dayTab as HTMLElement).color).toBe(readingColour);
+    expect(getComputedStyle(day as HTMLElement).color).toBe(readingColour);
   });
 });

--- a/FateConnect/Web/design-system/components/Input/components/DateField/index.tsx
+++ b/FateConnect/Web/design-system/components/Input/components/DateField/index.tsx
@@ -1,26 +1,15 @@
-import {
-  useCallback,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type FocusEvent,
-  type MouseEvent,
-} from 'react';
+import { useCallback, type FocusEvent } from 'react';
 import Popover from '@mui/material/Popover';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 
 import { IconButton } from '@ds-root/components/IconButton';
 import { CalendarTodayIcon } from '@ds-root/icons';
-import { caretAfterDigitCount, countDigits } from '@ds-root/utils/text';
 
 import { DATE_PICKER_LABEL } from '../../constants';
+import { useMaskedPicker } from '../../hooks/useMaskedPicker';
 import { InputField } from '../../InputField';
 import { DATE_PLACEHOLDER, MASKED_DATE_LENGTH } from './constants';
 import { formatDate, maskDate, parseDate } from './helpers';
-
-const TEXT_START = 0;
-const NO_CARET = -1;
 
 export type DateFieldProps = Readonly<{
   label: string;
@@ -37,11 +26,7 @@ export type DateFieldProps = Readonly<{
   maxDate?: Date;
 }>;
 
-/**
- * Campo de data do produto: o texto mascarado é a fonte de verdade e o
- * calendário é auxiliar. Digitar é o caminho principal, com o cursor preservado
- * ao editar no meio — sem isso ele pula para o fim a cada tecla.
- */
+/** Campo de data do produto: o calendário é auxiliar do texto mascarado. */
 export function DateField({
   label,
   value,
@@ -54,48 +39,19 @@ export function DateField({
   minDate,
   maxDate,
 }: DateFieldProps) {
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  const caretRef = useRef(NO_CARET);
-  const [calendarAnchor, setCalendarAnchor] = useState<HTMLElement | null>(null);
-
-  useLayoutEffect(() => {
-    const input = inputRef.current;
-    if (!input || caretRef.current === NO_CARET) return;
-
-    input.setSelectionRange(caretRef.current, caretRef.current);
-    caretRef.current = NO_CARET;
-  });
-
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const typed = event.target.value;
-      const masked = maskDate(typed);
-      const caretIndex = event.target.selectionStart ?? typed.length;
-
-      caretRef.current = caretAfterDigitCount(
-        masked,
-        countDigits(typed.slice(TEXT_START, caretIndex)),
-      );
-      onChange(masked);
-    },
-    [onChange],
+  const { inputRef, anchor, handleChange, handleOpenPicker, handleClosePicker } = useMaskedPicker(
+    maskDate,
+    onChange,
   );
-
-  const handleOpenCalendar = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => setCalendarAnchor(event.currentTarget),
-    [],
-  );
-
-  const handleCloseCalendar = useCallback(() => setCalendarAnchor(null), []);
 
   const handleDatePick = useCallback(
     (date: Date | null) => {
       if (!date) return;
 
       onChange(formatDate(date));
-      setCalendarAnchor(null);
+      handleClosePicker();
     },
-    [onChange],
+    [onChange, handleClosePicker],
   );
 
   return (
@@ -120,7 +76,7 @@ export function DateField({
           <IconButton
             type="button"
             label={DATE_PICKER_LABEL}
-            onClick={handleOpenCalendar}
+            onClick={handleOpenPicker}
             disabled={disabled}
           >
             <CalendarTodayIcon fontSize="small" />
@@ -129,9 +85,9 @@ export function DateField({
       />
 
       <Popover
-        open={Boolean(calendarAnchor)}
-        anchorEl={calendarAnchor}
-        onClose={handleCloseCalendar}
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={handleClosePicker}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       >

--- a/FateConnect/Web/design-system/components/Input/components/DateTimeField/constants/index.ts
+++ b/FateConnect/Web/design-system/components/Input/components/DateTimeField/constants/index.ts
@@ -1,0 +1,27 @@
+import type { DateOrTimeView } from '@mui/x-date-pickers/models';
+
+export const DATE_TIME_PLACEHOLDER = 'dd/mm/aaaa hh:mm';
+
+/** `dd/mm/aaaa hh:mm` — o campo não aceita mais que isso. */
+export const MASKED_DATE_TIME_LENGTH = 16;
+
+/**
+ * Nenhum botão na barra da biblioteca, porque nenhum dos dela funciona aqui: o
+ * painel foi feito para ser o seletor inteiro, dono do próprio ciclo, e aqui ele
+ * é conteúdo do nosso popover. O de avançar usa um setter que a vista controlada
+ * torna inerte, e o de confirmar só reage quando há mudança pendente — abrir e
+ * confirmar sem tocar em nada não fazia nada.
+ *
+ * Quem fecha é escolher o minuto, como no campo só de data escolher o dia.
+ */
+export const PICKER_SLOT_PROPS = { actionBar: { actions: [] } };
+
+export const DAY_VIEW = 'day';
+export const HOURS_VIEW = 'hours';
+const MINUTES_VIEW = 'minutes';
+
+/**
+ * Sem `year`: ele é um botão no topo do painel, e o cabeçalho do calendário
+ * logo abaixo já mostra o ano.
+ */
+export const PICKER_VIEWS: readonly DateOrTimeView[] = [DAY_VIEW, HOURS_VIEW, MINUTES_VIEW];

--- a/FateConnect/Web/design-system/components/Input/components/DateTimeField/helpers/helpers.test.ts
+++ b/FateConnect/Web/design-system/components/Input/components/DateTimeField/helpers/helpers.test.ts
@@ -1,0 +1,48 @@
+import { formatDateTime, maskDateTime, parseDateTime, parseDateTimeSoFar } from '.';
+
+describe('maskDateTime', () => {
+  it.each([
+    ['', ''],
+    ['2', '2'],
+    ['2205', '22/05'],
+    ['22051999', '22/05/1999'],
+    ['220519991', '22/05/1999 1'],
+    ['2205199918', '22/05/1999 18'],
+    ['22051999183', '22/05/1999 18:3'],
+    ['220519991830', '22/05/1999 18:30'],
+  ])('should format %s as %s', (input, expected) => {
+    expect(maskDateTime(input)).toBe(expected);
+  });
+
+  it('should ignore digits beyond the twelfth', () => {
+    expect(maskDateTime('22051999183099')).toBe('22/05/1999 18:30');
+  });
+
+  it('should reformat a value that already carries separators', () => {
+    expect(maskDateTime('22/05/1999 18:30')).toBe('22/05/1999 18:30');
+  });
+});
+
+describe('parseDateTime', () => {
+  it('should read a complete departure and refuse an impossible one', () => {
+    expect(parseDateTime('22/05/1999 18:30')?.getHours()).toBe(18);
+    expect(parseDateTime('22/05/1999 25:30')).toBeNull();
+    expect(parseDateTime('32/05/1999 18:30')).toBeNull();
+    expect(parseDateTime('22/05/1999')).toBeNull();
+  });
+});
+
+describe('formatDateTime', () => {
+  it('should write the departure in the product format', () => {
+    expect(formatDateTime(new Date(1999, 4, 22, 18, 30))).toBe('22/05/1999 18:30');
+  });
+});
+
+describe('parseDateTimeSoFar', () => {
+  it('should fall back to the day alone while the hour is still missing', () => {
+    expect(parseDateTimeSoFar('22/05/1999 18:30')).toEqual(new Date(1999, 4, 22, 18, 30));
+    expect(parseDateTimeSoFar('22/05/1999 18')).toEqual(new Date(1999, 4, 22));
+    expect(parseDateTimeSoFar('22/05/1999')).toEqual(new Date(1999, 4, 22));
+    expect(parseDateTimeSoFar('22/05')).toBeNull();
+  });
+});

--- a/FateConnect/Web/design-system/components/Input/components/DateTimeField/helpers/index.ts
+++ b/FateConnect/Web/design-system/components/Input/components/DateTimeField/helpers/index.ts
@@ -1,0 +1,61 @@
+import type { DateOrTimeView } from '@mui/x-date-pickers/models';
+import { format, isValid, parse } from 'date-fns';
+
+import { MASKED_DATE_LENGTH } from '@ds-root/components/Input/components/DateField/constants';
+import { maskDate, parseDate } from '@ds-root/components/Input/components/DateField/helpers';
+import { onlyDigits } from '@ds-root/utils/text';
+
+import { MASKED_DATE_TIME_LENGTH, PICKER_VIEWS } from '../constants';
+
+const DATE_TIME_FORMAT = 'dd/MM/yyyy HH:mm';
+const TEXT_START = 0;
+const MAX_DATE_TIME_DIGITS = 12;
+const DATE_DIGITS = 8;
+const HOUR_END = 2;
+
+/** Formata `dd/mm/aaaa hh:mm` progressivamente, sobre a máscara só de data. */
+export function maskDateTime(value: string): string {
+  const digits = onlyDigits(value).slice(TEXT_START, MAX_DATE_TIME_DIGITS);
+  const date = maskDate(digits);
+  const time = digits.slice(DATE_DIGITS);
+
+  if (!time) return date;
+  if (time.length <= HOUR_END) return `${date} ${time}`;
+
+  return `${date} ${time.slice(TEXT_START, HOUR_END)}:${time.slice(HOUR_END)}`;
+}
+
+/**
+ * Converte `dd/mm/aaaa hh:mm` em data, ou `null` quando o texto não fecha uma.
+ * Texto incompleto é `null` de propósito, como no campo só de data.
+ */
+export function parseDateTime(value: string): Date | null {
+  if (value.length !== MASKED_DATE_TIME_LENGTH) return null;
+
+  const parsed = parse(value, DATE_TIME_FORMAT, new Date());
+  if (!isValid(parsed)) return null;
+
+  return parsed;
+}
+
+export function formatDateTime(date: Date): string {
+  return format(date, DATE_TIME_FORMAT);
+}
+
+/**
+ * O que o calendário e o relógio conseguem mostrar do que já foi digitado: o
+ * dia e a hora quando os dois fecham, e só o dia enquanto a hora não chega.
+ */
+export function parseDateTimeSoFar(value: string): Date | null {
+  return parseDateTime(value) ?? parseDate(value.slice(TEXT_START, MASKED_DATE_LENGTH));
+}
+
+const PICKER_VIEW_NAMES: ReadonlySet<string> = new Set<string>(PICKER_VIEWS);
+
+/**
+ * O seletor avisa a troca de passo com o vocabulário dele, que inclui o `am/pm`
+ * de um relógio de 12 horas — que em pt-BR não existe.
+ */
+export function isPickerView(view: string): view is DateOrTimeView {
+  return PICKER_VIEW_NAMES.has(view);
+}

--- a/FateConnect/Web/design-system/components/Input/components/DateTimeField/index.tsx
+++ b/FateConnect/Web/design-system/components/Input/components/DateTimeField/index.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useState, type FocusEvent, type MouseEvent } from 'react';
+import type { DateOrTimeView } from '@mui/x-date-pickers/models';
+import { StaticDateTimePicker } from '@mui/x-date-pickers/StaticDateTimePicker';
+
+import { IconButton } from '@ds-root/components/IconButton';
+import { CalendarTodayIcon } from '@ds-root/icons';
+
+import { DATE_TIME_PICKER_LABEL } from '../../constants';
+import { useMaskedPicker } from '../../hooks/useMaskedPicker';
+import { InputField } from '../../InputField';
+import {
+  DATE_TIME_PLACEHOLDER,
+  DAY_VIEW,
+  HOURS_VIEW,
+  MASKED_DATE_TIME_LENGTH,
+  PICKER_SLOT_PROPS,
+  PICKER_VIEWS,
+} from './constants';
+import { formatDateTime, isPickerView, maskDateTime, parseDateTimeSoFar } from './helpers';
+import * as S from './styles';
+
+export type DateTimeFieldProps = Readonly<{
+  label: string;
+  /** Texto mascarado, possivelmente incompleto — é o que a pessoa digitou. */
+  value: string;
+  onChange: (masked: string) => void;
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
+  name?: string;
+  /** A presença da mensagem **é** o estado de erro do campo. */
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  minDate?: Date;
+  maxDate?: Date;
+}>;
+
+/**
+ * Campo de data e hora do produto, com o texto mascarado como fonte de verdade
+ * e o seletor da biblioteca num painel que o nosso tema desenha.
+ */
+export function DateTimeField({
+  label,
+  value,
+  onChange,
+  onBlur,
+  name,
+  error,
+  required,
+  disabled,
+  minDate,
+  maxDate,
+}: DateTimeFieldProps) {
+  const { inputRef, anchor, handleChange, handleOpenPicker, handleClosePicker } = useMaskedPicker(
+    maskDateTime,
+    onChange,
+  );
+  const [view, setView] = useState<DateOrTimeView>(DAY_VIEW);
+
+  const handleViewChange = useCallback((next: string) => {
+    if (isPickerView(next)) setView(next);
+  }, []);
+
+  const handleOpen = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      setView(DAY_VIEW);
+      handleOpenPicker(event);
+    },
+    [handleOpenPicker],
+  );
+
+  /**
+   * O painel anda sozinho: escolhido o dia ele vai para a hora — a aba de volta
+   * continua ali —, e escolhido o minuto ele fecha, como o campo só de data
+   * fecha ao escolher o dia.
+   *
+   * ⚠️ O seletor não diz qual trecho foi tocado: a prop recebe a data e um
+   * contexto, e nada mais. Do dia dá para saber pela vista, porque o calendário
+   * só aparece nela; do minuto, não — hora e minuto ficam **na tela ao mesmo
+   * tempo**, e mexer só no minuto não troca vista nenhuma. Aí quem responde é a
+   * comparação com o valor que já estava lá.
+   */
+  const handlePick = useCallback(
+    (date: Date | null) => {
+      if (!date) return;
+
+      const previous = parseDateTimeSoFar(value);
+      onChange(formatDateTime(date));
+
+      if (view === DAY_VIEW) {
+        setView(HOURS_VIEW);
+        return;
+      }
+      if (previous?.getMinutes() !== date.getMinutes()) handleClosePicker();
+    },
+    [onChange, value, view, handleClosePicker],
+  );
+
+  return (
+    <>
+      <InputField
+        ref={inputRef}
+        name={name}
+        label={label}
+        value={value}
+        onChange={handleChange}
+        onBlur={onBlur}
+        required={required}
+        disabled={disabled}
+        error={error}
+        fullWidth
+        type="text"
+        inputMode="numeric"
+        placeholder={DATE_TIME_PLACEHOLDER}
+        maxLength={MASKED_DATE_TIME_LENGTH}
+        shrinkLabel={Boolean(value)}
+        endAdornment={
+          <IconButton
+            type="button"
+            label={DATE_TIME_PICKER_LABEL}
+            onClick={handleOpen}
+            disabled={disabled}
+          >
+            <CalendarTodayIcon fontSize="small" />
+          </IconButton>
+        }
+      />
+
+      <S.PickerPopover
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={handleClosePicker}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        {/*
+          Uma peça por vez, com o valor em construção no topo. As duas lado a
+          lado somam 640px: no celular cobriam a tela e escondiam o campo que o
+          painel edita, e no desktop engoliam o diálogo.
+        */}
+        <StaticDateTimePicker
+          displayStaticWrapperAs="mobile"
+          value={parseDateTimeSoFar(value)}
+          onChange={handlePick}
+          onAccept={handleClosePicker}
+          view={view}
+          onViewChange={handleViewChange}
+          views={PICKER_VIEWS}
+          minDate={minDate}
+          maxDate={maxDate}
+          slotProps={PICKER_SLOT_PROPS}
+        />
+      </S.PickerPopover>
+    </>
+  );
+}

--- a/FateConnect/Web/design-system/components/Input/components/DateTimeField/styles.ts
+++ b/FateConnect/Web/design-system/components/Input/components/DateTimeField/styles.ts
@@ -1,0 +1,29 @@
+import Popover from '@mui/material/Popover';
+
+import { styled } from '@ds-root/styled';
+import { typographyTokens } from '@ds-root/tokens';
+
+/**
+ * O seletor traz o próprio recuo; o papel só o emoldura.
+ *
+ * As duas sobrescritas moram aqui, e não no tema, porque a biblioteca desenha
+ * esses elementos sem gancho de `styleOverrides`.
+ */
+export const PickerPopover = styled(Popover)(({ theme }) => ({
+  '& .MuiPickersLayout-root': { backgroundColor: theme.palette.background.paper },
+
+  // O título vem em `overline`, que é caixa alta e não é escala nossa.
+  '& .MuiPickersToolbar-title': { ...typographyTokens.caption, textTransform: 'none' },
+
+  // O dia sai em `h4` e a hora em `h3`, dois tamanhos que não são nossos e que
+  // fazem o valor competir com o título do diálogo atrás do painel.
+  '& .MuiDateTimePickerToolbar-dateContainer .MuiTypography-root, & .MuiDateTimePickerToolbar-timeDigitsContainer .MuiTypography-root':
+    typographyTokens.h2,
+
+  // Aba, dígito do topo e ação saem na cor primária, que no tema escuro é a
+  // superfície do cromo: como texto ela dá 4,11:1, abaixo dos 4,5:1 que a WCAG
+  // pede. O texto passa a ler a cor de texto, e o destaque sobrevive onde o
+  // limite é 3:1 — o traço da aba ativa e o dia escolhido.
+  '& .MuiTab-root.Mui-selected, & .MuiPickersToolbar-root .MuiButton-root, & .MuiPickersLayout-actionBar .MuiButton-root':
+    { color: theme.palette.text.primary },
+}));

--- a/FateConnect/Web/design-system/components/Input/constants/index.ts
+++ b/FateConnect/Web/design-system/components/Input/constants/index.ts
@@ -1,3 +1,4 @@
 export const DATE_PICKER_LABEL = 'Abrir calendário';
 export const TIME_PICKER_LABEL = 'Abrir seletor de horário';
+export const DATE_TIME_PICKER_LABEL = 'Abrir seletor de data e hora';
 export const HELP_TRIGGER_LABEL_PREFIX = 'Ajuda sobre';

--- a/FateConnect/Web/design-system/components/Input/hooks/useMaskedPicker.ts
+++ b/FateConnect/Web/design-system/components/Input/hooks/useMaskedPicker.ts
@@ -1,0 +1,71 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type MouseEvent,
+  type RefObject,
+} from 'react';
+
+import { caretAfterDigitCount, countDigits } from '@ds-root/utils/text';
+
+const TEXT_START = 0;
+const NO_CARET = -1;
+
+type MaskFunction = (typed: string) => string;
+
+export type MaskedPicker = {
+  inputRef: RefObject<HTMLInputElement | null>;
+  /** O gatilho que abriu o seletor, ou `null` enquanto ele está fechado. */
+  anchor: HTMLElement | null;
+  handleChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleOpenPicker: (event: MouseEvent<HTMLButtonElement>) => void;
+  handleClosePicker: VoidFunction;
+};
+
+/**
+ * O texto mascarado é a fonte de verdade e o seletor é auxiliar. Digitar é o
+ * caminho principal, com o cursor preservado ao editar no meio — sem isso ele
+ * pula para o fim a cada tecla.
+ */
+export function useMaskedPicker(
+  mask: MaskFunction,
+  onChange: (masked: string) => void,
+): MaskedPicker {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const caretRef = useRef(NO_CARET);
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+
+  useLayoutEffect(() => {
+    const input = inputRef.current;
+    if (!input || caretRef.current === NO_CARET) return;
+
+    input.setSelectionRange(caretRef.current, caretRef.current);
+    caretRef.current = NO_CARET;
+  });
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const typed = event.target.value;
+      const masked = mask(typed);
+      const caretIndex = event.target.selectionStart ?? typed.length;
+
+      caretRef.current = caretAfterDigitCount(
+        masked,
+        countDigits(typed.slice(TEXT_START, caretIndex)),
+      );
+      onChange(masked);
+    },
+    [mask, onChange],
+  );
+
+  const handleOpenPicker = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => setAnchor(event.currentTarget),
+    [],
+  );
+
+  const handleClosePicker = useCallback(() => setAnchor(null), []);
+
+  return { inputRef, anchor, handleChange, handleOpenPicker, handleClosePicker };
+}

--- a/FateConnect/Web/design-system/components/Input/index.tsx
+++ b/FateConnect/Web/design-system/components/Input/index.tsx
@@ -1,4 +1,5 @@
 import { DateField } from './components/DateField';
+import { DateTimeField } from './components/DateTimeField';
 import { SelectInput } from './components/SelectInput';
 import { InputField, type InputProps } from './InputField';
 
@@ -13,6 +14,7 @@ function Input(inputProps: InputProps) {
 }
 
 Input.Date = DateField;
+Input.DateTime = DateTimeField;
 Input.Select = SelectInput;
 
 export { Input };

--- a/FateConnect/Web/design-system/index.ts
+++ b/FateConnect/Web/design-system/index.ts
@@ -50,4 +50,4 @@ export { GlobalStyles } from './GlobalStyles';
 export { spacingScale, radiusScale, shadowTokens, iconSizeTokens } from './tokens';
 
 export { caretAfterDigitCount, countDigits, onlyDigits } from './utils/text';
-export { DATE_PICKER_LABEL } from './components/Input/constants';
+export { DATE_PICKER_LABEL, DATE_TIME_PICKER_LABEL } from './components/Input/constants';

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormDialog.test.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormDialog.test.tsx
@@ -1,10 +1,11 @@
+import { onlyDigits } from '@design-system';
 import { format } from 'date-fns';
 import { http, HttpResponse } from 'msw';
 
 import { server } from '@app/mocks/server';
 import { RideTypeEnum, type Ride, type RideInput } from '@app/services/rides/types';
 import { render, screen, userEvent, waitFor } from '@app/test/testing-library';
-import { toApiDate } from '@app/utils/apiDate';
+import { toApiDate, toDisplayDate } from '@app/utils/apiDate';
 
 import { EDIT_MODE, OFFER_MODE, RIDE_FORM_LABELS } from './constants';
 import { RideFormDialog, type RideFormDialogProps } from '.';
@@ -15,8 +16,9 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const DAYS_AHEAD = 30;
 
 const OFFERED_AT = new Date(Date.now() + DAYS_AHEAD * DAY_MS);
-/** O seletor do MUI recebe a data seção a seção, na ordem de pt-BR. */
-const TYPED_DATE = format(OFFERED_AT, 'ddMMyyyy');
+const OFFERED_HOUR = '18:30';
+/** O campo é mascarado: chegam só os dígitos, do dia ao minuto. */
+const TYPED_DEPARTURE = `${format(OFFERED_AT, 'ddMMyyyy')}${onlyDigits(OFFERED_HOUR)}`;
 
 const RIDE: Ride = {
   id: 'b1b0f5b4-7a6f-4f1e-9d3a-2f5c8e4a1d70',
@@ -40,6 +42,9 @@ const renderComponent = (props = DEFAULT_PROPS) => render(<RideFormDialog {...pr
 const destinationField = () =>
   screen.getByRole('textbox', { name: new RegExp(RIDE_FORM_LABELS.destination) });
 
+const departureField = () =>
+  screen.getByRole('textbox', { name: new RegExp(RIDE_FORM_LABELS.departure) });
+
 describe('RideFormDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,6 +64,7 @@ describe('RideFormDialog', () => {
     expect(await screen.findByRole('heading', { name: EDIT_MODE.title })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: EDIT_MODE.submitLabel })).toBeInTheDocument();
     expect(destinationField()).toHaveValue(RIDE.destination);
+    expect(departureField()).toHaveValue(`${toDisplayDate(RIDE.departureDate)} 07:30`);
     expect(
       screen.getByRole('textbox', { name: new RegExp(RIDE_FORM_LABELS.description) }),
     ).toHaveValue(RIDE.description);
@@ -129,14 +135,7 @@ describe('RideFormDialog', () => {
     await screen.findByRole('heading', { name: OFFER_MODE.title });
 
     await userEvent.type(destinationField(), 'Terminal Santo Antônio');
-    await userEvent.type(
-      screen.getByRole('textbox', { name: new RegExp(RIDE_FORM_LABELS.departureDate) }),
-      TYPED_DATE,
-    );
-    await userEvent.type(
-      screen.getByLabelText(new RegExp(RIDE_FORM_LABELS.departureTime)),
-      '18:30',
-    );
+    await userEvent.type(departureField(), TYPED_DEPARTURE);
     await userEvent.click(
       screen.getByRole('combobox', { name: new RegExp(RIDE_FORM_LABELS.rideType) }),
     );
@@ -153,7 +152,7 @@ describe('RideFormDialog', () => {
       availableSeats: 3,
       destination: 'Terminal Santo Antônio',
       departureDate: toApiDate(OFFERED_AT),
-      departureTime: '18:30',
+      departureTime: OFFERED_HOUR,
       rideType: RideTypeEnum.SOLIDARITY,
       description: '',
     });

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormFields/index.tsx
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/RideFormFields/index.tsx
@@ -29,30 +29,21 @@ export function RideFormFields() {
       />
 
       <Controller
-        name="departureDate"
+        name="departure"
         control={control}
         render={({ field }) => (
-          <Input.Date
+          <Input.DateTime
             name={field.name}
-            label={C.RIDE_FORM_LABELS.departureDate}
+            label={C.RIDE_FORM_LABELS.departure}
             required
             value={field.value}
             onChange={field.onChange}
             onBlur={field.onBlur}
             disabled={field.disabled}
             minDate={today}
-            error={errors.departureDate?.message}
+            error={errors.departure?.message}
           />
         )}
-      />
-
-      <Input
-        {...register('departureTime')}
-        type="time"
-        label={C.RIDE_FORM_LABELS.departureTime}
-        required
-        fullWidth
-        error={errors.departureTime?.message}
       />
 
       <Controller

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/constants/index.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/constants/index.ts
@@ -40,8 +40,7 @@ export const EDIT_MODE: RideFormMode = {
 
 export const RIDE_FORM_LABELS = {
   destination: 'Destino',
-  departureDate: 'Data',
-  departureTime: 'Hora',
+  departure: 'Data e hora',
   rideType: 'Tipo',
   seats: 'Vagas disponíveis',
   description: 'Descrição',
@@ -80,8 +79,8 @@ export const SEAT_OPTIONS: readonly SelectOption[] = [
 export const RIDE_FORM_MESSAGES = {
   destinationTooShort: `O destino deve ter ao menos ${RIDE_LIMITS.minDestination} caracteres`,
   destinationTooLong: `O destino deve ter no máximo ${RIDE_LIMITS.maxDestination} caracteres`,
-  departureDateRequired: 'Informe a data',
-  departureTimeRequired: 'Informe a hora',
+  departureRequired: 'Informe a data e a hora',
+  departureInvalid: 'Data e hora inválidas',
   departureInPast: 'A carona deve ser em data e hora futuras',
   rideTypeRequired: 'Selecione o tipo',
   seatsRequired: 'Selecione a quantidade de vagas',

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.test.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.test.ts
@@ -21,11 +21,10 @@ describe('toFormValues', () => {
     expect(toFormValues(undefined)).toEqual(EMPTY_RIDE_FORM);
   });
 
-  it('should cut the api date and time down to what the fields accept', () => {
+  it('should join the api date and time into the single field', () => {
     const values = toFormValues(RIDE);
 
-    expect(values.departureDate).toBe('22/05/2026');
-    expect(values.departureTime).toBe('07:30');
+    expect(values.departure).toBe('22/05/2026 07:30');
     expect(values.seats).toBe('4');
     expect(values.rideType).toBe(RideTypeEnum.EGALITARIAN);
   });
@@ -36,11 +35,10 @@ describe('toFormValues', () => {
 });
 
 describe('toRideInput', () => {
-  it('should send the seats as a number and carry every field', () => {
+  it('should split the departure back into the two fields the api keeps', () => {
     const values: RideFormValues = {
       destination: 'Fatec Sorocaba',
-      departureDate: '22/05/2026',
-      departureTime: '07:30',
+      departure: new Date(2026, 4, 22, 7, 30),
       rideType: RideTypeEnum.EGALITARIAN,
       seats: '4',
       description: 'Saída do centro.',

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/helpers/mapper.ts
@@ -1,33 +1,37 @@
+import { format } from 'date-fns';
+
 import type { Ride, RideInput } from '@app/services/rides/types';
-import { toApiDateText, toDisplayDate } from '@app/utils/apiDate';
+import { toApiDate, toDisplayDate } from '@app/utils/apiDate';
 import { firstCharacters } from '@app/utils/sequence';
 
 import { EMPTY_RIDE_FORM, type RideFormInput, type RideFormValues } from '../schema';
 
-/** A API devolve `HH:mm:ss` e o campo de hora só aceita `HH:mm`. */
+/** A API devolve `HH:mm:ss` e o campo mostra `HH:mm`. */
 const TIME_LENGTH = 5;
+const API_TIME_FORMAT = 'HH:mm';
 
 /** Sem carona é oferta, e o formulário abre vazio. */
 export function toFormValues(ride: Ride | undefined): RideFormInput {
   if (!ride) return EMPTY_RIDE_FORM;
 
+  const time = firstCharacters(ride.departureTime, TIME_LENGTH);
+
   return {
     destination: ride.destination,
-    departureDate: toDisplayDate(ride.departureDate),
-    departureTime: firstCharacters(ride.departureTime, TIME_LENGTH),
+    departure: `${toDisplayDate(ride.departureDate)} ${time}`,
     rideType: ride.rideType,
     seats: String(ride.availableSeats),
     description: ride.description ?? '',
   };
 }
 
-/** O schema já entregou os campos aparados e o tipo estreitado. */
+/** A API guarda o dia e a hora em campos separados, e o schema entregou os dois juntos. */
 export function toRideInput(values: RideFormValues): RideInput {
   return {
     availableSeats: Number(values.seats),
     destination: values.destination,
-    departureDate: toApiDateText(values.departureDate),
-    departureTime: values.departureTime,
+    departureDate: toApiDate(values.departure),
+    departureTime: format(values.departure, API_TIME_FORMAT),
     rideType: values.rideType,
     description: values.description,
   };

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.test.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.test.ts
@@ -9,14 +9,13 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const DAYS_AHEAD = 30;
 
 /** O que o campo guarda, e não o que a API recebe — é o que o schema lê. */
-function toFieldDate(date: Date): string {
-  return format(date, 'dd/MM/yyyy');
+function toFieldDeparture(date: Date): string {
+  return format(date, 'dd/MM/yyyy HH:mm');
 }
 
 const VALID: RideFormInput = {
   destination: 'Fatec Sorocaba',
-  departureDate: toFieldDate(new Date(Date.now() + DAYS_AHEAD * DAY_MS)),
-  departureTime: '07:30',
+  departure: toFieldDeparture(new Date(Date.now() + DAYS_AHEAD * DAY_MS)),
   rideType: RideTypeEnum.SOLIDARITY,
   seats: '3',
   description: 'Saída do centro.',
@@ -55,13 +54,22 @@ describe('rideFormSchema', () => {
     );
   });
 
-  it('should require the departure date and time', () => {
-    expect(firstErrorOf({ departureDate: '' })).toBe(RIDE_FORM_MESSAGES.departureDateRequired);
-    expect(firstErrorOf({ departureTime: '' })).toBe(RIDE_FORM_MESSAGES.departureTimeRequired);
+  it('should require the departure', () => {
+    expect(firstErrorOf({ departure: '' })).toBe(RIDE_FORM_MESSAGES.departureRequired);
   });
 
-  it('should stay quiet while the date is still half typed', () => {
-    expect(firstErrorOf({ departureDate: '22/0' })).toBeUndefined();
+  it('should refuse a departure that is still half typed', () => {
+    expect(firstErrorOf({ departure: '22/0' })).toBe(RIDE_FORM_MESSAGES.departureInvalid);
+    expect(firstErrorOf({ departure: '22/05/2026' })).toBe(RIDE_FORM_MESSAGES.departureInvalid);
+  });
+
+  it('should refuse a departure whose day or hour does not exist', () => {
+    expect(firstErrorOf({ departure: '31/02/2026 10:00' })).toBe(
+      RIDE_FORM_MESSAGES.departureInvalid,
+    );
+    expect(firstErrorOf({ departure: '22/05/2026 25:00' })).toBe(
+      RIDE_FORM_MESSAGES.departureInvalid,
+    );
   });
 
   // Relógio fixo porque a partida é lida no fuso do produto: sem isso, a máquina
@@ -78,13 +86,19 @@ describe('rideFormSchema', () => {
     });
 
     it('should refuse a departure that already happened', () => {
-      expect(firstErrorOf({ departureDate: '22/05/2026', departureTime: '08:00' })).toBe(
+      expect(firstErrorOf({ departure: '22/05/2026 08:00' })).toBe(
         RIDE_FORM_MESSAGES.departureInPast,
       );
     });
 
     it('should accept a departure still to come on the same day', () => {
-      expect(firstErrorOf({ departureDate: '22/05/2026', departureTime: '10:00' })).toBeUndefined();
+      expect(firstErrorOf({ departure: '22/05/2026 10:00' })).toBeUndefined();
+    });
+
+    it('should hand the departure over already read, not as the typed text', () => {
+      const result = rideFormSchema.safeParse({ ...VALID, departure: '22/05/2026 10:00' });
+
+      expect(result.data?.departure).toEqual(new Date(2026, 4, 22, 10, 0));
     });
 
     // A suíte fixa o fuso do processo no do produto, que é onde os dois jeitos de
@@ -93,7 +107,7 @@ describe('rideFormSchema', () => {
     it('should read the departure in the product time zone, not in the reader one', () => {
       process.env.TZ = 'UTC';
 
-      expect(firstErrorOf({ departureDate: '22/05/2026', departureTime: '10:00' })).toBeUndefined();
+      expect(firstErrorOf({ departure: '22/05/2026 10:00' })).toBeUndefined();
 
       process.env.TZ = PRODUCT_TIME_ZONE;
     });

--- a/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.ts
+++ b/FateConnect/Web/src/pages/Rides/components/RideFormDialog/schema/index.ts
@@ -7,10 +7,8 @@ import { isRideType } from '@app/pages/Rides/helpers/rideType';
 import { PRODUCT_TIME_ZONE, RIDE_FORM_MESSAGES, RIDE_LIMITS } from '../constants';
 
 const REQUIRED = 1;
-/** Os campos entregam o que a pessoa digitou, não o formato da API. */
+/** O campo entrega o que a pessoa digitou, não o formato da API. */
 const DEPARTURE_FORMAT = 'dd/MM/yyyy HH:mm';
-
-type DepartureFields = { departureDate: string; departureTime: string };
 
 function isSeatCount(value: string): boolean {
   const seats = Number(value);
@@ -18,52 +16,57 @@ function isSeatCount(value: string): boolean {
   return Number.isInteger(seats) && seats >= RIDE_LIMITS.minSeats && seats <= RIDE_LIMITS.maxSeats;
 }
 
-/**
- * A regra é do par data + hora, então mora no objeto. Campo ainda vazio ou
- * ilegível passa: quem reclama disso é a regra de cada campo, e acumular as
- * duas mensagens no mesmo lugar só confunde quem está preenchendo.
- */
-function isFutureDeparture({ departureDate, departureTime }: DepartureFields): boolean {
-  if (!departureDate || !departureTime) return true;
-
-  const departure = parse(`${departureDate} ${departureTime}`, DEPARTURE_FORMAT, new Date());
-  if (!isValid(departure)) return true;
-
-  return fromZonedTime(departure, PRODUCT_TIME_ZONE).getTime() > Date.now();
+function parseDeparture(departure: string): Date {
+  return parse(departure, DEPARTURE_FORMAT, new Date());
 }
 
-export const rideFormSchema = z
-  .object({
-    destination: z
-      .string()
-      .trim()
-      .min(RIDE_LIMITS.minDestination, RIDE_FORM_MESSAGES.destinationTooShort)
-      .max(RIDE_LIMITS.maxDestination, RIDE_FORM_MESSAGES.destinationTooLong),
-    departureDate: z.string().min(REQUIRED, RIDE_FORM_MESSAGES.departureDateRequired),
-    departureTime: z.string().min(REQUIRED, RIDE_FORM_MESSAGES.departureTimeRequired),
-    // O predicado estreita a saída: o formulário guarda texto, o schema entrega
-    // `RideTypeEnum`, e o mapeamento para a requisição não precisa de conversão.
-    rideType: z.string().refine(isRideType, RIDE_FORM_MESSAGES.rideTypeRequired),
-    seats: z.string().refine(isSeatCount, RIDE_FORM_MESSAGES.seatsRequired),
-    description: z
-      .string()
-      .trim()
-      .max(RIDE_LIMITS.maxDescription, RIDE_FORM_MESSAGES.descriptionTooLong),
-  })
-  .refine(isFutureDeparture, {
-    error: RIDE_FORM_MESSAGES.departureInPast,
-    path: ['departureDate'],
-  });
+/** Campo vazio passa: quem reclama dele é a regra de obrigatoriedade. */
+function isReadableDeparture(departure: string): boolean {
+  if (!departure) return true;
 
-/** O que os campos guardam: tudo texto, inclusive a data. */
+  return isValid(parseDeparture(departure));
+}
+
+/** Partida ilegível passa: quem reclama dela é a regra de formato. */
+function isFutureDeparture(departure: string): boolean {
+  const parsed = parseDeparture(departure);
+  if (!isValid(parsed)) return true;
+
+  return fromZonedTime(parsed, PRODUCT_TIME_ZONE).getTime() > Date.now();
+}
+
+export const rideFormSchema = z.object({
+  destination: z
+    .string()
+    .trim()
+    .min(RIDE_LIMITS.minDestination, RIDE_FORM_MESSAGES.destinationTooShort)
+    .max(RIDE_LIMITS.maxDestination, RIDE_FORM_MESSAGES.destinationTooLong),
+  // A transformação estreita a saída: o campo guarda texto e o schema entrega a
+  // partida já lida, então o envio a separa sem reinterpretar a máscara.
+  departure: z
+    .string()
+    .min(REQUIRED, RIDE_FORM_MESSAGES.departureRequired)
+    .refine(isReadableDeparture, RIDE_FORM_MESSAGES.departureInvalid)
+    .refine(isFutureDeparture, RIDE_FORM_MESSAGES.departureInPast)
+    .transform(parseDeparture),
+  // O predicado estreita a saída: o formulário guarda texto, o schema entrega
+  // `RideTypeEnum`, e o mapeamento para a requisição não precisa de conversão.
+  rideType: z.string().refine(isRideType, RIDE_FORM_MESSAGES.rideTypeRequired),
+  seats: z.string().refine(isSeatCount, RIDE_FORM_MESSAGES.seatsRequired),
+  description: z
+    .string()
+    .trim()
+    .max(RIDE_LIMITS.maxDescription, RIDE_FORM_MESSAGES.descriptionTooLong),
+});
+
+/** O que os campos guardam: tudo texto, inclusive a partida. */
 export type RideFormInput = z.input<typeof rideFormSchema>;
-/** O que sai validado, já com o tipo de carona estreitado. */
+/** O que sai validado, já com a partida lida e o tipo de carona estreitado. */
 export type RideFormValues = z.output<typeof rideFormSchema>;
 
 export const EMPTY_RIDE_FORM: RideFormInput = {
   destination: '',
-  departureDate: '',
-  departureTime: '',
+  departure: '',
   rideType: '',
   seats: '',
   description: '',


### PR DESCRIPTION
## Objetivo

O campo de hora do formulário de carona usava o seletor **do navegador**, e ele destoava nos dois temas: no escuro a listinha de horas saía branca sobre o diálogo escuro, e no claro a caixa vinha com moldura e sombra que não são as dos nossos componentes.

O PR tira o desenho das mãos do Chrome duas vezes. Onde o produto precisa do nosso desenho, o campo passa a ser nosso — `Data*` e `Hora*` viram um campo só, `Data e hora`, com máscara e um painel que o nosso tema desenha. E onde o navegador continua desenhando por conta, ele passa a saber em que tema está: o `CssBaseline` ganhou `enableColorScheme`, e `color-scheme` não existia em lugar nenhum do projeto.

## Alterações

- **Nasce o `DateTimeField` no design system**, exposto como `Input.DateTime`, irmão do `Input.Date`. A fonte de verdade é o texto mascarado `dd/mm/aaaa hh:mm`, com o cursor preservado ao editar no meio; o botão ao lado abre o painel.
- **O painel mostra um passo por vez** — o dia, depois a hora — com o valor em construção no topo e uma aba para cada trecho. Ele **anda sozinho**: escolhido o dia vai para a hora, escolhido o minuto fecha, como o campo só de data fecha ao escolher o dia. O `minDate` continua existindo.
- **O `Input.Date` fica** — ele serve o cadastro e os filtros das listas, que pedem só data.
- **O formulário de carona passa a ter um campo de partida**: `rideFormSchema` troca `departureDate` e `departureTime` por `departure`, e o mapper junta os dois na abertura e os separa no envio, porque a API mantém os campos distintos no `CreateRideDto`.
- **Copy:** rótulo `Data e hora`, apoio `dd/mm/aaaa hh:mm`, `Informe a data` e `Informe a hora` viram `Informe a data e a hora`, e entra `Data e hora inválidas` para o formato pela metade — que antes seguia com a data vazia. `A carona deve ser em data e hora futuras` fica como estava.
- **O `CssBaseline` recebe `enableColorScheme`**, então o Chrome desenha os controles nativos dele no tema em uso.
- **A data curta do seletor passa a pôr o dia antes do mês.** O adaptador crava `MMM d` em qualquer idioma, e o topo do painel dizia `nov 20`.

## Decisões que não vieram da issue

**Hook em vez de um segundo campo copiado.** O `DateTimeField` seria 95% cópia do `DateField` — cursor, âncora do popover, fiação do `InputField`. Isso virou o `useMaskedPicker`, e o `DateField` passou a consumi-lo, num commit de refactor separado. É por isso que o PR toca um arquivo que a issue não previa.

**O schema entrega `Date`, não texto.** O campo `departure` fecha com `.transform`, então `RideFormValues.departure` é um `Date` e o mapper serializa sem reinterpretar a máscara. A issue descrevia "separar de novo no envio" — é isso, sobre um valor já lido.

**O painel é o da biblioteca, e mostra um passo por vez.** A primeira versão punha `DateCalendar` e `TimeClock` lado a lado dentro do nosso `Popover`, como a issue descreve. Medido no celular a 412px, isso dava **320 × 588** — 64% da altura da tela, **cobrindo o próprio campo** que o painel edita, sem nada dizendo o que já tinha sido escolhido. O painel passou a ser o `StaticDateTimePicker`, que traz o valor no topo e as duas abas; hoje ele mede **320 × 467**.

**O painel não traz botão nenhum, e isso é consequência medida, não preferência.** Os dois da biblioteca não funcionam aqui, porque ela foi feita para ser o seletor inteiro, dono do próprio ciclo, e aqui é conteúdo do nosso popover:

| Botão | O que acontece | Por quê |
| --- | --- | --- |
| `Continuar` | não faz nada | atravessa o passo por `goToNextStep`, que usa o `setView` **cru** — inerte com a vista controlada, e sem avisar |
| `OK` | não faz nada se você não tocou em nada | só reage a mudança pendente |

Não há API pública que entregue o avanço automático **e** o `Continuar`: controlar a vista mata um, não controlar mata o outro. Quem fecha passou a ser escolher o minuto.

**Três sobrescritas moram no `styles.ts` do campo, não no tema**, porque a biblioteca desenha esses elementos sem gancho de `styleOverrides` — conferido listando as regras que de fato casam com cada elemento:

| O que a biblioteca faz | O que ficou |
| --- | --- |
| título em `overline`, caixa alta | a nossa escala, sem caixa alta |
| dia em `h4` e hora em `h3` (34px e 48px) | `h2` nos dois, 24px |
| aba, dígito e ação na cor primária | a cor de texto — a primária, no escuro, é a superfície do cromo e como texto dá **4,11:1** |

**O ano saiu da lista de passos**, e não por CSS: a biblioteca só desenha aquele botão quando `year` está nos passos. O cabeçalho do calendário logo abaixo já mostra o ano.

## Como foi provado

**Portões:** eslint 0 erros nos arquivos do diff, `tsc` 0, suíte **634/634**, cobertura 98,71% linhas / 93,8% ramos.

**Mutações**, cada uma derrubando o caso escrito para ela: `enableColorScheme` desligado; `parseDateTimeSoFar` sem o recuo para o dia; máscara sem o corte no décimo segundo dígito; schema sem a regra de formato incompleto; `minDate` não repassado; hook sem devolver o cursor; ano de volta nos passos; tamanhos de volta aos da biblioteca; título de volta à caixa alta; cor de volta à primária (só cai no **escuro** — no claro a primária *é* a cor de texto); avanço do dia removido; e fechamento por vista guardada em vez de comparação de minuto.

**Medido na aplicação de pé**, porta 5497, contra um stub próprio na 4311:

| O quê | Medido |
| --- | --- |
| Campo contra os vizinhos | raio `4px`, borda `rgba(0,0,0,0.44)`, 1px — **idênticos** ao `Destino` e ao `Tipo` ao lado; o desenho do botão a 13,7px da borda |
| Cursor ao editar no meio | caret em **4**, com o campo terminando em 15 |
| Painel | **320 × 467**, dentro da tela no desktop e no celular |
| Contraste no escuro | título 6,77 · dia 12,84 · hora 6,77 · aba ativa 12,84 — todos acima de 4,5:1; o traço da aba a 4,11, acima dos 3:1 de não-texto |
| Contraste no claro | título 5,27 · demais 7,89 |
| `color-scheme` | `dark` na raiz **e herdado pelo `input[type=time]`** do painel de filtros |
| Envio | `POST /rides` com `departureDate: "2026-09-30"` e `departureTime: "18:30"` |
| Edição | `2026-11-20T00:00:00` + `07:30:00` abre como `20/11/2026 07:30`, e o `PUT` devolve os dois separados |

Os dois caminhos do painel, exercitados na aplicação:

| Caminho | Resultado |
| --- | --- |
| ofertar: dia → hora → minuto | `24/11/2026 07:45` (a hora digitada sobrevive à troca de dia) → `09:45` → `09:15`, e o painel fecha |
| editar: aba da hora, mexer **só** no minuto | `07:30` → `07:45`, e o painel fecha |

A escada de mensagens aparece na tela na ordem certa: `Informe a data e a hora` → `Data e hora inválidas` → `A carona deve ser em data e hora futuras`.

## Resíduo

- **O campo de hora do painel de filtros continua nativo**, por decisão da issue: a #267 o troca por turno. Ele melhora de graça com o `enableColorScheme`.
- **Um item da issue já não era verdade:** ela lista o `DateInput` do `DatePicker` como fora de escopo, "quem o apaga é a #259". A #259 mergeou em 01/09, e não existe mais `DateInput` nem `DatePicker` no repositório.

## Issue

- #311

Closes #311

## Evidências

### Filtros
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/101e7cc9-6ded-493b-9ddf-c50fb3634d22" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/891ed670-a03d-44eb-85ad-54246357c064" />

### Criar carona
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/f156a447-30c9-4fb2-be28-2dc821778230" />
<img width="1289" height="911" alt="image" src="https://github.com/user-attachments/assets/e1a85729-5888-46e2-97a9-1a8011aa1000" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d4262517-2729-43f0-98a2-315219e16e49" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/5ac08478-a7ba-41d6-b9a0-a7ee166ea8bd" />
